### PR TITLE
adjust worker size

### DIFF
--- a/models/streamline/decode_instructions/streamline__decode_instructions_2_pyth_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_2_pyth_realtime.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_instructions_decoder(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'decoded_instructions_2', 'sql_limit', {{var('sql_limit','10000000')}}, 'producer_batch_size', {{var('producer_batch_size','10000000')}}, 'worker_batch_size', {{var('worker_batch_size','500000')}}, 'batch_call_limit', {{var('batch_call_limit','1000')}}, 'call_type', 'backfill'))",
+        func = "{{this.schema}}.udf_bulk_instructions_decoder(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'decoded_instructions_2', 'sql_limit', {{var('sql_limit','10000000')}}, 'producer_batch_size', {{var('producer_batch_size','10000000')}}, 'worker_batch_size', {{var('worker_batch_size','250000')}}, 'batch_call_limit', {{var('batch_call_limit','1000')}}, 'call_type', 'backfill'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_decoder']


### PR DESCRIPTION
- Reduce worker batch size based on execution results I am seeing in CW logs
  - Basically this will result in running 2 lambdas concurrently instead of 1 lambda at current execution intervals