### PR TITLE
An 1971/update streamline backfill models

### DIFF
--- a/macros/streamline/bulk_get_block_txs/task_bulk_get_block_txs_historical.sql
+++ b/macros/streamline/bulk_get_block_txs/task_bulk_get_block_txs_historical.sql
@@ -3,7 +3,7 @@
 execute immediate 'create or replace task streamline.bulk_get_block_txs_historical
     warehouse = dbt_cloud_solana
     allow_overlapping_execution = false
-    schedule = \'USING CRON */6 * * * * UTC\'
+    schedule = \'USING CRON */30 * * * * UTC\'
 as
 BEGIN
     call streamline.refresh_external_table_next_batch(\'block_txs_api\',\'complete_block_txs\');

--- a/models/streamline/streamline__all_unknown_block_rewards_historical.sql
+++ b/models/streamline/streamline__all_unknown_block_rewards_historical.sql
@@ -5,11 +5,12 @@
 WITH pre_final AS (
 
     SELECT
-        SEQ8() AS block_id
+        SEQ8()+98680445 AS block_id
     FROM
-        TABLE(GENERATOR(rowcount => 1000000000))
+        TABLE(GENERATOR(rowcount => 60000000))
     WHERE
-        block_id <= 98680445
+        block_id > 98680445
+        AND block_id <= 148378013
     EXCEPT
     SELECT
         block_id

--- a/models/streamline/streamline__all_unknown_block_txs_historical.sql
+++ b/models/streamline/streamline__all_unknown_block_txs_historical.sql
@@ -5,11 +5,12 @@
 WITH pre_final AS (
 
     SELECT
-        SEQ8() AS block_id
+        SEQ8()+98680445 AS block_id
     FROM
-        TABLE(GENERATOR(rowcount => 1000000000))
+        TABLE(GENERATOR(rowcount => 60000000))
     WHERE
-        block_id <= 98680445
+        block_id > 98680445
+        AND block_id <= 148378013
     EXCEPT
     SELECT
         block_id

--- a/models/streamline/streamline__all_unknown_blocks_historical.sql
+++ b/models/streamline/streamline__all_unknown_blocks_historical.sql
@@ -3,12 +3,14 @@
 ) }}
 
 SELECT
-    SEQ8() AS block_id
+    SEQ8() + 98680445 AS block_id
 FROM
-    TABLE(GENERATOR(rowcount => 1000000000))
-WHERE block_id <= 98680445
+    TABLE(GENERATOR(rowcount => 60000000))
+WHERE
+    block_id > 98680445
+    AND block_id <= 148378013
 EXCEPT
 SELECT
     block_id
-from 
+FROM
     {{ ref('streamline__complete_blocks') }}

--- a/models/streamline/streamline__complete_block_rewards.sql
+++ b/models/streamline/streamline__complete_block_rewards.sql
@@ -5,18 +5,6 @@
     merge_update_columns = ["_partition_id"]
 ) }}
 
-WITH meta AS (
-
-    SELECT
-        registered_on,
-        file_name
-    FROM
-        TABLE(
-            information_schema.external_table_files(
-                table_name => '{{ source( "solana_external", "block_rewards_api") }}'
-            )
-        ) A
-)
 SELECT
     block_id,
     _partition_id

--- a/models/streamline/streamline__complete_block_txs.sql
+++ b/models/streamline/streamline__complete_block_txs.sql
@@ -5,18 +5,6 @@
     merge_update_columns = ["_partition_id"]
 ) }}
 
-WITH meta AS (
-
-    SELECT
-        registered_on,
-        file_name
-    FROM
-        TABLE(
-            information_schema.external_table_files(
-                table_name => '{{ source( "solana_external", "block_txs_api") }}'
-            )
-        ) A
-)
 SELECT
     block_id,
     _partition_id


### PR DESCRIPTION
- Update streamline models to backfill new set of blokcs
- Update block txs schedule to twice an hour because lambda is now configured to run for full 15mins + the amount of data loaded takes >10mins to refresh the tables before a new set of blocks can be retrieved for processing