### PR TITLE
remove temp null val for new columns

### DIFF
--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -92,8 +92,8 @@ prev_null_block_timestamp_txs AS (
         t.inner_instructions,
         t.log_messages,
         t.address_table_lookups,
-        units_consumed,
-        units_limit,
+        t.units_consumed,
+        t.units_limit,
         t.version,
         t._partition_id,
         GREATEST(

--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -92,8 +92,8 @@ prev_null_block_timestamp_txs AS (
         t.inner_instructions,
         t.log_messages,
         t.address_table_lookups,
-        null as units_consumed,
-        null as units_limit,
+        units_consumed,
+        units_limit,
         t.version,
         t._partition_id,
         GREATEST(


### PR DESCRIPTION
Remove temporary null values for an inner CTE. No longer necessary after new columns have been added.