### PR TITLE
make recency test larger interval

### DIFF
--- a/models/silver/nfts/silver__nft_bids_yawww.yml
+++ b/models/silver/nfts/silver__nft_bids_yawww.yml
@@ -12,7 +12,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 14
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
- Making the interval larger on the recency test for yawww bids.  I created a bid myself today and it is reflected in the model so I don't think there is an issue here with the code / nothing has changed programmatically on yawww's end

`select block_timestamp::date, count(*)
from solana.silver.nft_bids_yawww
group by 1
order by 1 desc;`