### PR TITLE
add alias to prevent ambiguous col name

### DIFF
--- a/models/silver/nfts/silver__nft_compressed_mints.sql
+++ b/models/silver/nfts/silver__nft_compressed_mints.sql
@@ -89,7 +89,7 @@ onchain AS (
             -1
         )
     {% if is_incremental() %}
-    WHERE _inserted_timestamp >= (
+    WHERE m._inserted_timestamp >= (
         SELECT
             MAX(_inserted_timestamp)
         FROM


### PR DESCRIPTION
Fixing error from [https://github.com/FlipsideCrypto/solana-models/actions/runs/7536313920/job/20513554807](https://github.com/FlipsideCrypto/solana-models/actions/runs/7536313920/job/20513554807)

I reran the incremental in prod w/ this fix applied and it worked

> 15:02:44  Concurrency: 8 threads (target='prod')
> 15:02:44  
> 15:02:44  1 of 1 START sql incremental model silver.nft_compressed_mints ................. [RUN]
> 15:03:28  1 of 1 OK created sql incremental model silver.nft_compressed_mints ............ [SUCCESS 2966407 in 44.02s]