### PR TITLE
break up the model to only run 50 requests per invocation

### DIFF
--- a/.github/workflows/dbt_run_helius_metadata.yml
+++ b/.github/workflows/dbt_run_helius_metadata.yml
@@ -41,7 +41,7 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s models/silver/metadata/helius/silver__helius_nft_requests.sql
+          dbt run -s models/silver/metadata/helius/silver__helius_nft_requests.sql models/bronze/bronze_api/bronze_api__helius_nft_metadata.sql
           dbt run -s models/bronze/bronze_api/bronze_api__helius_nft_metadata.sql
           
           

--- a/models/bronze/bronze_api/bronze_api__helius_nft_metadata.sql
+++ b/models/bronze/bronze_api/bronze_api__helius_nft_metadata.sql
@@ -62,7 +62,7 @@ final_requests AS (
     FROM
         pre_requests
 ),
-response AS ({% for item in range(0, 100) %}
+response AS ({% for item in range(1, 51) %}
     (
     SELECT
         livequery_dev.live.udf_api('POST', 'https://rpc.helius.xyz/?api-key=' || (


### PR DESCRIPTION
**Problem**
For whatever reason, somewhere between 50 and 100 calls to the livequery external func causes the query to hang on the Snowflake side. I tested this by breaking the batch of 100 into 2 batches of 50. When I did this, both batches (1-50, 51-100) finished in ~1.5mins. When I combined them into 1 statement (1-100), the query hangs (i.e. It never even sends the request to livequery API). I confirmed this behavior by looking at the livequery logs, as I see 2 sets of 50 logs messages that call the API but when I run the full 100, there are 0 logs in Cloudwatch.

**Fixes**

- Change bronze api model to only run 50 requests
- Change workflow job to run the bronze api model twice so we still get 100 responses per workflow invocation
- Modify the for loop range() such that it will output numbers 1 through 50