### PR TITLE
rewards incremental and update test

### DIFF
--- a/models/silver/rewards/silver__rewards_fee.sql
+++ b/models/silver/rewards/silver__rewards_fee.sql
@@ -4,7 +4,7 @@
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','floor(block_id,-6)','_inserted_timestamp::DATE'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(vote_pubkey, epoch_earned);",
-    tags = ['rewards']
+    tags = ['rewards', 'scheduled_non_core']
 ) }}
 
 WITH base AS (

--- a/models/silver/rewards/silver__rewards_fee.yml
+++ b/models/silver/rewards/silver__rewards_fee.yml
@@ -12,7 +12,8 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null:
+              where: _inserted_timestamp::date < current_date
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:

--- a/models/silver/rewards/silver__rewards_rent.yml
+++ b/models/silver/rewards/silver__rewards_rent.yml
@@ -12,7 +12,8 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null:
+              where: _inserted_timestamp::date < current_date
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:

--- a/models/silver/rewards/silver__rewards_staking.sql
+++ b/models/silver/rewards/silver__rewards_staking.sql
@@ -4,7 +4,7 @@
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','floor(block_id,-6)','_inserted_timestamp::DATE'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(stake_pubkey, epoch_earned);",
-    tags = ['rewards']
+    tags = ['rewards', 'scheduled_non_core']
 ) }}
 
 WITH base AS (

--- a/models/silver/rewards/silver__rewards_staking.yml
+++ b/models/silver/rewards/silver__rewards_staking.yml
@@ -12,7 +12,8 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null:
+              where: _inserted_timestamp::date < current_date
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:

--- a/models/silver/rewards/silver__rewards_voting.sql
+++ b/models/silver/rewards/silver__rewards_voting.sql
@@ -4,7 +4,7 @@
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','floor(block_id,-6)','_inserted_timestamp::DATE'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(vote_pubkey, epoch_earned);",
-    tags = ['rewards']
+    tags = ['rewards', 'scheduled_non_core']
 ) }}
 
 WITH base AS (

--- a/models/silver/rewards/silver__rewards_voting.yml
+++ b/models/silver/rewards/silver__rewards_voting.yml
@@ -12,7 +12,8 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null:
+              where: _inserted_timestamp::date < current_date
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:


### PR DESCRIPTION
- add non_core tag to rewards to initiate incremental runs. Did not include `rewards_rent` since it was recently removed as a part of block rewards in Solana
- add filter to null block_timestamp test