### PR TITLE
add extra field for partition

### DIFF
--- a/models/silver/prices/silver__token_prices_coin_gecko_hourly.sql
+++ b/models/silver/prices/silver__token_prices_coin_gecko_hourly.sql
@@ -147,7 +147,8 @@ imputed_prices AS (
         LAST_VALUE(
             p.close ignore nulls
         ) over (
-            PARTITION BY d.symbol
+            PARTITION BY d.symbol,
+            d.id
             ORDER BY
                 d.date_hour rows unbounded preceding
         ) AS imputed_close


### PR DESCRIPTION
- bug fix: when tokens have the same `symbol`, the imputed price may be set incorrectly. The field `id` is added to the partition by.
- example of incorrect prices when tokens have same symbol 'btc' :
```
SELECT
*
FROM solana.silver.token_prices_coin_gecko_hourly
WHERE recorded_hour between '2024-01-13' AND '2024-01-15'
AND symbol = 'btc'
ORDER BY recorded_hour
```
