### PR TITLE
increase date interval for recency test

### DIFF
--- a/models/silver/gauges/silver__gauges_votes_marinade.yml
+++ b/models/silver/gauges/silver__gauges_votes_marinade.yml
@@ -15,7 +15,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 14
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
There can be multiple days where no gauge votes occur, so the test for recency was increased to 14 days.