### PR TITLE
add test to check for missing decoded instructs in silver

### DIFF
--- a/tests/test_silver__decoded_instructions_missing.sql
+++ b/tests/test_silver__decoded_instructions_missing.sql
@@ -1,0 +1,30 @@
+SELECT
+    block_id,
+    tx_id,
+    INDEX,
+    COALESCE(
+        inner_index,
+        -1
+    )
+FROM
+    {% if target.database == 'SOLANA' %}
+        solana.streamline.complete_decoded_instructions_2
+    {% else %}
+        solana_dev.streamline.complete_decoded_instructions_2
+    {% endif %}
+    
+WHERE
+    _inserted_timestamp between current_date - 2 and current_date - 1
+EXCEPT
+SELECT
+    block_id,
+    tx_id,
+    INDEX,
+    COALESCE(
+        inner_index,
+        -1
+    )
+FROM
+    {{ ref('silver__decoded_instructions') }}
+WHERE
+    _inserted_timestamp BETWEEN current_date - 2 and current_date - 1


### PR DESCRIPTION
- Check `silver.decoded_instructions` for records in bronze that did not make it into silver with 1 day lag
  - This was an issue with previous model logic since it was using an inner join w/ `silver.blocks`. There is now a 2 hour look back to check for late arriving data, but missing data would still happen if things fall out of that window