### PR TITLE
update to check 7 day window instead of 2

### DIFF
--- a/models/silver/silver__gauges_votes_saber.yml
+++ b/models/silver/silver__gauges_votes_saber.yml
@@ -14,7 +14,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 7
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/silver/silver__gauges_votes_saber.yml
+++ b/models/silver/silver__gauges_votes_saber.yml
@@ -14,7 +14,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 7
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/silver/silver__gov_actions_saber.yml
+++ b/models/silver/silver__gov_actions_saber.yml
@@ -12,7 +12,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 7
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
- After investigating saber gov actions model recency test failure, it has been determined that this was due to true inactivity.  Tests txs were made on 5/16 to confirm current logic still works for locks/unlocks and they showed up properly in our model.  As a result, we are increasing the recency window to 7 days instead of 2 days.