### PR TITLE
remove upperbound when searching for completed, too strict

### DIFF
--- a/tests/test_streamline__complete_decoded_instructions_2__missing.sql
+++ b/tests/test_streamline__complete_decoded_instructions_2__missing.sql
@@ -16,5 +16,3 @@ FROM
     {{ ref('streamline__complete_decoded_instructions_2') }}
 WHERE
     _inserted_timestamp >= dateadd('hour',-3,date_trunc('hour',current_timestamp()))
-    -- seeing situations where _inserted_timestamp hour != _partition_by_created_date_hour when files are written right at XX:00:00.000
-    AND _inserted_timestamp <= dateadd('hour',-2, date_trunc('hour',current_timestamp()))


### PR DESCRIPTION
- Remove the upper bound when searching for completed, the range was too strict and it kept failing even though the data was in completed. 
  - This will now pass as long as the data recorded in bronze from 3 hours ago has made it to completed at **any** point in the last 3 hours.