### PR TITLE
2 hour look back

### DIFF
--- a/models/silver/parser/silver__decoded_instructions.sql
+++ b/models/silver/parser/silver__decoded_instructions.sql
@@ -47,9 +47,7 @@ ON A.block_id = b.block_id
 WHERE
     A._inserted_timestamp >= (
         SELECT
-            MAX(
-                _inserted_timestamp
-            ) _inserted_timestamp
+             dateadd('hour', -2, MAX(_inserted_timestamp)) as _inserted_timestamp
         FROM
             {{ this }}
     )


### PR DESCRIPTION
- Use a 2 hour lookback to prevent missing decoded instructions due to inner join with blocks table
  - In current state, if block for a decoded instruction has not been ingested then the decoded instruction will never get loaded into the table