### PR TITLE
An 4000/tx count checks

### DIFF
--- a/models/silver/_observability/silver_observability__blocks_tx_count.sql
+++ b/models/silver/_observability/silver_observability__blocks_tx_count.sql
@@ -1,0 +1,44 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'block_id',
+    full_refresh = false
+) }}
+
+WITH base as (
+    SELECT 
+        block_id,
+        count(*) as transaction_count,
+        max(_inserted_timestamp) as _inserted_timestamp
+    FROM 
+        {{ ref('silver__transactions') }}
+    {% if is_incremental() %}
+    WHERE
+        _inserted_timestamp > (select max(_inserted_timestamp) from {{this}})
+    {% else %}
+    WHERE 
+        block_id >= 226000000
+    {% endif %}
+    GROUP BY 1
+    UNION ALL 
+    SELECT 
+        block_id,
+        count(*),
+        max(_inserted_timestamp) as _inserted_timestamp
+    FROM 
+        {{ ref('silver__votes') }}
+    {% if is_incremental() %}
+    WHERE
+        _inserted_timestamp > (select max(_inserted_timestamp) from {{this}})
+    {% else %}
+    WHERE 
+        block_id >= 226000000
+    {% endif %}
+    GROUP BY 1
+)
+SELECT 
+    block_id,
+    sum(transaction_count) as transaction_count,
+    max(_inserted_timestamp) as _inserted_timestamp
+FROM 
+    base 
+GROUP BY 1

--- a/models/silver/_observability/silver_observability__blocks_tx_count.yml
+++ b/models/silver/_observability/silver_observability__blocks_tx_count.yml
@@ -1,0 +1,27 @@
+version: 2
+models:
+  - name: silver_observability__blocks_tx_count
+    description: Records of all block transaction counts. This is an intermediate table used for transaction completeness testing
+    columns:
+      - name: BLOCK_ID
+        description: The lowest block id in the test
+        tests:
+          - not_null
+          - unique
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: TRANSACTION_COUNT
+        description: The lowest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: _INSERTED_TIMESTAMP
+        description: The lowest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ


### PR DESCRIPTION
- Make a model to track current tx counts by block from our silver data
- Modify transaction completeness observability
  - Compare expected (solscan) tx counts vs. actual (silver) tx counts when it is available for a given block
  - If expected count is not available OR block < 226000000, use existing logic for checking transaction completeness