### PR TITLE
validator name referencing wrong labels column

### DIFF
--- a/models/core/core__ez_staking_lp_actions.sql
+++ b/models/core/core__ez_staking_lp_actions.sql
@@ -350,7 +350,7 @@ SELECT
     validator_rank,
     commission, 
     COALESCE(
-        label,
+        address_name,
         vote_account
     ) AS validator_name
 FROM temp2


### PR DESCRIPTION
- Current model is referencing wrong column, all the validator names are "solana validator" instead of the "address name" which is the name of that specific validator.