### PR TITLE
An 2258/tests for streamline based models

### DIFF
--- a/models/silver/nfts/silver__nft_mint_price_generic2.yml
+++ b/models/silver/nfts/silver__nft_mint_price_generic2.yml
@@ -1,0 +1,50 @@
+version: 2
+models:
+  - name: silver__nft_mint_price_generic2
+    description: intermediary model for getting an nft's mint price
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - MINT
+            - PAYER
+            - MINT_CURRENCY
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "block timestamp of the latest transaction with a mint price"
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+      - name: TX_IDS
+        description: "set of transaction ids that has an associated mint price"
+        tests:
+          - not_null
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null
+      - name: PAYER 
+        description: "{{ doc('mint_payer') }}"
+        tests: 
+          - not_null:
+              where: mint_price is not null
+      - name: MINT_CURRENCY
+        description: "{{ doc('mint_currency') }}"
+        tests: 
+          - not_null:
+              where: mint_price is not null
+      - name: DECIMAL
+        description: "{{ doc('decimal') }}"
+        tests: 
+          - not_null
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        tests: 
+          - not_null
+      - name: MINT_PRICE
+        description: "{{ doc('mint_price') }}"
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/nfts/silver__nft_sales_magic_eden_v1_2.sql
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_v1_2.sql
@@ -139,7 +139,7 @@ WHERE
             LEAST(DATEADD(
                 'day',
                 1,
-                COALESCE(MAX(block_timestamp) :: DATE, '2021-09-07')),'2022-09-19')
+                COALESCE(MAX(block_timestamp) :: DATE, '2021-09-07')),'2022-10-05')
                 FROM
                     {{ this }}
         )
@@ -148,7 +148,7 @@ WHERE
             LEAST(DATEADD(
             'day',
             30,
-            COALESCE(MAX(block_timestamp) :: DATE, '2021-09-07')),'2022-09-19')
+            COALESCE(MAX(block_timestamp) :: DATE, '2021-09-07')),'2022-10-05')
             FROM
                 {{ this }}
         ) 

