### PR TITLE
output gap range instead of single block id

### DIFF
--- a/tests/test_silver__blocks_gaps.sql
+++ b/tests/test_silver__blocks_gaps.sql
@@ -1,20 +1,15 @@
-{{ config(error_if = '>25', warn_if = '>0') }}
-
 WITH tmp AS (
-
     SELECT
         block_id,
-        previous_block_id
+        previous_block_id,
+        block_timestamp
     FROM
         {{ ref('silver__blocks') }}
-    WHERE 
-        _inserted_date < current_date 
-    AND 
-        block_id >= 130000000
 ),
 missing AS (
     SELECT
-        t1.previous_block_id AS missing_block_id
+        t1.previous_block_id AS missing_block_id,
+        t1.block_timestamp
     FROM
         tmp t1
         LEFT OUTER JOIN tmp t2
@@ -22,8 +17,28 @@ missing AS (
     WHERE
         t2.block_id IS NULL
         AND t1.previous_block_id IS NOT NULL
+),
+gaps AS (
+    SELECT
+        (
+            SELECT
+                MAX(block_id)
+            FROM
+                solana.silver.blocks
+            WHERE
+                block_id > 0
+                AND block_id < missing_block_id
+        ) AS gap_start_block_id,
+        missing_block_id AS gap_end_block_id,
+        gap_end_block_id - gap_start_block_id AS diff
+    FROM
+        missing
+    WHERE
+        block_timestamp :: DATE < CURRENT_DATE
 )
 SELECT
     *
 FROM
-    missing
+    gaps
+WHERE
+    gap_end_block_id <> 1690556;-- this block is not available


### PR DESCRIPTION
- Modify the block gaps test to output the full possible gap range.  Previous edition was flawed because it gave only 1 block id per gap...meaning if there was a gap of 100 blocks missing, we would need to run this 100 times for it to show.