### PR TITLE
An 1369/fix saber gov tables

### DIFF
--- a/models/descriptions/gov_action_escrow_account.md
+++ b/models/descriptions/gov_action_escrow_account.md
@@ -1,0 +1,5 @@
+{% docs gov_action_escrow_account %}
+
+Account owner of the locker account for governance
+
+{% enddocs %}

--- a/models/silver/silver__gauges_votes_saber.sql
+++ b/models/silver/silver__gauges_votes_saber.sql
@@ -11,7 +11,7 @@ WITH all_saber_gauges_events AS (
         block_timestamp,
         block_id,
         tx_id,
-        index,
+        INDEX,
         instruction
     FROM
         {{ ref('silver__events') }}
@@ -87,3 +87,5 @@ FROM
     AND e.index = l.event_index
 WHERE
     l.log_type = 'vote'
+AND 
+    e.instruction :accounts [0] :: STRING = '28ZDtf6d2wsYhBvabTxUHTRT6MDxqjmqR7RMCp348tyU' -- this is saber gaugemeister

--- a/models/silver/silver__gov_actions_saber.yml
+++ b/models/silver/silver__gov_actions_saber.yml
@@ -33,6 +33,10 @@ models:
         description: "{{ doc('gov_action_locker_account') }}"
         tests: 
           - not_null
+      - name: ESCROW_ACCOUNT
+        description: "{{ doc('gov_action_escrow_account') }}"
+        tests: 
+          - not_null
       - name: MINT
         description: "{{ doc('gov_action_mint') }}"
         tests: 


### PR DESCRIPTION
- Fix gov actions table for Saber.  This was missing transactions from 3rd party apps that were approved to lock tokens staked on their app and vote on behalf of other users.  These apps do not interact with the tribeca program directly but as an inner_instruction instead
- Fix gauge votes table for Saber. This was including non-saber gauge voting.  Old assumption was the program_id was sufficient to filter out these but it is not.  Changed to filter on the Saber gaugemeister as well which is included as the 1st account in a voting instruction.
- Added escrow_account to gov_actions table, this is not used in the fix, but could be useful down the line so i decided to add it just at the silver layer.