### PR TITLE
add buffered lookback

### DIFF
--- a/models/silver/swaps/silver__swaps_intermediate_jupiterv6.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_jupiterv6.sql
@@ -19,7 +19,7 @@ WITH base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        MAX(_inserted_timestamp) - INTERVAL '1 hour'
     FROM
         {{ this }}
 )
@@ -63,7 +63,7 @@ transfers AS (
 AND
     A._inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp)
+            MAX(_inserted_timestamp)  - INTERVAL '1 day'
         FROM
             {{ this }}
     )


### PR DESCRIPTION
- Add buffer lookback on `max(_inserted_timestamp)` due to time difference between when records are inserted into `transfers` and when events are decoded in `decoded_instructions` 
- 1 day for `transfers` and 1 hour for `decoded_instructions`