### PR TITLE
An 1719 realms

### DIFF
--- a/models/silver/silver__proposal_votes_realms.sql
+++ b/models/silver/silver__proposal_votes_realms.sql
@@ -45,15 +45,15 @@ SELECT
     realms_id, 
     proposal, 
     voter, 
-    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 1), ':', 2) :: INTEGER AS vote_choice, 
-    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 2), ':', 2) :: INTEGER AS vote_weight, 
+    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 1), ':', 2) AS vote_choice, 
+    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 2), ':', 2) AS vote_weight, 
     t._inserted_timestamp
-FROM {{ ref('silver__transactions') }} t
+FROM vote_txs v 
     
-LEFT OUTER JOIN TABLE(FLATTEN(t.log_messages)) l
-    
-LEFT OUTER JOIN vote_txs v
+LEFT OUTER JOIN {{ ref('silver__transactions') }} t
 ON v.tx_id = t.tx_id
+
+LEFT OUTER JOIN TABLE(FLATTEN(t.log_messages)) l
     
 WHERE 
     v.block_timestamp :: date = '2022-07-19' 

--- a/models/silver/silver__proposal_votes_realms.sql
+++ b/models/silver/silver__proposal_votes_realms.sql
@@ -26,7 +26,7 @@ vote_txs AS (
         program_id, 
         instruction :accounts[0] :: STRING AS realms_id, 
         instruction :accounts[2] :: STRING AS proposal, 
-        instruction :accounts[2] :: STRING AS voter, 
+        instruction :accounts[5] :: STRING AS voter, 
         instruction :accounts[6] :: STRING AS vote_account, 
         _inserted_timestamp
     FROM 

--- a/models/silver/silver__proposal_votes_realms.sql
+++ b/models/silver/silver__proposal_votes_realms.sql
@@ -1,20 +1,70 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', tx_id, index)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+) }}
+
 WITH vote_txs AS (
     SELECT
-        tx_id
+        block_timestamp, 
+        block_id, 
+        tx_id,
+        succeeded, 
+        e.index, 
+        program_id, 
+        instruction :accounts[0] :: STRING AS realms_id, 
+        instruction :accounts[2] :: STRING AS proposal, 
+        i.value :parsed :info :source :: STRING AS voter, 
+        _inserted_timestamp
     FROM 
-        {{ ref('silver__events') }} 
+        {{ ref('silver__events') }}  e, 
+  
+    LATERAL FLATTEN (input => inner_instruction :instructions) i 
+  
     WHERE 
         program_id = 'GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw' -- General Realms contract. Mango and Serum have different IDs, maybe more.
+
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+    )
+    {% endif %}
 )
 
 SELECT 
-    tx_id, 
-    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 1), ':', 2) :: INTEGER AS rank, 
-    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 2), ':', 2) :: INTEGER AS vote_weight
-FROM 
-    {{ ref('silver__transactions') }} t
+    v.block_timestamp, 
+    v.block_id,
+    v.tx_id, 
+    v.succeeded,
+    v.index, 
+    program_id, 
+    realms_id, 
+    proposal, 
+    voter, 
+    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 1), ':', 2) :: INTEGER AS vote_choice, 
+    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 2), ':', 2) :: INTEGER AS vote_weight, 
+    t._inserted_timestamp
+FROM {{ ref('silver__transactions') }} t
+    
 LEFT OUTER JOIN TABLE(FLATTEN(t.log_messages)) l
     
-WHERE block_timestamp :: date = '2022-07-19' 
-AND l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote %'  
-AND tx_id = '4T3aZ7o4TSFq9h1WAxDopmF8YJkGVHGnWdQ4hUiA2dx2rvvhnkkFNgqAUds75wBqz1NfPY1PKFsJsRAv7tYAUCRi'
+LEFT OUTER JOIN vote_txs v
+ON v.tx_id = t.tx_id
+    
+WHERE 
+    v.block_timestamp :: date = '2022-07-19' 
+    AND l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote %'  
+
+    {% if is_incremental() %}
+    AND t._inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+    )
+    {% endif %}
+    

--- a/models/silver/silver__proposal_votes_realms.sql
+++ b/models/silver/silver__proposal_votes_realms.sql
@@ -5,7 +5,19 @@
   cluster_by = ['block_timestamp::DATE'],
 ) }}
 
