### PR TITLE
use python to get signers from accts

### DIFF
--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -1,6 +1,9 @@
 {% macro create_udfs() %}
     {% set sql %}
     {{ udf_bulk_get_decoded_instructions_data() }};
+    {{ create_udf_ordered_signers(
+        schema = "silver"
+    ) }}
     {% endset %}
     {% do run_query(sql) %}
 {% endmacro %}

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -1,0 +1,17 @@
+{% macro create_udf_ordered_signers(schema) %}
+create or replace function {{ schema }}.udf_ordered_signers(accts array)
+returns array
+language python
+runtime_version = '3.8'
+handler = 'ordered_signers'
+as
+$$
+def ordered_signers(accts) -> list:
+    signers = [] 
+    for v in accts:
+        if v["signer"]:
+            signers.append(v["pubkey"])
+
+    return signers
+$$;
+{% endmacro %}


### PR DESCRIPTION
- Using python UDF to get signers from the accounts array insteads of using CTEs.  There was an issue w/ the old data where the signers array was created out of order...however I could not recreate the issue as reloading the table generated the correct ordering.  Changing to python will guarantee the ordering based on code we write so will no longer be a black box.  Side benefit, using UDF seems to load 2x faster on incremental.