### PR TITLE
reduce batch load size

### DIFF
--- a/models/silver/silver__transactions2.sql
+++ b/models/silver/silver__transactions2.sql
@@ -48,7 +48,7 @@ WITH pre_final AS (
         )
     AND
         _partition_id <= (
-            select max(_partition_id)+10
+            select max(_partition_id)+1
             from {{this}}
         )
     AND 


### PR DESCRIPTION
- reducing batch size because we are now getting into more recent backfills which were changed to ~200k blocks per batch vs. 45k blocks + these blocks hold more data