### PR TITLE
disable old bronze

### DIFF
--- a/models/bronze/bronze__blocks.sql
+++ b/models/bronze/bronze__blocks.sql
@@ -1,5 +1,6 @@
 {{ config (
-    materialized = 'view'
+    materialized = 'view',
+    enabled = false,
 ) }}
 
 SELECT 

--- a/models/bronze/bronze__transactions.sql
+++ b/models/bronze/bronze__transactions.sql
@@ -1,5 +1,6 @@
 {{ config (
-    materialized = 'view'
+    materialized = 'view',
+    enabled = false,
 ) }}
 
 SELECT


### PR DESCRIPTION
disable `bronze.blocks` and `bronze.transactions` since they have been replaced with `blocks2` and `transactions2` a while ago