### PR TITLE
turn off recency test

### DIFF
--- a/models/silver/silver__nft_sales_smb.yml
+++ b/models/silver/silver__nft_sales_smb.yml
@@ -10,9 +10,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 2
+          # - dbt_expectations.expect_row_values_to_have_recent_data:
+          #     datepart: day
+          #     interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/silver/silver__nft_sales_solport.yml
+++ b/models/silver/silver__nft_sales_solport.yml
@@ -11,9 +11,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 2
+          # - dbt_expectations.expect_row_values_to_have_recent_data:
+          #     datepart: day
+          #     interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
Per our resident solana expert @mdill89 we can turn the recency tests off for these models

`Solana monkey business one they told people to start using magic eden because there was a potential bug in their marketplace`

`Solport i think just has very low volume to almost no volume outside their launchpad`
