### PR TITLE
use inserted_timestamp for recency test

### DIFF
--- a/models/silver/metadata/silver__nft_collection.yml
+++ b/models/silver/metadata/silver__nft_collection.yml
@@ -15,6 +15,10 @@ models:
         description: "{{ doc('_inserted_timestamp') }}"
         tests:
           - not_null
+      - name: inserted_timestamp
+        description: "{{ doc('inserted_timestamp') }}"
+        tests:
+          - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 2


### PR DESCRIPTION
The recency test using _inserted_timestamp gives false alerts, since the data is being correctly ingested albeit backed up due to large NFT volume. This change will now confirm that the process is working correctly -- the to-do is to look into ways to adjust the logic to account for larger rises in volume.