### PR TITLE
reduce max block range filtered per run

### DIFF
--- a/models/streamline/parser/history/streamline__all_undecoded_instructions_history.sql
+++ b/models/streamline/parser/history/streamline__all_undecoded_instructions_history.sql
@@ -17,4 +17,4 @@ select
     tx_id,
     h.block_id
 from {{ ref('streamline__all_undecoded_instructions_history_queue') }} h
-where h.block_id between (select max_block_id-8000000 from m) and (select max_block_id from m)
+where h.block_id between (select max_block_id-200000 from m) and (select max_block_id from m)


### PR DESCRIPTION
- Limit the max range of blocks streamline is given work for on any given run
  - This is done to limit impact on downstream incremental loads. If the distribution of blocks in a given instance is wide, it will force a large scan of the bronze data and cause performance issues on incremental. By limiting the block range here, we are able to force it to only load a max of a few partitions at a time since we are partitioning every 100,000 blocks
  - Tested [here](https://app.snowflake.com/zsniary/exa10207/#/compute/history/queries/01af4b6d-0603-cac7-3d4f-830165e35943/detail?autoRefreshInSeconds=0) w/ 5M records loaded by the historical model