### PR TITLE
change alias so it selects column we want

### DIFF
--- a/models/silver/idls/silver__verified_user_idls.sql
+++ b/models/silver/idls/silver__verified_user_idls.sql
@@ -107,7 +107,7 @@ SELECT
     b.program_id,
     b.idl,
     b.idl_hash,
-    iff(r.error_rate <= 0.25,true,false) as is_valid,
+    (r.error_rate <= 0.25) as new_is_valid,
     b.discord_username,
     b._inserted_timestamp,
     CONCAT(
@@ -127,7 +127,7 @@ WHERE
         OR 
         (
             t.idl_hash <> b.idl_hash -- updated
-            AND is_valid -- only update if the new one is valid
+            AND new_is_valid -- only update if the new one is valid
         )
     )
 qualify(ROW_NUMBER() over(PARTITION BY b.program_id


### PR DESCRIPTION
- Fix issue with updated + valid IDLs with an already valid existing IDL not being updated into the table
  - Issue was with alias `is_valid` being same name as the column in the existing table. When it references the value in the where clause it is using the wrong one
  - Rename alias to something different so it references the value we want not the existing value