### PR TITLE
An 2678/yawww recency

### DIFF
--- a/models/silver/nfts/silver__nft_bids_yawww.yml
+++ b/models/silver/nfts/silver__nft_bids_yawww.yml
@@ -10,9 +10,6 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 14
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/silver/nfts/silver__nft_sales_yawww.yml
+++ b/models/silver/nfts/silver__nft_sales_yawww.yml
@@ -12,7 +12,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 14
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
The Yawww platform does not have much volume, so recency tests were adjusted:
- For NFT sales, increase the recency time interval to 14 days
- For NFT bids, remove the recency test as it was discussed that removing this completely would be appropriate.