### PR TITLE
An 837/create lp actions

### DIFF
--- a/models/silver/silver__events.sql
+++ b/models/silver/silver__events.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "CONCAT_WS('-', block_id, tx_id, index)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp::DATE'],
+  cluster_by = ['ingested_at::DATE','program_id'],
   post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION"
 ) }}
 

--- a/models/silver/silver__staking_lp_actions.sql
+++ b/models/silver/silver__staking_lp_actions.sql
@@ -1,0 +1,67 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "CONCAT_WS('-', block_id, tx_id)",
+    incremental_strategy = 'delete+insert',
+    cluster_by = ['block_timestamp::DATE'],
+) }}
+
+WITH base_e AS (
+
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        INDEX,
+        event_type,
+        program_id,
+        instruction,
+        inner_instruction
+    FROM
+        {{ ref('silver__events') }}
+    WHERE
+         program_id = 'Stake11111111111111111111111111111111111111'
+
+{% if is_incremental() %}
+AND ingested_at :: DATE >= CURRENT_DATE - 2
+{% endif %}
+),
+base_t AS (
+    SELECT
+        block_id,
+        tx_id,
+        succeeded,
+        signers,
+        pre_balances,
+        post_balances,
+        pre_token_balances,
+        post_token_balances,
+        account_keys
+    FROM
+        {{ ref('silver__transactions') }}
+
+{% if is_incremental() %}
+WHERE
+    ingested_at :: DATE >= CURRENT_DATE - 2
+{% endif %}
+)
+SELECT
+    e.block_id,
+    e.block_timestamp,
+    e.tx_id,
+    t.succeeded,
+    e.index,
+    e.event_type,
+    e.program_id,
+    t.signers,
+    t.account_keys,
+    e.instruction,
+    e.inner_instruction,
+    t.pre_balances,
+    t.post_balances,
+    t.pre_token_balances,
+    t.post_token_balances
+FROM
+    base_e e
+    LEFT OUTER JOIN base_t t
+    ON t.block_id = e.block_id
+    AND t.tx_id = e.tx_id


### PR DESCRIPTION
- Add table for `staking` actions
- Change cluster keys for `events`.  Using `ingested_at` for cluster key to stay consistent with our other silver tables that are used to build downstream.  Also adding `program_id` since we will likely be getting events belonging to specific programs.