### PR TITLE
An 4384/new compressed nft endpoint

### DIFF
--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -17,6 +17,7 @@
             {{ udf_bulk_get_solscan_blocks() }};
             {{ create_udf_bulk_instructions_decoder() }};
             {{ create_udf_verify_idl() }};
+            {{ create_udf_decode_compressed_mint_change_logs() }};
         {% endif %}
 
         {{ create_udf_ordered_signers(

--- a/macros/streamline/streamline_udfs.sql
+++ b/macros/streamline/streamline_udfs.sql
@@ -18,7 +18,7 @@
     {%- endif %}
 {% endmacro %}
 
-{% macro create_udf_decode_compressed_mint_change_logs %}
+{% macro create_udf_decode_compressed_mint_change_logs() %}
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_decode_compressed_mint_change_logs("JSON" ARRAY) returns VARIANT api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
         'https://l426aqju0g.execute-api.us-east-1.amazonaws.com/prod/udf_decode_compressed_mint_change_logs'

--- a/macros/streamline/streamline_udfs.sql
+++ b/macros/streamline/streamline_udfs.sql
@@ -17,3 +17,12 @@
         'https://7938mznoq8.execute-api.us-east-1.amazonaws.com/dev/verify_idl'
     {%- endif %}
 {% endmacro %}
+
+{% macro create_udf_decode_compressed_mint_change_logs %}
+    CREATE
+    OR REPLACE EXTERNAL FUNCTION streamline.udf_decode_compressed_mint_change_logs("JSON" ARRAY) returns VARIANT api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
+        'https://l426aqju0g.execute-api.us-east-1.amazonaws.com/prod/udf_decode_compressed_mint_change_logs'
+    {% else %}
+        'https://7938mznoq8.execute-api.us-east-1.amazonaws.com/dev/udf_decode_compressed_mint_change_logs'
+    {%- endif %}
+{% endmacro %}

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
@@ -86,7 +86,7 @@ base AS (
 )
 SELECT
     ARRAY_AGG(request) AS batch_request,
-    streamline.udf_bulk_parse_compressed_nft_mints(batch_request) AS responses,
+    streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
     MIN(event_inserted_timestamp) AS start_inserted_timestamp,
     MAX(event_inserted_timestamp) AS end_inserted_timestamp,
     concat_ws(

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
@@ -31,7 +31,7 @@
     {% set query2 = """
         qualify(ROW_NUMBER() over (
         ORDER BY
-            _inserted_timestamp)) <= 10000""" %}
+            _inserted_timestamp)) <= 2000""" %}
     {% do run_query(query ~ incr ~ query2) %}
     {% set min_inserted_timestamp = run_query("""SELECT min(_inserted_timestamp) FROM bronze_api.parse_compressed_nft_mints__intermediate_tmp""").columns[0].values()[0] %}
     {% set max_inserted_timestamp = run_query("""SELECT max(_inserted_timestamp) FROM bronze_api.parse_compressed_nft_mints__intermediate_tmp""").columns[0].values()[0] %}
@@ -66,7 +66,7 @@ base AS (
                 e.tx_id
         ) AS rn,
         FLOOR(
-            rn / 1000
+            rn / 200
         ) AS gn,
         e._inserted_timestamp AS event_inserted_timestamp
     FROM
@@ -83,6 +83,7 @@ base AS (
         AND e.block_timestamp :: DATE = C.block_timestamp :: DATE
         AND ii_program_id = 'noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV'
         AND e._inserted_timestamp between '{{ min_inserted_timestamp }}' and '{{ max_inserted_timestamp }}'
+        AND NOT startswith(DATA, '2GJh')
 )
 SELECT
     ARRAY_AGG(request) AS batch_request,

--- a/models/streamline/decode_instructions/streamline__idls_nft_compression.sql
+++ b/models/streamline/decode_instructions/streamline__idls_nft_compression.sql
@@ -1,0 +1,14 @@
+{{ config (
+    materialized = 'incremental',
+    unique_key = 'program_id',
+    full_refresh = false,
+    tags = ['streamline_decoder'],
+) }}
+
+select 
+    'placeholder'::string as program_id,
+    {'hello':'world'}::variant as idl,
+    'placeholder' as idl_source,
+    'flipside' as discord_username,
+    sha2(idl) as idl_hash,
+    sysdate() as _inserted_timestamp


### PR DESCRIPTION
- Add udf to new api endpoint
- Add placeholder table to handle grabbing IDLs that is not part of the regular decoding workflow
  - This will require some additional ad-hoc setup to get the proper IDL into the table in prod (this is already done in DEV)
- Adjust number of events being parsed in a single call
  - Remove events that we know are not change log events that were previously being passed in