--- a/models/silver/nfts/silver__nft_sales_magic_eden_v1_2.yml
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_v1_2.yml
@@ -1,0 +1,57 @@
+version: 2
+models:
+  - name: silver__nft_sales_magic_eden_v1_2
+    description: intermediary model for sales on Magic Eden V1
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - MINT
+            - SELLER
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests:
+          - not_null
+      - name: PROGRAM_ID 
+        description: "{{ doc('program_id') }}"
+        tests: 
+          - not_null
+      - name: PURCHASER
+        description: "{{ doc('purchaser') }}"
+        tests: 
+          - not_null:
+              where: succeeded = TRUE
+      - name: SELLER
+        description: "{{ doc('seller') }}"
+        tests: 
+          - not_null:
+              where: succeeded = TRUE
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null:
+              where: succeeded = TRUE
+      - name: SALES_AMOUNT
+        description: "{{ doc('sales_amount') }}"
+        tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/nfts/silver__nft_sales_magic_eden_v2_2.yml
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_v2_2.yml
@@ -1,0 +1,67 @@
+version: 2
+models:
+  - name: silver__nft_sales_magic_eden_v2_2
+    description: intermediary model for sales on Magic Eden V2
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+      - compare_model_subset:
+          name: silver__nft_sales_magic_eden_v2_2_business_logic_test
+          compare_model: ref('testing__nft_sales_magic_eden_v2')
+          compare_columns: 
+            - tx_id
+            - purchaser
+            - seller
+            - mint
+            - round(sales_amount,8)
+          model_condition: "where tx_id in ('28PWDFj8Cxb9YihmGqN6CeU5iNrNW1fiZ5mxVbu8Sox61uiTH2m57duJ4F5pv7DahNPr2oAN7umziBCHab6FCBXR',
+            '2opUe8cZkhMrVQBNy9McDZThPdW7gFoFzf4J6TnX3QUKAQi9pfDZoYwAQFcvDrQBfzg2Jw7SXhx6D5Y6kdPh68oY',
+            '4hr1zeCVBHT1FGgcHad19tp8Jp9Q6itcKHjRLK7uuVVwjhDbSDG2hrEm6Zfd73RiNnu9sqQbBfpo798viibFunWi',
+            '4iq2miqiFfJXw7gKHunTLnLyzFDom13vakh25DUXZRFDnZaUC9KztFbcqx9L9Up8WB7u6qd3NyuoCsHMNKHrBHYV')"
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests:
+          - not_null
+      - name: PROGRAM_ID 
+        description: "{{ doc('program_id') }}"
+        tests: 
+          - not_null
+      - name: PURCHASER
+        description: "{{ doc('purchaser') }}"
+        tests: 
+          - not_null
+      - name: SELLER
+        description: "{{ doc('seller') }}"
+        tests: 
+          - not_null: 
+              where: succeeded = TRUE
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null:
+              where: succeeded = TRUE
+      - name: SALES_AMOUNT
+        description: "{{ doc('sales_amount') }}"
+        tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/silver___inner_instructions2.yml
+++ b/models/silver/silver___inner_instructions2.yml
@@ -1,0 +1,36 @@
+version: 2
+models:
+  - name: silver___inner_instructions2
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: block_id > 39824213
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: INDEX
+        description: Location of the inner_instruction within the inner_instructions of a transaction
+        tests: 
+          - not_null 
+      - name: MAPPED_INSTRUCTION_INDEX
+        description: Specifies the instruction which this inner_instruction applies
+        tests: 
+          - not_null
+      - name: VALUE
+        description: json object that contains the inner instruction
+        tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/silver___instructions2.yml
+++ b/models/silver/silver___instructions2.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: silver___instructions2
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: block_id > 39824213
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null
+      - name: INDEX
+        description: Location of the instruction within the instructions of a transaction
+        tests: 
+          - not_null 
+      - name: VALUE
+        description: json object that contains the instruction
+        tests: 
+          - not_null:
+              where: block_timestamp::date > current_date - 30
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/silver___post_token_balances2.yml
+++ b/models/silver/silver___post_token_balances2.yml
@@ -1,0 +1,59 @@
+version: 2
+models:
+  - name: silver___post_token_balances2
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_ID
+            - TX_ID
+            - INDEX
+          where: block_timestamp::date > current_date - 30
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: INDEX
+        description: Location of the post token balance entry within the array for a transaction
+        tests: 
+          - not_null 
+      - name: ACCOUNT_INDEX
+        description: Location corresponding to the index in the account_keys array 
+        tests: 
+          - not_null
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null 
+      - name: OWNER
+        description: Address of the owner of the token account
+        tests: 
+          - not_null:
+              where: block_id > 111492264 # before this we don't have owner from figment
+      - name: DECIMAL 
+        description: Number of decimals in the token value, need to divide amount by 10^decimal
+        tests: 
+          - not_null 
+      - name: UIAMOUNT
+        description: Amount of the token in the transaction 
+        tests: 
+          - not_null
+      - name: UIAMOUNTSTRING
+        description: Amount of the token in the transaction in string format
+        tests: 
+          - not_null  
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/silver___pre_token_balances2.yml
+++ b/models/silver/silver___pre_token_balances2.yml
@@ -1,0 +1,59 @@
+version: 2
+models:
+  - name: silver___pre_token_balances2
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_ID
+            - TX_ID
+            - INDEX
+          where: block_timestamp::date > current_date - 30
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: INDEX
+        description: Location of the pre token balance entry within the array for a transaction
+        tests: 
+          - not_null 
+      - name: ACCOUNT_INDEX
+        description: Location corresponding to the index in the accounts array 
+        tests: 
+          - not_null
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null 
+      - name: OWNER
+        description: Address of the owner of the token account
+        tests: 
+          - not_null:
+              where: block_id > 111492264 # before this we don't have owner from figment
+      - name: DECIMAL 
+        description: Number of decimals in the token value, need to divide amount by 10^decimal
+        tests: 
+          - not_null 
+      - name: UIAMOUNT
+        description: Amount of the token in the transaction 
+        tests: 
+          - not_null
+      - name: UIAMOUNTSTRING
+        description: Amount of the token in the transaction in string format
+        tests: 
+          - not_null  
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null

--- a/models/silver/silver__mint_actions2.yml
+++ b/models/silver/silver__mint_actions2.yml
@@ -1,0 +1,61 @@
+version: 2
+models:
+  - name: silver__mint_actions2
+    description: table holding mint initialization or token minting events
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+            - EVENT_TYPE
+            - MINT
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: block_id > 39824213 and _inserted_timestamp::date < current_date
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests:
+          - not_null
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        tests:
+          - not_null
+      - name: INNER_INDEX
+        description: Location of the inner instruction within an instruction
+      - name: EVENT_TYPE 
+        description: "{{ doc('event_type') }}"
+        tests: 
+          - not_null
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null
+      - name: DECIMAL
+        description: "{{ doc('decimal') }}"
+        tests: 
+          - not_null:
+              where: event_type in ('initializeMint','initializeMint2')
+      - name: MINT_AMOUNT
+        description: "{{ doc('mint_amount') }}"
+        tests: 
+          - not_null:
+              where: event_type in ('mintTo','mintToChecked')
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null


### PR DESCRIPTION
- Create .yml files for new models based on streamline data sources
- Update block_id filter range in `nft_sales_magic_eden_v1_2` to be consistent