### PR TITLE
An 1981/update streamline for chainhead

### DIFF
--- a/macros/streamline/bulk_get_block_rewards/task_bulk_get_block_rewards_historical.sql
+++ b/macros/streamline/bulk_get_block_rewards/task_bulk_get_block_rewards_historical.sql
@@ -3,42 +3,10 @@
 execute immediate 'create or replace task streamline.bulk_get_block_rewards_historical
     warehouse = dbt_cloud_solana
     allow_overlapping_execution = false
-    schedule = \'USING CRON */3 * * * * UTC\'
+    schedule = \'USING CRON */15 * * * * UTC\'
 as
 BEGIN
-    call streamline.refresh_external_table_next_batch(\'block_rewards_api\',\'complete_block_rewards\');
-    create or replace temporary table streamline.complete_block_rewards__dbt_tmp as
-    (
-        select * 
-        from (
-            SELECT
-                block_id,
-                _partition_id
-            FROM
-                bronze.block_rewards_api AS s
-            WHERE
-                s.block_id IS NOT NULL
-                AND s._partition_id > (
-                    select 
-                        coalesce(max(_partition_id),0)
-                    from
-                        streamline.complete_block_rewards
-                )
-
-            group by 1,2
-        ) 
-        order by (_partition_id)
-    );
-    merge into streamline.complete_block_rewards as DBT_INTERNAL_DEST
-        using streamline.complete_block_rewards__dbt_tmp as DBT_INTERNAL_SOURCE
-        on DBT_INTERNAL_SOURCE.block_id = DBT_INTERNAL_DEST.block_id
-        when matched then 
-            update set
-            _partition_id = DBT_INTERNAL_SOURCE._partition_id
-        when not matched then 
-            insert ("BLOCK_ID", "_PARTITION_ID")
-            values ("BLOCK_ID", "_PARTITION_ID");
-    select streamline.udf_bulk_get_block_rewards()
+    select streamline.udf_bulk_get_block_rewards(FALSE)
         where exists (
             select 1
             from streamline.all_unknown_block_rewards_historical

--- a/macros/streamline/bulk_get_block_rewards/task_bulk_get_block_rewards_real_time.sql
+++ b/macros/streamline/bulk_get_block_rewards/task_bulk_get_block_rewards_real_time.sql
@@ -1,0 +1,25 @@
+{% macro task_bulk_get_block_rewards_real_time() %}
+{% set sql %}
+execute immediate 'create or replace task streamline.bulk_get_block_rewards_real_time
+    warehouse = dbt_cloud_solana
+    allow_overlapping_execution = false
+    schedule = \'USING CRON */15 * * * * UTC\'
+as
+BEGIN
+    select streamline.udf_bulk_get_block_rewards(TRUE)
+        where exists (
+            select 1
+            from streamline.all_unknown_block_rewards_real_time
+            limit 1
+        );       
+END;'
+{% endset %}
+{% do run_query(sql) %}
+
+{% if target.database == 'SOLANA' %}
+    {% set sql %}
+    alter task streamline.bulk_get_block_rewards_real_time resume;
+    {% endset %}
+    {% do run_query(sql) %}
+{% endif %}
+{% endmacro %}

--- a/macros/streamline/bulk_get_block_rewards/udf_bulk_get_block_rewards.sql
+++ b/macros/streamline/bulk_get_block_rewards/udf_bulk_get_block_rewards.sql
@@ -1,6 +1,6 @@
 {% macro udf_bulk_get_block_rewards() %}
     CREATE
-    OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_block_rewards() returns text api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
+    OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_block_rewards(is_real_time boolean) returns text api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
         'https://pj4rqb8z96.execute-api.us-east-1.amazonaws.com/prod/bulk_get_block_rewards'
     {% else %}
         'https://11zlwk4fm3.execute-api.us-east-1.amazonaws.com/dev/bulk_get_block_rewards'

--- a/macros/streamline/bulk_get_block_txs/task_bulk_get_block_txs_historical.sql
+++ b/macros/streamline/bulk_get_block_txs/task_bulk_get_block_txs_historical.sql
@@ -3,44 +3,10 @@
 execute immediate 'create or replace task streamline.bulk_get_block_txs_historical
     warehouse = dbt_cloud_solana
     allow_overlapping_execution = false
-    schedule = \'USING CRON */30 * * * * UTC\'
+    schedule = \'USING CRON */15 * * * * UTC\'
 as
 BEGIN
-    call streamline.refresh_external_table_next_batch(\'block_txs_api\',\'complete_block_txs\');
-    create or replace temporary table streamline.complete_block_txs__dbt_tmp as
-    (
-        select * 
-        from (
-            SELECT
-                block_id,
-                _partition_id
-            FROM
-                bronze.block_txs_api AS s
-            WHERE
-                s.block_id IS NOT NULL
-
-
-            AND s._partition_id > (
-                select 
-                    coalesce(max(_partition_id),0)
-                from
-                    streamline.complete_block_txs
-            )
-            group by 1,2
-        ) 
-        order by (_partition_id)
-    );
-
-    merge into streamline.complete_block_txs as DBT_INTERNAL_DEST
-        using streamline.complete_block_txs__dbt_tmp as DBT_INTERNAL_SOURCE
-        on DBT_INTERNAL_SOURCE.block_id = DBT_INTERNAL_DEST.block_id
-        when matched then 
-            update set _partition_id = DBT_INTERNAL_SOURCE._partition_id
-        when not matched then 
-            insert ("BLOCK_ID", "_PARTITION_ID")
-            values ("BLOCK_ID", "_PARTITION_ID");
-
-    select streamline.udf_bulk_get_block_txs()
+    select streamline.udf_bulk_get_block_txs(FALSE)
     where exists (
         select 1
         from streamline.all_unknown_block_txs_historical

--- a/macros/streamline/bulk_get_block_txs/task_bulk_get_block_txs_real_time.sql
+++ b/macros/streamline/bulk_get_block_txs/task_bulk_get_block_txs_real_time.sql
@@ -1,0 +1,25 @@
+{% macro task_bulk_get_block_txs_real_time() %}
+{% set sql %}
+execute immediate 'create or replace task streamline.bulk_get_block_txs_real_time
+    warehouse = dbt_cloud_solana
+    allow_overlapping_execution = false
+    schedule = \'USING CRON */15 * * * * UTC\'
+as
+BEGIN
+    select streamline.udf_bulk_get_block_txs(TRUE)
+    where exists (
+        select 1
+        from streamline.all_unknown_block_txs_real_time
+        limit 1
+    );
+END;'
+{% endset %}
+{% do run_query(sql) %}
+
+{% if target.database == 'SOLANA' %}
+    {% set sql %}
+    alter task streamline.bulk_get_block_txs_real_time resume;
+    {% endset %}
+    {% do run_query(sql) %}
+{% endif %}
+{% endmacro %}

--- a/macros/streamline/bulk_get_block_txs/udf_bulk_get_block_txs.sql
+++ b/macros/streamline/bulk_get_block_txs/udf_bulk_get_block_txs.sql
@@ -1,6 +1,6 @@
 {% macro udf_bulk_get_block_txs() %}
     CREATE
-    OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_block_txs() returns text api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
+    OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_block_txs(is_real_time boolean) returns text api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
         'https://pj4rqb8z96.execute-api.us-east-1.amazonaws.com/prod/bulk_get_block_txs'
     {% else %}
         'https://11zlwk4fm3.execute-api.us-east-1.amazonaws.com/dev/bulk_get_block_txs'

--- a/macros/streamline/bulk_get_blocks/task_bulk_get_blocks_historical.sql
+++ b/macros/streamline/bulk_get_blocks/task_bulk_get_blocks_historical.sql
@@ -3,68 +3,10 @@
 execute immediate 'create or replace task streamline.bulk_get_blocks_historical
     warehouse = dbt_cloud_solana
     allow_overlapping_execution = false
-    schedule = \'USING CRON */5 * * * * UTC\'
+    schedule = \'USING CRON */15 * * * * UTC\'
 as
 BEGIN
-    alter external table bronze.blocks_api refresh;
-    create or replace temporary table streamline.complete_blocks__dbt_tmp as
-    (
-        select * 
-        from (
-                WITH meta AS (
-                    SELECT
-                        registered_on,
-                        file_name
-                    FROM
-                        TABLE(
-                            information_schema.external_table_files(
-                                table_name => \'bronze.blocks_api\'
-                            )
-                        ) A
-                    WHERE
-                        registered_on >= (
-                            SELECT
-                                COALESCE(MAX(_INSERTED_TIMESTAMP), \'1970-01-01\' :: DATE) max_INSERTED_TIMESTAMP
-                            FROM
-                                streamline.complete_blocks
-                        )
-                )
-                SELECT
-                    block_id,
-                    _inserted_date,
-                    m.registered_on as _inserted_timestamp
-                FROM
-                    bronze.blocks_api AS s
-                    JOIN meta m
-                    ON m.file_name = metadata$filename
-                WHERE
-                    s.block_id IS NOT NULL
-
-
-                    AND s._inserted_date >= CURRENT_DATE
-                    AND m.registered_on > (
-                        SELECT
-                            coalesce(max(_inserted_timestamp),\'2022-01-01 00:00:00\'::timestamp_ntz)
-                        FROM
-                            streamline.complete_blocks
-                    )
-                    qualify(ROW_NUMBER() over (PARTITION BY block_id
-                    ORDER BY
-                    _inserted_date, _inserted_timestamp DESC)) = 1
-        ) 
-        order by (_inserted_date)
-    );
-    merge into streamline.complete_blocks as DBT_INTERNAL_DEST
-        using streamline.complete_blocks__dbt_tmp as DBT_INTERNAL_SOURCE
-        on DBT_INTERNAL_SOURCE.block_id = DBT_INTERNAL_DEST.block_id
-        when matched then 
-            update set
-            _inserted_date = DBT_INTERNAL_SOURCE._inserted_date,
-            _inserted_timestamp = DBT_INTERNAL_SOURCE._inserted_timestamp
-        when not matched then 
-            insert ("BLOCK_ID", "_INSERTED_DATE", "_INSERTED_TIMESTAMP")
-            values ("BLOCK_ID", "_INSERTED_DATE", "_INSERTED_TIMESTAMP");
-    select streamline.udf_bulk_get_blocks()
+    select streamline.udf_bulk_get_blocks(FALSE)
     where exists (
         select 1
         from streamline.all_unknown_blocks_historical

--- a/macros/streamline/bulk_get_blocks/task_bulk_get_blocks_real_time.sql
+++ b/macros/streamline/bulk_get_blocks/task_bulk_get_blocks_real_time.sql
@@ -1,0 +1,25 @@
+{% macro task_bulk_get_blocks_real_time() %}
+{% set sql %}
+execute immediate 'create or replace task streamline.bulk_get_blocks_real_time
+    warehouse = dbt_cloud_solana
+    allow_overlapping_execution = false
+    schedule = \'USING CRON */15 * * * * UTC\'
+as
+BEGIN
+    select streamline.udf_bulk_get_blocks(TRUE)
+    where exists (
+        select 1
+        from streamline.all_unknown_blocks_real_time
+        limit 1
+    );
+END;'
+{% endset %}
+{% do run_query(sql) %}
+
+{% if target.database == 'SOLANA' %}
+    {% set sql %}
+    alter task streamline.bulk_get_blocks_real_time resume;
+    {% endset %}
+    {% do run_query(sql) %}
+{% endif %}
+{% endmacro %}

--- a/macros/streamline/bulk_get_blocks/udf_bulk_get_blocks.sql
+++ b/macros/streamline/bulk_get_blocks/udf_bulk_get_blocks.sql
@@ -1,6 +1,6 @@
 {% macro udf_bulk_get_blocks() %}
     CREATE
-    OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_blocks() returns text api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
+    OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_blocks(is_real_time boolean) returns text api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
         'https://pj4rqb8z96.execute-api.us-east-1.amazonaws.com/prod/bulk_get_blocks'
     {% else %}
         'https://11zlwk4fm3.execute-api.us-east-1.amazonaws.com/dev/bulk_get_blocks'

--- a/models/streamline/streamline__all_unknown_block_rewards_real_time.sql
+++ b/models/streamline/streamline__all_unknown_block_rewards_real_time.sql
@@ -1,0 +1,31 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+WITH pre_final AS (
+
+    SELECT
+        SEQ8()+
+        iff(
+            (select max(block_id)-300000 from {{ ref('streamline__complete_block_rewards') }}) < 148520683,
+            148520683,
+            (select max(block_id)-300000 from {{ ref('streamline__complete_block_rewards') }})) 
+        as block_id
+    FROM
+        TABLE(GENERATOR(rowcount => 5000000))
+    EXCEPT
+    SELECT
+        block_id
+    FROM
+        {{ ref('streamline__complete_block_rewards') }}
+)
+SELECT
+    block_id,
+    (
+        SELECT
+            coalesce(MAX(_partition_id) + 1,1)
+        FROM
+            {{ ref('streamline__complete_block_rewards') }}
+    ) AS batch_id
+FROM
+    pre_final

--- a/models/streamline/streamline__all_unknown_block_txs_real_time.sql
+++ b/models/streamline/streamline__all_unknown_block_txs_real_time.sql
@@ -1,0 +1,31 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+WITH pre_final AS (
+
+    SELECT
+        SEQ8()+
+        iff(
+            (select max(block_id)-300000 from {{ ref('streamline__complete_block_txs') }}) < 148520683,
+            148520683,
+            (select max(block_id)-300000 from {{ ref('streamline__complete_block_txs') }})) 
+        as block_id
+    FROM
+        TABLE(GENERATOR(rowcount => 5000000))
+    EXCEPT
+    SELECT
+        block_id
+    FROM
+        {{ ref('streamline__complete_block_txs') }}
+)
+SELECT
+    block_id,
+    (
+        SELECT
+            coalesce(MAX(_partition_id) + 1,1)
+        FROM
+            {{ ref('streamline__complete_block_txs') }}
+    ) AS batch_id
+FROM
+    pre_final

--- a/models/streamline/streamline__all_unknown_blocks_real_time.sql
+++ b/models/streamline/streamline__all_unknown_blocks_real_time.sql
@@ -1,0 +1,18 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+SELECT
+    SEQ8()+
+    iff(
+        (select max(block_id)-300000 from {{ ref('streamline__complete_block_txs') }}) < 148520683,
+        148520683,
+        (select max(block_id)-300000 from {{ ref('streamline__complete_block_txs') }})) 
+    as block_id
+FROM
+    TABLE(GENERATOR(rowcount => 5000000))
+EXCEPT
+SELECT
+    block_id
+FROM
+    {{ ref('streamline__complete_blocks') }}


### PR DESCRIPTION
- Add streamline resources to support getting chain head data
- Remove table refresh steps from streamline tasks, this is now done in streamline itself