### PR TITLE
Increase recency test interval

### DIFF
--- a/models/silver/liquidity_pool/silver__initialization_pools_orca.yml
+++ b/models/silver/liquidity_pool/silver__initialization_pools_orca.yml
@@ -12,7 +12,7 @@ models:
         tests:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 14
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/silver/liquidity_pool/silver__initialization_pools_raydium.yml
+++ b/models/silver/liquidity_pool/silver__initialization_pools_raydium.yml
@@ -12,7 +12,7 @@ models:
         tests:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 7
+              interval: 14
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
Increase the recency test interval to 14 days for the creation of new pools in Orca + Raydium.