### PR TITLE
set task to resumed state after create

### DIFF
--- a/macros/task_run_sp_create_prod_clone.sql
+++ b/macros/task_run_sp_create_prod_clone.sql
@@ -3,5 +3,7 @@
         warehouse = dbt_cloud
         schedule = 'USING CRON 15 6 * * * UTC'
     as
-        call {{ target_schema }}.create_prod_clone('solana', 'solana_dev', 'internal_dev')
+        call {{ target_schema }}.create_prod_clone('solana', 'solana_dev', 'internal_dev');
+
+    alter task {{ target_schema }}.run_sp_create_prod_clone resume
 {%- endmacro %}


### PR DESCRIPTION
- tasks are suspended by default on creation.  Add statement to start it after create.