### PR TITLE
update frequency and add test

### DIFF
--- a/.github/workflows/dbt_run_helius_metadata.yml
+++ b/.github/workflows/dbt_run_helius_metadata.yml
@@ -4,8 +4,8 @@ run-name: dbt_run_helius_metadata
 on:
   workflow_dispatch:
   schedule:
-    # Runs "at minute 0 past every 12th hour" (see https://crontab.guru)
-    - cron: '0 */12 * * *'
+    # Runs "at minute 0 past hour 3 and 15" (see https://crontab.guru)
+    - cron: '0 3,15 * * *'
     
 env:
   DBT_PROFILES_DIR: "${{ secrets.DBT_PROFILES_DIR }}"

--- a/.github/workflows/dbt_run_helius_metadata.yml
+++ b/.github/workflows/dbt_run_helius_metadata.yml
@@ -4,8 +4,8 @@ run-name: dbt_run_helius_metadata
 on:
   workflow_dispatch:
   schedule:
-    # Runs "every 7th minute" (see https://crontab.guru)
-    - cron: '*/7 * * * *'
+    # Runs "at minute 0 past every 12th hour" (see https://crontab.guru)
+    - cron: '0 */12 * * *'
     
 env:
   DBT_PROFILES_DIR: "${{ secrets.DBT_PROFILES_DIR }}"
@@ -42,6 +42,5 @@ jobs:
       - name: Run DBT Jobs
         run: |
           dbt run -s models/silver/metadata/helius/silver__helius_nft_requests.sql models/bronze/bronze_api/bronze_api__helius_nft_metadata.sql
-          dbt run -s models/bronze/bronze_api/bronze_api__helius_nft_metadata.sql
           
           

--- a/models/bronze/bronze_api/bronze_api__helius_nft_metadata.yml
+++ b/models/bronze/bronze_api/bronze_api__helius_nft_metadata.yml
@@ -7,6 +7,10 @@ models:
         description: "Raw response data"
       - name: MAX_MINT_EVENT_INSERTED_TIMESTAMP
         description: "The latest inserted timestamp for the mints passed to a call"
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 


### PR DESCRIPTION
- Helius backfill has caught up so adjusting the run interval
- Running it twice a day, based on the assumption this table doesn't have to be updated too frequently. 
- The nft_mints table averages about 15k mints every 1/2 day, and the current job should get about 20k mints per run, so there's a decent buffer. If it does get backed up the test on the bronze_api__helius_nft_metadata should alert