### PR TITLE
stop opensea incremental

### DIFF
--- a/models/silver/nfts/silver__nft_sales_opensea.sql
+++ b/models/silver/nfts/silver__nft_sales_opensea.sql
@@ -3,6 +3,7 @@
     unique_key = "CONCAT_WS('-', tx_id, mint)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE'],
+    enabled = false,
 ) }}
 
 WITH sales_inner_instructions AS (

--- a/models/silver/nfts/silver__nft_sales_opensea.yml
+++ b/models/silver/nfts/silver__nft_sales_opensea.yml
@@ -11,9 +11,6 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
Halting the incremental for Opensea since it recently stopped support for NFTs on Solana.