### PR TITLE
An 4501/generalize dynamic predicate

### DIFF
--- a/macros/dbt/get_merge.sql
+++ b/macros/dbt/get_merge.sql
@@ -1,65 +1,8 @@
 {% macro get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}
     {% set predicate_override = "" %}
-    {% if incremental_predicates[0] == "dynamic_block_date_ranges" %}
+    {% if incremental_predicates[0] == "dynamic_range_predicate" %}
         -- run some queries to dynamically determine the min + max of this 'date_column' in the new data
-        {% set get_limits_query %}
-            WITH full_range AS (
-                SELECT 
-                    min(block_timestamp::date) as full_range_start_block_date,
-                    max(block_timestamp::date) as full_range_end_block_date
-                FROM {{ source }}
-            ),
-            block_range as (
-                SELECT
-                    date_day,
-                    row_number() over (order by date_day) - 1 as rn
-                FROM
-                    crosschain.core.dim_dates
-                WHERE 
-                    date_day between (select full_range_start_block_date from full_range) and (select full_range_end_block_date from full_range)
-            ),
-            partition_block_counts as (
-                SELECT
-                    b.date_day as block_date,
-                    COUNT(*) as count_in_window
-                FROM
-                    block_range b
-                    left outer join {{ source }} r
-                        on r.block_timestamp::date = b.date_day
-                group by 1
-            ),
-            range_groupings AS (
-                SELECT
-                    block_date,
-                    count_in_window,
-                    CONDITIONAL_CHANGE_EVENT(count_in_window > 1) OVER (ORDER BY block_date) as group_val
-                FROM
-                    partition_block_counts
-            ), 
-            contiguous_ranges as (
-                select 
-                    min(block_date) as start_block_date,
-                    max(block_date) as end_block_date
-                from range_groupings
-                where count_in_window > 1
-                group by group_val
-            ),
-            between_stmts as (
-                select 
-                    concat('DBT_INTERNAL_DEST.block_timestamp::date between \'',start_block_date,'\' and \'',end_block_date,'\'') as b
-                from 
-                    contiguous_ranges
-            )
-            select 
-                concat('(',listagg(b, ' OR '),')')
-            from between_stmts
-        {% endset %}
-        {% set between_stmts = run_query(get_limits_query).columns[0].values()[0] %}
-        {% if between_stmts != '()' %} /* in case empty update array */
-            {% set predicate_override = between_stmts %}
-        {% else %}
-            {% set predicate_override = '1=1' %} /* need to have something or it will error since 'dynamic_block_date_ranges' is not a column */
-        {% endif %}
+        {% set predicate_override = dynamic_range_predicate(source, incremental_predicates[1], "DBT_INTERNAL_DEST") %}
     {% endif %}
     {% set predicates = [predicate_override] if predicate_override else incremental_predicates %}
     -- standard merge from here

--- a/models/silver/parser/silver__decoded_instructions.sql
+++ b/models/silver/parser/silver__decoded_instructions.sql
@@ -2,7 +2,7 @@
 -- depends_on: {{ ref('bronze__streamline_FR_decoded_instructions_2') }}
 {{ config(
     materialized = 'incremental',
-    incremental_predicates = ["dynamic_block_date_ranges"],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     unique_key = "decoded_instructions_id",
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE','program_id'],
     merge_exclude_columns = ["inserted_timestamp"],

--- a/models/silver/parser/silver__decoded_instructions_combined.sql
+++ b/models/silver/parser/silver__decoded_instructions_combined.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    incremental_predicates = ["dynamic_block_date_ranges"],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     unique_key = "decoded_instructions_combined_id",
     cluster_by = ['program_id','block_timestamp::DATE','_inserted_timestamp::DATE'],
     post_hook = enable_search_optimization(
@@ -36,7 +36,7 @@ FROM
 {% do run_query(
     query ~ incr
 ) %}
-{% set between_stmts = dynamic_block_date_ranges("silver.decoded_instructions__intermediate_tmp") %}
+{% set between_stmts = dynamic_range_predicate("silver.decoded_instructions__intermediate_tmp","block_timestamp::date") %}
 {% endif %}
 
 WITH txs AS (


### PR DESCRIPTION
- Refactor the dynamic predicates macro
  - Add input params for source and predicate column name
  - Only supports INTEGER or DATE data types for predicate column
  - Modify existing usages to use this version of the macro
- This will move to `fsc-utils` in the future