### PR TITLE
db owner no longer has CRUD access to streamline externals

### DIFF
--- a/macros/streamline/sp_refresh_external_table_batch.sql
+++ b/macros/streamline/sp_refresh_external_table_batch.sql
@@ -3,6 +3,7 @@
 create or replace procedure streamline.refresh_external_table_next_batch(external_table_name string, streamline_table_name string)
 returns string
 language sql
+execute as caller
 as
 $$
     declare 

--- a/macros/streamline/sp_refresh_external_tables_full.sql
+++ b/macros/streamline/sp_refresh_external_tables_full.sql
@@ -3,6 +3,7 @@
 create or replace procedure streamline.sp_refresh_external_tables_full()
 returns boolean
 language sql
+execute as caller
 as
 $$
     begin 


### PR DESCRIPTION
- New role owning the database doesn't have CRUD grants on objects in the streamline database.  Executing as caller will ensure that the functional role's perms (which does have CRUD on streamline) are used to execute these statements.