### PR TITLE
change data type by using sysdate

### DIFF
--- a/models/silver/_observability/silver_observability__transactions_completeness.sql
+++ b/models/silver/_observability/silver_observability__transactions_completeness.sql
@@ -154,7 +154,7 @@ SELECT
     blocks_tested,
     blocks_impacted_count,
     blocks_impacted_array,
-    CURRENT_TIMESTAMP() AS test_timestamp
+    sysdate() AS test_timestamp
 FROM
     summary_stats
     JOIN impacted_blocks


### PR DESCRIPTION
- Will also need to run a one-time script to hot-swap the tables because of changing the column type.

`use role DBT_CLOUD_SOLANA;

create or replace TRANSIENT TABLE solana.silver_observability.TRANSACTIONS_COMPLETENESS_2 (
	TEST_NAME VARCHAR(12) COMMENT 'Name for the test',
	MIN_BLOCK NUMBER(38,0) COMMENT 'The lowest block id in the test',
	MAX_BLOCK NUMBER(38,0) COMMENT 'The highest block id in the test',
	MIN_BLOCK_TIMESTAMP TIMESTAMP_NTZ(9) COMMENT 'The lowest block timestamp in the test',
	MAX_BLOCK_TIMESTAMP TIMESTAMP_NTZ(9) COMMENT 'The highest block timestamp in the test',
	BLOCKS_TESTED NUMBER(18,0) COMMENT 'Count of blocks in the test',
	BLOCKS_IMPACTED_COUNT NUMBER(18,0) COMMENT 'Count of block gaps in the test',
	BLOCKS_IMPACTED_ARRAY ARRAY COMMENT 'Array of affected blocks',
	TEST_TIMESTAMP TIMESTAMP_NTZ(9) COMMENT 'When the test was run'
)COMMENT='Records of all blocks with missing transactions with a timestamp the test was run'
;

insert into solana.silver_observability.TRANSACTIONS_COMPLETENESS_2
select *
from solana.silver_observability.TRANSACTIONS_COMPLETENESS;

ALTER TABLE solana.silver_observability.TRANSACTIONS_COMPLETENESS SWAP WITH solana.silver_observability.TRANSACTIONS_COMPLETENESS_2;

drop table solana.silver_observability.TRANSACTIONS_COMPLETENESS_2;`