-WITH vote_txs AS (
+WITH vote_programs AS (
+    SELECT 
+        address
+    FROM {{ source(
+        'crosschain',
+        'address_labels'
+    ) }} 
+    WHERE 
+        blockchain = 'solana'
+        AND project_name = 'realms'
+),  
+
+vote_txs AS (
     SELECT
         block_timestamp, 
         block_id, 
@@ -16,15 +28,19 @@ WITH vote_txs AS (
         instruction :accounts[0] :: STRING AS realms_id, 
         instruction :accounts[2] :: STRING AS proposal, 
         i.value :parsed :info :source :: STRING AS voter, 
+        instruction :accounts[6] :: STRING AS vote_account, 
         _inserted_timestamp
     FROM 
-        {{ ref('silver__events') }}  e, 
+        {{ ref('silver__events') }}  e 
   
-    LATERAL FLATTEN (input => inner_instruction :instructions) i 
-  
-    WHERE 
-        program_id = 'GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw' -- General Realms contract. Mango and Serum have different IDs, maybe more.
+    INNER JOIN vote_programs v
+    ON e.program_id = v.address
 
+    LEFT OUTER JOIN TABLE(FLATTEN(inner_instruction :instructions)) i
+
+    WHERE 
+        instruction :data :: STRING <> 'Q'
+    
     {% if is_incremental() %}
     AND _inserted_timestamp >= (
     SELECT
@@ -41,30 +57,56 @@ SELECT
     v.tx_id, 
     v.succeeded,
     v.index, 
-    program_id, 
+    l.index AS _index, 
+    v.program_id, 
     realms_id, 
     proposal, 
     voter, 
-    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 1), ':', 2) AS vote_choice, 
-    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 2), ':', 2) AS vote_weight, 
+    vote_account, 
+    CASE WHEN (l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote { vote: Deny }')
+    OR (l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote { vote: No }') THEN 
+        'NO'
+    WHEN (l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote { vote: Approve%') 
+    OR (l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote { vote: Yes }') THEN 
+        'YES'
+    ELSE 
+        'ABSTAIN'
+    END AS vote_choice,
+    CASE WHEN l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote { vote: Approve%' THEN 
+        split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 1), ':', 2)
+    ELSE 
+        0
+    END AS vote_rank, 
+    CASE WHEN l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote { vote: Approve%' THEN 
+        split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 2), ':', 2) :: INTEGER
+    WHEN l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote { vote: Yes }' THEN 
+        100
+    ELSE 
+        0
+    END AS vote_weight,
     t._inserted_timestamp
 FROM vote_txs v 
-    
-LEFT OUTER JOIN {{ ref('silver__transactions') }} t
+
+INNER JOIN {{ ref('silver__transactions') }} t
 ON v.tx_id = t.tx_id
 
-LEFT OUTER JOIN TABLE(FLATTEN(t.log_messages)) l
+INNER JOIN TABLE(FLATTEN(t.log_messages)) l
     
 WHERE 
-    v.block_timestamp :: date = '2022-07-19' 
-    AND l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote %'  
+    (l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote %' 
+    AND v.index = 0 
+    AND _index <= 6)
+    OR (
+    l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote %'
+    AND v.index = 1 
+    AND _index >= 7) 
 
-    {% if is_incremental() %}
-    AND t._inserted_timestamp >= (
+{% if is_incremental() %}
+AND t._inserted_timestamp >= (
     SELECT
         MAX(_inserted_timestamp)
     FROM
         {{ this }}
-    )
-    {% endif %}
+)
+{% endif %}
     

--- a/models/silver/silver__proposal_votes_realms.sql
+++ b/models/silver/silver__proposal_votes_realms.sql
@@ -1,0 +1,20 @@
+WITH vote_txs AS (
+    SELECT
+        tx_id
+    FROM 
+        {{ ref('silver__events') }} 
+    WHERE 
+        program_id = 'GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw' -- General Realms contract. Mango and Serum have different IDs, maybe more.
+)
+
+SELECT 
+    tx_id, 
+    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 1), ':', 2) :: INTEGER AS rank, 
+    split_part(split_part(split_part(split_part(l.value :: STRING, '{', 3), '}', 1), ',', 2), ':', 2) :: INTEGER AS vote_weight
+FROM 
+    {{ ref('silver__transactions') }} t
+LEFT OUTER JOIN TABLE(FLATTEN(t.log_messages)) l
+    
+WHERE block_timestamp :: date = '2022-07-19' 
+AND l.value :: STRING LIKE 'Program log: GOVERNANCE-INSTRUCTION: CastVote %'  
+AND tx_id = '4T3aZ7o4TSFq9h1WAxDopmF8YJkGVHGnWdQ4hUiA2dx2rvvhnkkFNgqAUds75wBqz1NfPY1PKFsJsRAv7tYAUCRi'

--- a/models/silver/silver__proposal_votes_realms.sql
+++ b/models/silver/silver__proposal_votes_realms.sql
@@ -77,7 +77,7 @@ b AS (
         LEFT OUTER JOIN TABLE(FLATTEN(t.log_messages)) l
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
+WHERE _inserted_timestamp >= (
     SELECT
         MAX(_inserted_timestamp)
     FROM

--- a/models/silver/silver__proposal_votes_realms.yml
+++ b/models/silver/silver__proposal_votes_realms.yml
@@ -1,0 +1,60 @@
+version: 2
+models:
+  - name: silver__proposal_votes_realms
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2 # just an initial proposal so far
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null
+      - name: INDEX
+        description: "{{ doc('index') }}"
+        tests: 
+          - not_null
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        tests: 
+          - not_null
+      - name: REALMS_ID 
+        description: An address that is unique to the space or voting group on Realms. 
+        tests: 
+          - not_null
+      - name: PROPOSAL
+        description: Address representing the proposal being voted on
+        tests: 
+          - not_null
+      - name: VOTER
+        description: Address voting on the proposal
+        tests: 
+          - not_null
+      - name: VOTE_CHOICE
+        description: How the user voted on the proposal
+        tests: 
+          - not_null
+      - name: VOTE_WEIGHT
+        description: The percent of voting power committed to the vote
+        tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/silver__proposal_votes_realms.yml
+++ b/models/silver/silver__proposal_votes_realms.yml
@@ -31,11 +31,6 @@ models:
         description: "{{ doc('index') }}"
         tests: 
           - not_null
-      - name: _INDEX
-        description: An internal column that corresponds to the vote's position in the transaction log. 
-        tests: 
-          - not_null:
-              store_failures: FALSE # Can only store failures for one internal column
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 

--- a/models/silver/silver__proposal_votes_realms.yml
+++ b/models/silver/silver__proposal_votes_realms.yml
@@ -1,6 +1,7 @@
 version: 2
 models:
   - name: silver__proposal_votes_realms
+    description: An EZ view of all vote transactions on Realms DAO governance spaces. A space serves as a voting group for an organization, dAPP, or DAO.  
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -13,7 +14,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2 # just an initial proposal so far
+              interval: 2 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
@@ -30,6 +31,11 @@ models:
         description: "{{ doc('index') }}"
         tests: 
           - not_null
+      - name: _INDEX
+        description: An internal column that corresponds to the vote's position in the transaction log. 
+        tests: 
+          - not_null:
+              store_failures: FALSE # Can only store failures for one internal column
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 
@@ -46,8 +52,16 @@ models:
         description: Address voting on the proposal
         tests: 
           - not_null
+      - name: VOTE_ACCOUNT 
+        description: An account belonging to the voting wallet that is opened on a vote. Used to transfer the voting tx fee. 
+        tests: 
+          - not_null
       - name: VOTE_CHOICE
         description: How the user voted on the proposal
+        tests: 
+          - not_null
+      - name: VOTE_RANK
+        description: The order of a user's preferred choices when more than one vote option is available
         tests: 
           - not_null
       - name: VOTE_WEIGHT


### PR DESCRIPTION
Vote options are found in the transaction log. Yes and no votes have two separate log structures. 

There is a default program ID for realms that starts with GovER... However, if you write your own gov contract your space will have a unique program ID. There are multiple important spaces, such as Mango Markets, Serum, and Orca that utilize their own program ID. Labels for all the governance spaces' program IDs were uploaded from the Solana labs github to the labels table and pulled in via a CTE to this model to ID votes that occur on Realms. 

The final "WHERE" clause is necessary to correctly represent three transactions in which two vote accounts were created and two votes occurred within the same transaction. These "double" votes were done by the same voter on the same transaction. The following tx_ids are the transactions in question: 'jGD6MefUkncsxnaXVznVxm5UCfzw6ENoecfC2EBvo8JLpXFUGMW2tRcFJp3v1irL4b8ohoBv5C5oS23xcsYW1Tt', '2mydbkQycUMNwSmjuwbunagB3uNpyJQ3eq7gVQRYfEc5MC6opkouf5GRiZFaXg2FNinVb4bPhVgsAJK4e7Zx9KNG', and 'ctzYATbWK98U6v3RNcpxWBDURe8bAGMptaLtHKRuTVr9xPNFE7bqdhQx6yLLGf2StQQ5hj461am2u28fhY2GGAP' 