### PR TITLE
include mintv1 in onchain table

### DIFF
--- a/models/silver/nfts/silver__nft_compressed_mints_onchain.sql
+++ b/models/silver/nfts/silver__nft_compressed_mints_onchain.sql
@@ -30,10 +30,18 @@ WITH bgum_mints AS (
   WHERE
     succeeded
     AND program_id = 'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY'
-    AND ARRAY_CONTAINS(
-      'Program log: Instruction: MintToCollectionV1' :: variant,
-      log_messages
-    )
+    AND 
+      (
+        ARRAY_CONTAINS(
+        'Program log: Instruction: MintToCollectionV1' :: variant,
+        log_messages
+        )
+        OR 
+        ARRAY_CONTAINS(
+        'Program log: Instruction: MintV1' :: variant,
+        log_messages
+        )
+      )
     AND collection_mint IS NOT NULL
     
 {% if is_incremental() %}


### PR DESCRIPTION
- Include `MintV1` compressed mints in our onchain table
  - Backfill of the downstream mints table will be done separately as it requires bronze-api calls