### PR TITLE
workaround for materializing  with udf followed by order by cluster key

### DIFF
--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('silver__nft_compressed_mints_onchain') }}
+-- depends_on: {{ ref('silver__events') }}
 {{ config(
     materialized = 'incremental',
     tags = ['bronze_api'],
@@ -35,67 +36,78 @@
     {% do run_query(query ~ incr ~ query2) %}
     {% set min_inserted_timestamp = run_query("""SELECT min(_inserted_timestamp) FROM bronze_api.parse_compressed_nft_mints__intermediate_tmp""").columns[0].values()[0] %}
     {% set max_inserted_timestamp = run_query("""SELECT max(_inserted_timestamp) FROM bronze_api.parse_compressed_nft_mints__intermediate_tmp""").columns[0].values()[0] %}
+
+    {% set call_api_query %}
+        CREATE OR REPLACE TEMPORARY TABLE bronze_api.parse_compressed_nft_mints__final_tmp AS 
+        WITH collection_subset AS (
+            SELECT
+                distinct tx_id, block_timestamp
+            FROM
+                bronze_api.parse_compressed_nft_mints__intermediate_tmp
+        ),
+        base AS (
+            SELECT
+                e.tx_id,
+                e.index,
+                ii.index AS inner_index,
+                ii.value :data :: STRING AS DATA,
+                OBJECT_CONSTRUCT(
+                    'tx_id',
+                    e.tx_id,
+                    'index',
+                    e.index,
+                    'inner_index',
+                    inner_index,
+                    'instruction_data',
+                    DATA
+                ) AS request,
+                ii.value :programId :: STRING AS ii_program_id,
+                ROW_NUMBER() over (
+                    ORDER BY
+                        e._inserted_timestamp,
+                        e.tx_id
+                ) AS rn,
+                FLOOR(
+                    rn / 200
+                ) AS gn,
+                e._inserted_timestamp AS event_inserted_timestamp
+            FROM
+                collection_subset C
+                JOIN {{ ref('silver__events') }}
+                e
+                ON C.tx_id = e.tx_id
+                JOIN TABLE(FLATTEN(e.inner_instruction :instructions)) ii
+            WHERE
+                e.program_id IN (
+                    'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY',
+                    '1atrmQs3eq1N2FEYWu6tyTXbCjP4uQwExpjtnhXtS8h'
+                )
+                AND e.block_timestamp :: DATE = C.block_timestamp :: DATE
+                AND ii_program_id = 'noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV'
+                AND e._inserted_timestamp between '{{ min_inserted_timestamp }}' and '{{ max_inserted_timestamp }}'
+                AND NOT startswith(DATA, '2GJh')
+        )
+        SELECT
+            ARRAY_AGG(request) AS batch_request,
+            streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
+            MIN(event_inserted_timestamp) AS start_inserted_timestamp,
+            MAX(event_inserted_timestamp) AS end_inserted_timestamp,
+            concat_ws(
+                '-',
+                end_inserted_timestamp,
+                gn
+            ) AS _id
+        FROM
+            base
+        GROUP BY
+            gn
+    {% endset %}
+
+    {% do run_query(call_api_query) %}
 {% endif %}
 
-WITH collection_subset AS (
-    SELECT
-        *
-    FROM
-        bronze_api.parse_compressed_nft_mints__intermediate_tmp
-),
-base AS (
-    SELECT
-        e.tx_id,
-        e.index,
-        ii.index AS inner_index,
-        ii.value :data :: STRING AS DATA,
-        OBJECT_CONSTRUCT(
-            'tx_id',
-            e.tx_id,
-            'index',
-            e.index,
-            'inner_index',
-            inner_index,
-            'instruction_data',
-            DATA
-        ) AS request,
-        ii.value :programId :: STRING AS ii_program_id,
-        ROW_NUMBER() over (
-            ORDER BY
-                e._inserted_timestamp,
-                e.tx_id
-        ) AS rn,
-        FLOOR(
-            rn / 200
-        ) AS gn,
-        e._inserted_timestamp AS event_inserted_timestamp
-    FROM
-        collection_subset C
-        JOIN {{ ref('silver__events') }}
-        e
-        ON C.tx_id = e.tx_id
-        JOIN TABLE(FLATTEN(e.inner_instruction :instructions)) ii
-    WHERE
-        e.program_id IN (
-            'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY',
-            '1atrmQs3eq1N2FEYWu6tyTXbCjP4uQwExpjtnhXtS8h'
-        )
-        AND e.block_timestamp :: DATE = C.block_timestamp :: DATE
-        AND ii_program_id = 'noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV'
-        AND e._inserted_timestamp between '{{ min_inserted_timestamp }}' and '{{ max_inserted_timestamp }}'
-        AND NOT startswith(DATA, '2GJh')
-)
 SELECT
-    ARRAY_AGG(request) AS batch_request,
-    streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
-    MIN(event_inserted_timestamp) AS start_inserted_timestamp,
-    MAX(event_inserted_timestamp) AS end_inserted_timestamp,
-    concat_ws(
-        '-',
-        end_inserted_timestamp,
-        gn
-    ) AS _id
-FROM
-    base
-GROUP BY
-    gn
+    *
+FROM 
+    bronze_api.parse_compressed_nft_mints__final_tmp
+


### PR DESCRIPTION
- There is some blackbox issue where the returned UDF results work as expected but when it is followed by order by statement in the create tmp table step for incremental loading it doesnt work. 
- Workaround is to materialize the UDF results in a separate tmp table and then the order by (clustering) operation will work.

```
15:44:44  1 of 1 START sql incremental model bronze_api.parse_compressed_nft_mints ....... [RUN]
15:45:21  1 of 1 OK created sql incremental model bronze_api.parse_compressed_nft_mints .. [SUCCESS 11 in 36.59s]
```