### PR TITLE
remove join with transactions table

### DIFF
--- a/models/silver/swaps/silver__swaps_intermediate_generic.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_generic.sql
@@ -45,23 +45,19 @@ AND _inserted_timestamp >= (
 dex_txs AS (
     SELECT
         e.*,
-        IFF(array_size(signers) = 1, signers[0]::STRING, NULL) AS swapper,
-        signers
+        IFF(array_size(signers) = 1, signers[0]::STRING, NULL) AS swapper
     FROM
         base_events e
-        INNER JOIN {{ ref('silver__transactions') }}
-        t
-        ON t.tx_id = e.tx_id
-        AND t.block_timestamp :: DATE = e.block_timestamp :: DATE
     WHERE
         (
             program_id IN (
                 -- saber
                 'Crt7UoUR6QgrFrN7j8rmSQpUTNWNSitSwWvsWGf1qZ5t',
                 'SSwpkEEcbUqx4vtoEByFjSkhKdCT862DNVb52nZg1UZ'
-            ) -- jupiter v2,v3
+            )
             OR (
                 program_id IN (
+                     -- jupiter v2,v3
                     'JUP2jxvXaqu7NQY1GmNF4m1vodw12LVXYxbFL2uJvfo',
                     'JUP3c2Uh3WA4Ng34tw6kPd2G4C5BB21Xo36Je1s32Ph'
                 )
@@ -71,18 +67,6 @@ dex_txs AS (
             )
         )
         AND inner_instruction_program_ids [0] <> 'DecZY86MU5Gj7kppfUCEmd4LbXXuyZH1yHaP2NTqdiZB' --associated with wrapping of tokens
-
-{% if is_incremental() %}
--- AND t.block_timestamp :: DATE = '2022-11-01'
-AND t._inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND t.block_timestamp :: DATE >= '2021-12-14'
-{% endif %}
 ),
 base_transfers AS (
     SELECT

--- a/models/silver/swaps/silver__swaps_intermediate_jupiterv4.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_jupiterv4.sql
@@ -39,32 +39,15 @@ dex_txs AS (
         IFF(ARRAY_SIZE(signers) = 1, signers [0] :: STRING, NULL) AS swapper,
         silver.udf_get_jupv4_inner_programs(
             inner_instruction :instructions
-        ) AS inner_programs,
-        signers
+        ) AS inner_programs
     FROM
         base_events e
-        INNER JOIN {{ ref('silver__transactions') }}
-        t
-        ON t.tx_id = e.tx_id
-        AND t.block_timestamp :: DATE = e.block_timestamp :: DATE
     WHERE
         program_id = 'JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB'
         AND ARRAY_SIZE(
             e.instruction :accounts
         ) > 6
         AND inner_instruction_program_ids [0] <> 'DecZY86MU5Gj7kppfUCEmd4LbXXuyZH1yHaP2NTqdiZB' --associated with wrapping of tokens
-
-{% if is_incremental() %}
--- AND t.block_timestamp :: DATE = '2022-11-01'
-AND t._inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND t.block_timestamp :: DATE >= '2022-07-12'
-{% endif %}
 ),
 temp_inner_program_ids AS (
     SELECT

--- a/models/silver/swaps/silver__swaps_intermediate_orca.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_orca.sql
@@ -45,14 +45,9 @@ AND _inserted_timestamp >= (
 dex_txs AS (
     SELECT
         e.*,
-        IFF(ARRAY_SIZE(signers) = 1, signers [0] :: STRING, NULL) AS swapper,
-        signers
+        IFF(ARRAY_SIZE(signers) = 1, signers [0] :: STRING, NULL) AS swapper
     FROM
         base_events e
-        INNER JOIN {{ ref('silver__transactions') }}
-        t
-        ON t.tx_id = e.tx_id
-        AND t.block_timestamp :: DATE = e.block_timestamp :: DATE
     WHERE
         program_id IN (
             -- Orca
@@ -61,18 +56,6 @@ dex_txs AS (
             'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc'
         )
         AND inner_instruction_program_ids [0] <> 'DecZY86MU5Gj7kppfUCEmd4LbXXuyZH1yHaP2NTqdiZB'
-
-{% if is_incremental() %}
--- AND t.block_timestamp :: DATE = '2022-11-01'
-AND t._inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND t.block_timestamp :: DATE >= '2021-12-14'
-{% endif %}
 ),
 base_transfers AS (
     SELECT

--- a/models/silver/swaps/silver__swaps_intermediate_raydium.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_raydium.sql
@@ -65,10 +65,6 @@ dex_txs AS (
         END AS user_owner
     FROM
         base_events e
-        INNER JOIN {{ ref('silver__transactions') }}
-        t
-        ON t.tx_id = e.tx_id
-        AND t.block_timestamp :: DATE = e.block_timestamp :: DATE
     WHERE
         (
             (
@@ -100,17 +96,6 @@ dex_txs AS (
                 )
             )
         )
-
-{% if is_incremental() %}
-AND t._inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND t.block_timestamp :: DATE >= '2021-12-14'
-{% endif %}
 ),
 base_transfers AS (
     SELECT


### PR DESCRIPTION
Remove joins with the `transaction` table, because the `events` table now contains the `signers` column. This fixes the 'ambiguous column' error that occurred.