### PR TITLE
allow solana to run on dbt 1.2

### DIFF
--- a/.github/workflows/dbt_run_incremental.yml
+++ b/.github/workflows/dbt_run_incremental.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          pip3 install dbt-snowflake==1.3.0 cli_passthrough requests click
+          pip3 install dbt-snowflake==1.2.0 cli_passthrough requests click
           dbt deps
       - name: Run DBT Jobs
         run: |

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: calogica/dbt_expectations
-    version: 0.8.0
+    version: 0.7.0
   - package: dbt-labs/dbt_external_tables
     version: 0.8.0
   - package: dbt-labs/dbt_utils


### PR DESCRIPTION
- hotfix to allow solana to run on dbt 1.2.0