### PR TITLE
revert patch fix, force udf max batch rows, decrease batch size

### DIFF
--- a/macros/streamline/streamline_udfs.sql
+++ b/macros/streamline/streamline_udfs.sql
@@ -20,7 +20,11 @@
 
 {% macro create_udf_decode_compressed_mint_change_logs() %}
     CREATE
-    OR REPLACE EXTERNAL FUNCTION streamline.udf_decode_compressed_mint_change_logs("JSON" ARRAY) returns VARIANT api_integration = aws_solana_api_dev AS {% if target.database == 'SOLANA' -%}
+    OR REPLACE EXTERNAL FUNCTION streamline.udf_decode_compressed_mint_change_logs("JSON" ARRAY) 
+    returns VARIANT 
+    api_integration = aws_solana_api_dev 
+    max_batch_rows = 1
+    AS {% if target.database == 'SOLANA' -%}
         'https://l426aqju0g.execute-api.us-east-1.amazonaws.com/prod/udf_decode_compressed_mint_change_logs'
     {% else %}
         'https://7938mznoq8.execute-api.us-east-1.amazonaws.com/dev/udf_decode_compressed_mint_change_logs'

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
@@ -87,7 +87,7 @@ base AS (
 )
 SELECT
     ARRAY_AGG(request) AS batch_request,
-    solana_dev.streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
+    streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
     MIN(event_inserted_timestamp) AS start_inserted_timestamp,
     MAX(event_inserted_timestamp) AS end_inserted_timestamp,
     concat_ws(

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
@@ -1,5 +1,4 @@
 -- depends_on: {{ ref('silver__nft_compressed_mints_onchain') }}
--- depends_on: {{ ref('silver__events') }}
 {{ config(
     materialized = 'incremental',
     tags = ['bronze_api'],
@@ -32,82 +31,71 @@
     {% set query2 = """
         qualify(ROW_NUMBER() over (
         ORDER BY
-            _inserted_timestamp)) <= 2000""" %}
+            _inserted_timestamp)) <= 1500""" %}
     {% do run_query(query ~ incr ~ query2) %}
     {% set min_inserted_timestamp = run_query("""SELECT min(_inserted_timestamp) FROM bronze_api.parse_compressed_nft_mints__intermediate_tmp""").columns[0].values()[0] %}
     {% set max_inserted_timestamp = run_query("""SELECT max(_inserted_timestamp) FROM bronze_api.parse_compressed_nft_mints__intermediate_tmp""").columns[0].values()[0] %}
-
-    {% set call_api_query %}
-        CREATE OR REPLACE TEMPORARY TABLE bronze_api.parse_compressed_nft_mints__final_tmp AS 
-        WITH collection_subset AS (
-            SELECT
-                distinct tx_id, block_timestamp
-            FROM
-                bronze_api.parse_compressed_nft_mints__intermediate_tmp
-        ),
-        base AS (
-            SELECT
-                e.tx_id,
-                e.index,
-                ii.index AS inner_index,
-                ii.value :data :: STRING AS DATA,
-                OBJECT_CONSTRUCT(
-                    'tx_id',
-                    e.tx_id,
-                    'index',
-                    e.index,
-                    'inner_index',
-                    inner_index,
-                    'instruction_data',
-                    DATA
-                ) AS request,
-                ii.value :programId :: STRING AS ii_program_id,
-                ROW_NUMBER() over (
-                    ORDER BY
-                        e._inserted_timestamp,
-                        e.tx_id
-                ) AS rn,
-                FLOOR(
-                    rn / 200
-                ) AS gn,
-                e._inserted_timestamp AS event_inserted_timestamp
-            FROM
-                collection_subset C
-                JOIN {{ ref('silver__events') }}
-                e
-                ON C.tx_id = e.tx_id
-                JOIN TABLE(FLATTEN(e.inner_instruction :instructions)) ii
-            WHERE
-                e.program_id IN (
-                    'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY',
-                    '1atrmQs3eq1N2FEYWu6tyTXbCjP4uQwExpjtnhXtS8h'
-                )
-                AND e.block_timestamp :: DATE = C.block_timestamp :: DATE
-                AND ii_program_id = 'noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV'
-                AND e._inserted_timestamp between '{{ min_inserted_timestamp }}' and '{{ max_inserted_timestamp }}'
-                AND NOT startswith(DATA, '2GJh')
-        )
-        SELECT
-            ARRAY_AGG(request) AS batch_request,
-            streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
-            MIN(event_inserted_timestamp) AS start_inserted_timestamp,
-            MAX(event_inserted_timestamp) AS end_inserted_timestamp,
-            concat_ws(
-                '-',
-                end_inserted_timestamp,
-                gn
-            ) AS _id
-        FROM
-            base
-        GROUP BY
-            gn
-    {% endset %}
-
-    {% do run_query(call_api_query) %}
 {% endif %}
 
+WITH collection_subset AS (
+    SELECT
+        *
+    FROM
+        bronze_api.parse_compressed_nft_mints__intermediate_tmp
+),
+base AS (
+    SELECT
+        e.tx_id,
+        e.index,
+        ii.index AS inner_index,
+        ii.value :data :: STRING AS DATA,
+        OBJECT_CONSTRUCT(
+            'tx_id',
+            e.tx_id,
+            'index',
+            e.index,
+            'inner_index',
+            inner_index,
+            'instruction_data',
+            DATA
+        ) AS request,
+        ii.value :programId :: STRING AS ii_program_id,
+        ROW_NUMBER() over (
+            ORDER BY
+                e._inserted_timestamp,
+                e.tx_id
+        ) AS rn,
+        FLOOR(
+            rn / 150
+        ) AS gn,
+        e._inserted_timestamp AS event_inserted_timestamp
+    FROM
+        collection_subset C
+        JOIN {{ ref('silver__events') }}
+        e
+        ON C.tx_id = e.tx_id
+        JOIN TABLE(FLATTEN(e.inner_instruction :instructions)) ii
+    WHERE
+        e.program_id IN (
+            'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY',
+            '1atrmQs3eq1N2FEYWu6tyTXbCjP4uQwExpjtnhXtS8h'
+        )
+        AND e.block_timestamp :: DATE = C.block_timestamp :: DATE
+        AND ii_program_id = 'noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV'
+        AND e._inserted_timestamp between '{{ min_inserted_timestamp }}' and '{{ max_inserted_timestamp }}'
+        AND NOT startswith(DATA, '2GJh')
+)
 SELECT
-    *
-FROM 
-    bronze_api.parse_compressed_nft_mints__final_tmp
-
+    ARRAY_AGG(request) AS batch_request,
+    solana_dev.streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
+    MIN(event_inserted_timestamp) AS start_inserted_timestamp,
+    MAX(event_inserted_timestamp) AS end_inserted_timestamp,
+    concat_ws(
+        '-',
+        end_inserted_timestamp,
+        gn
+    ) AS _id
+FROM
+    base
+GROUP BY
+    gn


### PR DESCRIPTION
- Force max batch size in UDF
  - This was causing some calls to pass multiple rows into the lambda instead of just one batch of requests. The lambda is currently only expecting 1 batch per call
- Decrease batch size
  - Saw some instances of longer running execution times, going to reduce it to give it more buffer
- Revert temp fix