### PR TITLE
exclude current date from gap test

### DIFF
--- a/tests/silver__transactions__block_id-assert-no-gaps.sql
+++ b/tests/silver__transactions__block_id-assert-no-gaps.sql
@@ -3,7 +3,8 @@
 SELECT 
     block_id AS slot
 FROM {{ ref('silver__blocks') }}
-WHERE block_id NOT IN (
+WHERE block_timestamp::date <= current_date - 1
+AND block_id NOT IN (
     SELECT 
         block_id 
     FROM {{ ref('silver__transactions') }}


### PR DESCRIPTION
- Gaps tests are failing for current date when the test is run due to how data comes in where it is not guaranteed to come in by contiguous blocks. I have verified over the last few days that the "gaps" resolve themselves on the next incremental as the data is actually there in the chainwalkers database.