### PR TITLE
adjust unique test

### DIFF
--- a/models/silver/nfts/silver__nft_sales_tensorswap.yml
+++ b/models/silver/nfts/silver__nft_sales_tensorswap.yml
@@ -7,6 +7,7 @@ models:
             - TX_ID
             - MINT
             - PURCHASER
+            - SELLER
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"


### PR DESCRIPTION
Per Tensorswap, there can be situations where the owner = seller, where  a user sells into their own pool. This adjusts the unique_combination test to not alert when this occurs in a transactions.