### PR TITLE
An 1030 inner instructions test

### DIFF
--- a/tests/silver__inner_instructions__program_id-assert-not-null.sql
+++ b/tests/silver__inner_instructions__program_id-assert-not-null.sql
@@ -1,3 +1,5 @@
+{{ config(error_if = '>1000', warn_if = '>1000') }}
+
 SELECT 
     DISTINCT 
         block_timestamp::date, 

--- a/tests/silver__inner_instructions__program_id-assert-not-null.sql
+++ b/tests/silver__inner_instructions__program_id-assert-not-null.sql
@@ -1,0 +1,8 @@
+SELECT 
+    DISTINCT 
+        block_timestamp::date, 
+        block_id as slot 
+FROM {{ ref('silver___inner_instructions') }} 
+WHERE value:instructions[0]:programIdIndex::number IS NOT NULL 
+GROUP BY block_timestamp::date, block_id 
+ORDER BY block_timestamp::date DESC

--- a/tests/silver__inner_instructions__program_id-assert-not-null.sql
+++ b/tests/silver__inner_instructions__program_id-assert-not-null.sql
@@ -1,4 +1,4 @@
-{{ config(error_if = '>1000', warn_if = '>1000') }}
+{{ config(error_if = '>1000', warn_if '>1000') }}
 
 SELECT 
     DISTINCT 
@@ -7,4 +7,3 @@ SELECT
 FROM {{ ref('silver___inner_instructions') }} 
 WHERE value:instructions[0]:programIdIndex::number IS NOT NULL 
 GROUP BY block_timestamp::date, block_id 
-ORDER BY block_timestamp::date DESC


### PR DESCRIPTION
Inner instructions test for Solana. We can have a small amount of bad inner instructions at any time, but should be caught by a test on the platform side and fixed by the next incremental run. So therefore there is a tolerance for bad instructions. 