### PR TITLE
An 4313/clean up deprecation

### DIFF
--- a/.github/workflows/dbt_run_daily.yml
+++ b/.github/workflows/dbt_run_daily.yml
@@ -49,4 +49,5 @@ jobs:
           dbt run -s models/bronze/bronze__validators_app_api.sql models/bronze/bronze__vote_accounts.sql models/bronze/bronze__stake_program_accounts.sql models/bronze/bronze__vote_accounts_extended_stats.sql
           dbt run -s models/silver/validator/silver__snapshot_stake_accounts.sql models/silver/validator/silver__snapshot_validators_app_data.sql models/silver/validator/silver__snapshot_vote_accounts.sql models/silver/validator/silver__snapshot_vote_accounts_extended_stats.sql
           dbt run -s tag:nft_api
+          dbt run -s tag:daily
 

--- a/models/gold/defi/defi__fact_stake_pool_actions.sql
+++ b/models/gold/defi/defi__fact_stake_pool_actions.sql
@@ -4,7 +4,7 @@
     tags = ['scheduled_non_core']
 ) }}
 
-{% for model_suffix in ["socean","lido","eversol"] %}
+{% for model_suffix in ["socean","lido"] %}
 
     SELECT
         '{{ model_suffix }}' AS stake_pool_name,
@@ -41,6 +41,28 @@
         UNION ALL
         {% endif %}
     {% endfor %}
+UNION ALL
+SELECT
+    'eversol' as stake_pool_name,
+    tx_id,
+    block_id,
+    block_timestamp,
+    INDEX,
+    succeeded,
+    action,
+    address,
+    stake_pool,
+    amount,
+    'SOL' AS token,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id', 'index']
+    ) }} AS fact_stake_pool_actions_id,
+    '2000-01-01' as inserted_timestamp,
+    '2000-01-01' AS modified_timestamp
+FROM
+    {{ ref(
+        'silver__stake_pool_actions_eversol_view'
+    ) }}
 UNION ALL
 SELECT
     CASE

--- a/models/gold/gov/gov__fact_proposal_votes.sql
+++ b/models/gold/gov/gov__fact_proposal_votes.sql
@@ -19,22 +19,13 @@ SELECT
     NULL AS vote_choice,
     NULL AS vote_rank,
     NULL AS vote_weight,
-    COALESCE (
-    proposal_votes_marinade_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['tx_id', 'voter_nft', 'proposal']
-        ) }}
-    ) AS fact_proposal_votes_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id', 'voter_nft', 'proposal']
+    ) }} AS fact_proposal_votes_id,
+    '2000-01-01' as inserted_timestamp,
+    '2000-01-01' AS modified_timestamp
 FROM
-    {{ ref('silver__proposal_votes_marinade') }}
+    {{ ref('silver__proposal_votes_marinade_view') }}
 UNION ALL
 SELECT
     'realms' AS governance_platform,

--- a/models/gold/nft/nft__fact_nft_sales.sql
+++ b/models/gold/nft/nft__fact_nft_sales.sql
@@ -93,22 +93,13 @@ SELECT
     seller,
     mint,
     sales_amount,
-    COALESCE (
-        nft_sales_smb_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['tx_id']
-        ) }}
-    ) AS fact_nft_sales_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id']
+    ) }} AS fact_nft_sales_id,
+    '2000-01-01' as inserted_timestamp,
+    '2000-01-01' AS modified_timestamp
 FROM
-    {{ ref('silver__nft_sales_smb') }}
+    {{ ref('silver__nft_sales_smb_view') }}
 UNION
 SELECT
     'solport',

