### PR TITLE
exclude instructions that dont have enough accounts

### DIFF
--- a/models/silver/nfts/silver__nft_compressed_mints_onchain.sql
+++ b/models/silver/nfts/silver__nft_compressed_mints_onchain.sql
@@ -32,7 +32,8 @@ WITH bgum_mints AS (
       'Program log: Instruction: MintToCollectionV1' :: variant,
       log_messages
     )
-
+    AND collection_mint IS NOT NULL
+    
 {% if is_incremental() %}
 AND e._inserted_timestamp >= (
   SELECT


### PR DESCRIPTION
- Fix issue where non-mint bubblegum event was being included in the model
  - This is due to more than one bubblegum event being in a single transaction and one of them is a mint and one is not
  - Check the accounts size to determine whether to include
  - tx_id of interest `3SPTg1N6qKqHUtNEJpVYHgcSKoc1doJF8Y6W8A1dtJPLkrnAYG2HkUJqUcybhJvc39FsfRTFvB59pnXJb7FLLbDc`