### PR TITLE
temporary fix to avoid full table scan on underlying

### DIFF
--- a/models/silver/silver__daily_signers.sql
+++ b/models/silver/silver__daily_signers.sql
@@ -83,6 +83,8 @@ b AS (
         t,
         TABLE(FLATTEN(signers)) s
     WHERE
+        b_date >= current_date - 7
+    AND
         b_date IN (
             SELECT
                 block_timestamp_date
@@ -120,6 +122,8 @@ C AS (
         {{ ref('silver__events') }}
         e
     WHERE
+        e.block_timestamp :: DATE >= current_date - 7
+    AND
         e.block_timestamp :: DATE IN (
             SELECT
                 block_timestamp_date


### PR DESCRIPTION
- Our underlying tables have grown to a size where snowflake is no longer respecting the dynamic query pruning and requires a literal or static value.  See one reason https://community.snowflake.com/s/article/Pruning-is-not-happening-subquery.
- This is a temporary fix to limit the scan to last 7 days worth of data.  Any backfills required beyond this point will need a manual adjustment until a longer term fix is in place.