### PR TITLE
pretty much all blocks before this have null timestamps

### DIFF
--- a/models/silver/silver__transactions2.sql
+++ b/models/silver/silver__transactions2.sql
@@ -84,6 +84,7 @@ WITH pre_final AS (
     from {{ this }} t
     inner join {{ ref('silver__blocks2') }} b on b.block_id = t.block_id
     where t.block_timestamp::date is null
+    and t.block_id > 39824213;
 )
 {% endif %}
 SELECT

--- a/models/silver/silver__votes2.sql
+++ b/models/silver/silver__votes2.sql
@@ -78,6 +78,7 @@ WITH pre_final AS (
     from {{ this }} t
     inner join {{ ref('silver__blocks2') }} b on b.block_id = t.block_id
     where t.block_timestamp::date is null
+    and t.block_id > 39824213;
 )
 {% endif %}
 SELECT


### PR DESCRIPTION
- don't try to get block_timestamps for blocks before `39824213`, pretty much they all have null timestamps from the node.