--- a/models/silver/governance/silver__gov_actions_marinade.sql
+++ b/models/silver/governance/silver__gov_actions_marinade.sql
@@ -3,7 +3,7 @@
     unique_key = "tx_id",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    tags = ['daily']
 ) }}
 
 WITH base AS (

--- a/models/silver/governance/silver__gov_actions_marinade_tmp.sql
+++ b/models/silver/governance/silver__gov_actions_marinade_tmp.sql
@@ -3,7 +3,7 @@
     unique_key = "tx_id",
     incremental_strategy = 'delete+insert',
     cluster_by = ['_inserted_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    tags = ['daily']
 ) }}
 
 WITH token_balances AS (

--- a/models/silver/governance/silver__gov_actions_saber.sql
+++ b/models/silver/governance/silver__gov_actions_saber.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "tx_id",
     incremental_strategy = 'delete+insert',
-    tags = ['scheduled_non_core']
+    tags = ['daily']
 ) }}
 
 WITH post_token_balances AS (

--- a/models/silver/governance/silver__proposal_creation_realms.sql
+++ b/models/silver/governance/silver__proposal_creation_realms.sql
@@ -3,7 +3,7 @@
   unique_key = "tx_id",
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp::DATE'],
-  tags = ['scheduled_non_core']
+  tags = ['daily']
 ) }}
 
 WITH vote_programs AS (

--- a/models/silver/governance/silver__proposal_votes_marinade.sql
+++ b/models/silver/governance/silver__proposal_votes_marinade.sql
@@ -3,7 +3,8 @@
     unique_key = "CONCAT_WS('-', tx_id, voter_nft, proposal)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH marinade_vote_txs AS (

--- a/models/silver/governance/silver__proposal_votes_marinade_view.sql
+++ b/models/silver/governance/silver__proposal_votes_marinade_view.sql
@@ -1,0 +1,23 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT 
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    voter,
+    voter_nft,
+    voter_account,
+    proposal,
+    _inserted_timestamp,
+    proposal_votes_marinade_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
+FROM
+  {{ source(
+    'solana_silver',
+    'proposal_votes_marinade'
+  ) }}

--- a/models/silver/governance/silver__proposal_votes_realms.sql
+++ b/models/silver/governance/silver__proposal_votes_realms.sql
@@ -3,7 +3,7 @@
   unique_key = "CONCAT_WS('-', tx_id, index)",
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp::DATE'],
-  tags = ['scheduled_non_core']
+  tags = ['daily']
 ) }}
 
 WITH vote_programs AS (

--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_orca.yml
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_orca.yml
@@ -8,6 +8,7 @@ models:
             - TX_ID
             - INDEX
             - INNER_INDEX
+          where: block_timestamp::date > current_date - 30
       - compare_model_subset:
           name: silver__liquidity_pool_actions_orca_business_logic_test
           compare_model: ref('testing__liquidity_pool_actions_orca')

--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_raydium.yml
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_raydium.yml
@@ -8,6 +8,7 @@ models:
             - TX_ID
             - INDEX
             - INNER_INDEX
+          where: block_timestamp::date > current_date - 30
       - compare_model_subset:
           name: silver__liquidity_pool_actions_raydium_business_logic_test
           compare_model: ref('testing__liquidity_pool_actions_raydium')

--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_saber.yml
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_saber.yml
@@ -7,6 +7,7 @@ models:
             - BLOCK_ID
             - TX_ID
             - ACTION_INDEX
+          where: block_timestamp::date > current_date - 30
       - compare_model_subset:
           name: silver__liquidity_pool_actions_saber_business_logic_test
           compare_model: ref('testing__liquidity_pool_actions_saber')

--- a/models/silver/nfts/silver__nft_metadata.sql
+++ b/models/silver/nfts/silver__nft_metadata.sql
@@ -2,7 +2,8 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', contract_address, token_id)",
     incremental_strategy = 'delete+insert',
-    tags = ['scheduled_non_core']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH base AS (

--- a/models/silver/nfts/silver__nft_mint_price.sql
+++ b/models/silver/nfts/silver__nft_mint_price.sql
@@ -28,7 +28,7 @@ with base as (
         _inserted_timestamp,
         2 as ranking
     from 
-        {{ ref('silver__nft_mint_price_other') }}
+        {{ ref('silver__nft_mint_price_other_view') }}
     where 
         mint_price is not null
     union 

--- a/models/silver/nfts/silver__nft_mint_price_other.sql
+++ b/models/silver/nfts/silver__nft_mint_price_other.sql
@@ -3,7 +3,8 @@
     unique_key = "CONCAT_WS('-', mint, payer, mint_currency)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH base_events AS (

--- a/models/silver/nfts/silver__nft_mint_price_other_view.sql
+++ b/models/silver/nfts/silver__nft_mint_price_other_view.sql
@@ -1,0 +1,19 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT 
+    mint,
+    payer,
+    mint_currency,
+    decimal,
+    program_id,
+    mint_price,
+    tx_ids,
+    block_timestamp,
+    _inserted_timestamp
+FROM
+  {{ source(
+    'solana_silver',
+    'nft_mint_price_other'
+  ) }}

--- a/models/silver/nfts/silver__nft_sales_smb.sql
+++ b/models/silver/nfts/silver__nft_sales_smb.sql
@@ -3,7 +3,8 @@
     unique_key = "tx_id",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH base_table AS (

--- a/models/silver/nfts/silver__nft_sales_smb_view.sql
+++ b/models/silver/nfts/silver__nft_sales_smb_view.sql
@@ -1,0 +1,24 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT 
+     block_timestamp, 
+     block_id, 
+     tx_id, 
+     succeeded, 
+     program_id, 
+     mint, 
+     purchaser, 
+     seller, 
+     sales_amount, 
+     _inserted_timestamp,
+     nft_sales_smb_id,
+     inserted_timestamp,
+     modified_timestamp,
+     _invocation_id
+FROM
+  {{ source(
+    'solana_silver',
+    'nft_sales_smb'
+  ) }}

--- a/models/silver/silver__mint_actions.yml
+++ b/models/silver/silver__mint_actions.yml
@@ -10,6 +10,7 @@ models:
             - INNER_INDEX
             - EVENT_TYPE
             - MINT
+          where: block_timestamp::date > current_date - 30
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"

--- a/models/silver/silver__transactions.yml
+++ b/models/silver/silver__transactions.yml
@@ -29,6 +29,7 @@ models:
         tests: 
           - null_threshold:
               threshold_percent: 0.99 # some older transactions have valid null fees
+              where: block_timestamp::date > current_date - 30
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 

--- a/models/silver/silver__votes.yml
+++ b/models/silver/silver__votes.yml
@@ -31,6 +31,7 @@ models:
         tests: 
           - null_threshold:
               threshold_percent: 0.99 # some older transactions have valid null fees
+              where: block_timestamp::date > current_date - 30
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
@@ -45,6 +46,7 @@ models:
         tests: 
           - null_threshold:
               threshold_percent: 0.9999 # some vote program transactions don't have vote accounts or unknown which account is vote account
+              where: block_timestamp::date > current_date - 30
       - name: VOTE_AUTHORITY
         description: Authority for the voting delegator
         tests: 

--- a/models/silver/staking/silver__stake_pool_actions_eversol.sql
+++ b/models/silver/staking/silver__stake_pool_actions_eversol.sql
@@ -4,7 +4,8 @@
     incremental_strategy = 'merge',
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::date'],
     merge_exclude_columns = ["inserted_timestamp"],
-    tags = ['scheduled_non_core']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH base_stake_pool_events AS (

--- a/models/silver/staking/silver__stake_pool_actions_eversol_view.sql
+++ b/models/silver/staking/silver__stake_pool_actions_eversol_view.sql
@@ -1,0 +1,28 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT 
+    tx_id,
+    block_id,
+    block_timestamp,
+    index,
+    succeeded,
+    action,
+    stake_pool,
+    stake_pool_withdraw_authority,
+    stake_pool_deposit_authority,
+    address,  -- use signers instead of instruction account because of "passthrough" wallets
+    reserve_stake_address,
+    amount,
+    _inserted_timestamp,
+    _unique_key,
+    stake_pool_actions_eversol_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
+FROM
+  {{ source(
+    'solana_silver',
+    'stake_pool_actions_eversol'
+  ) }}

--- a/models/silver/swaps/silver__swaps_intermediate_jupiterv4.yml
+++ b/models/silver/swaps/silver__swaps_intermediate_jupiterv4.yml
@@ -7,6 +7,7 @@ models:
             - BLOCK_ID
             - TX_ID
             - SWAP_INDEX
+          where: block_timestamp::date > current_date - 30
       - compare_model_subset:
           name: silver__swaps_intermediate_jupiterv4_business_logic_test
           compare_model: ref('testing__swaps_intermediate_jupiterv4')

--- a/models/silver/swaps/silver__swaps_intermediate_jupiterv6.yml
+++ b/models/silver/swaps/silver__swaps_intermediate_jupiterv6.yml
@@ -7,6 +7,7 @@ models:
             - TX_ID
             - SWAP_INDEX
             - PROGRAM_ID
+          where: block_timestamp::date > current_date - 30
       - compare_model_subset:
           name: silver__swaps_intermediate_jupiterv6_business_logic_test
           compare_model: ref('testing__swaps_intermediate_jupiterv6')

--- a/models/silver/swaps/silver__swaps_intermediate_orca.yml
+++ b/models/silver/swaps/silver__swaps_intermediate_orca.yml
@@ -7,6 +7,7 @@ models:
             - BLOCK_ID
             - TX_ID
             - SWAP_INDEX
+          where: block_timestamp::date > current_date - 30
       - compare_model_subset:
           name: silver__swaps_intermediate_orca_business_logic_test
           compare_model: ref('testing__swaps_intermediate_orca')

--- a/models/silver/swaps/silver__swaps_intermediate_raydium.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_raydium.sql
@@ -17,7 +17,7 @@ WITH base_events AS(
             --raydium program_ids
             '675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8',
             '5quBtoiQqxF9Jv6KYKctB59NT3gtJD2Y65kdnB1Uev3h',
-            '93BgeoLHo5AdNbpqy9bD12dtfxtA5M2fh3rj72bE35Y3',
+            -- '93BgeoLHo5AdNbpqy9bD12dtfxtA5M2fh3rj72bE35Y3', -- latest event 2023-03-25
             'routeUGWgWzqBWFcrCfv8tritsqukccJPu3q5GPP3xS',
             'CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK',
             --program ids for acct mapping
@@ -102,7 +102,7 @@ dex_txs AS (
                     )
                 )
                 OR program_id IN (
-                    '93BgeoLHo5AdNbpqy9bD12dtfxtA5M2fh3rj72bE35Y3',
+                    -- '93BgeoLHo5AdNbpqy9bD12dtfxtA5M2fh3rj72bE35Y3', -- latest event 2023-03-25
                     'routeUGWgWzqBWFcrCfv8tritsqukccJPu3q5GPP3xS'
                 )
                 OR (
@@ -215,7 +215,7 @@ raydium_account_mapping AS(
         d.program_id IN (
             '675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8',
             '5quBtoiQqxF9Jv6KYKctB59NT3gtJD2Y65kdnB1Uev3h',
-            '93BgeoLHo5AdNbpqy9bD12dtfxtA5M2fh3rj72bE35Y3',
+            -- '93BgeoLHo5AdNbpqy9bD12dtfxtA5M2fh3rj72bE35Y3', --latest event 2023-03-25
             'routeUGWgWzqBWFcrCfv8tritsqukccJPu3q5GPP3xS',
             'CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK'
         )

--- a/models/silver/swaps/silver__swaps_intermediate_raydium.yml
+++ b/models/silver/swaps/silver__swaps_intermediate_raydium.yml
@@ -7,6 +7,7 @@ models:
             - BLOCK_ID
             - TX_ID
             - SWAP_INDEX
+          where: block_timestamp::date > current_date - 30
       - compare_model_subset:
           name: silver__swaps_intermediate_raydium_business_logic_test
           compare_model: ref('testing__swaps_intermediate_raydium')

--- a/models/silver/tokens/silver__token_burn_actions.yml
+++ b/models/silver/tokens/silver__token_burn_actions.yml
@@ -8,6 +8,7 @@ models:
             - INDEX
             - INNER_INDEX
             - MINT
+          where: block_timestamp::date > current_date - 30
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"

--- a/models/silver/tokens/silver__token_mint_actions.yml
+++ b/models/silver/tokens/silver__token_mint_actions.yml
@@ -8,6 +8,7 @@ models:
             - INDEX
             - INNER_INDEX
             - MINT
+          where: block_timestamp::date > current_date - 30
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -77,6 +77,11 @@ sources:
       - name: swaps_intermediate_jupiterv5_1
       - name: swaps_intermediate_jupiterv5_2
       - name: rewards_rent
+      - name: stake_pool_actions_eversol
+      - name: nft_sales_smb
+      - name: nft_mint_price_other
+      - name: nft_metadata
+      - name: proposal_votes_marinade
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
- disable and create views for tables that no longer have new events
- disable `silver.nft_metadata` as it has been superceded by helius process
- adjust models to run daily (mostly gov tables that seem to only have 1 new event a day)
- decrease intervals for long-running tests