### PR TITLE
An 4390/retry views for failed old decoder txs

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -76,3 +76,8 @@ vars:
   STREAMLINE_RETRY_UNKNOWN: False
   UPDATE_SNOWFLAKE_TAGS: True
   UPDATE_UDFS_AND_SPS: False 
+
+  API_INTEGRATION: '{{ var("config")[target.name]["API_INTEGRATION"] if var("config")[target.name] else var("config")["dev"]["API_INTEGRATION"] }}'
+  EXTERNAL_FUNCTION_URI: '{{ var("config")[target.name]["EXTERNAL_FUNCTION_URI"] if var("config")[target.name] else var("config")["dev"]["EXTERNAL_FUNCTION_URI"] }}'
+  ROLES: |
+      ["INTERNAL_DEV"]

--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -75,6 +75,73 @@
     {% endfor %}
 {% endmacro %}
 
+{% macro decoded_instructions_backfill_missing_and_retries_generate_views(program_id) %}
+    {% set start_block = 0 %}  /* we just pick the lowest possible value so that retry views are always run last (i.e. after main backfill is done) */
+    {% set end_block = 239165744 %} /* legacy decoder not used after this block */
+    {% set query = """create or replace view streamline.decoded_instructions_backfill_""" ~ start_block ~ """_""" ~ end_block ~ """_retry_""" ~ program_id ~ """ AS
+        with missing_decode as (
+            select block_id, tx_id, index, coalesce(inner_index,-1) as inner_index
+            from """ ~ ref('streamline__complete_decoded_instructions_2') ~ """
+            where program_id = '""" ~ program_id ~ """'
+            and _inserted_timestamp::date < '2024-01-04'
+            except
+            select block_id, tx_id, index, coalesce(inner_index,-1)
+            from """ ~ ref('silver__decoded_instructions') ~ """ 
+            where program_id = '""" ~ program_id ~ """'
+        ),
+        prev_failed_decode as (
+            select block_id, tx_id, index, coalesce(inner_index,-1)
+            from """ ~ ref('silver__decoded_instructions') ~ """ 
+            where program_id = '""" ~ program_id ~ """'
+            and decoded_instruction:error::string is not null
+            and _inserted_timestamp::date < '2024-01-04'
+        ),
+        retries as (
+            select *
+            from missing_decode
+            union all 
+            select *
+            from prev_failed_decode
+        ),
+        retry_events as (
+            select
+                e.block_id,
+                e.tx_id,
+                e.index,
+                NULL as inner_index,
+                e.instruction,
+                e.program_id,
+                e.block_timestamp,
+                md5(cast(coalesce(cast(e.block_id as TEXT), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(e.tx_id as TEXT), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(e.index as TEXT), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(inner_index as TEXT), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(e.program_id as TEXT), '_dbt_utils_surrogate_key_null_') as TEXT)) as id
+            from retries r
+            join """ ~ ref('silver__events') ~ """  e on r.block_id = e.block_id 
+                and r.tx_id = e.tx_id 
+                and r.index = e.index 
+            where e.program_id = '""" ~ program_id ~ """'
+            and e.succeeded
+        ),
+        completed_subset as (
+            select 
+                *
+            from 
+                """ ~ ref('streamline__complete_decoded_instructions_2') ~ """
+            where 
+                program_id = '""" ~ program_id ~ """'
+            and 
+                _inserted_timestamp >= '2024-01-04'
+        )
+        select 
+            e.*
+        from retry_events e 
+        left outer join completed_subset c 
+                on c.complete_decoded_instructions_2_id = e.id
+        where 
+            c.complete_decoded_instructions_2_id is null
+        ;""" %}
+
+        {% do run_query(query) %}
+{% endmacro %}
+
 {% macro decoded_instructions_backill_cleanup_views() %}
     {% set results = run_query("""select
             table_schema,


### PR DESCRIPTION
- Macro to generate a view to output retry/missing decoder events from previous decoder to run with new decoder
  - Generates a view by program_id
- Add default config values for livequery to fix issue when running dbt with non-standard profiles (i.e. dev-2xl, prod-2xl, etc)