### PR TITLE
do not call udf if no block ids

### DIFF
--- a/models/bronze/bronze_api/bronze_api__solscan_blocks.sql
+++ b/models/bronze/bronze_api/bronze_api__solscan_blocks.sql
@@ -49,3 +49,4 @@ select
     sysdate() as _inserted_timestamp,
     concat_ws('-',_inserted_timestamp,1) as _id
 from make_requests mr
+where array_size(block_ids) > 0;


### PR DESCRIPTION
- Do not make external function call when there are no `block_ids` returned from the base CTE