### PR TITLE
An 4546/allow parameterized retries for decoder errs

### DIFF
--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -145,6 +145,7 @@
 {% endmacro %}
 
 -- USE THIS TO BACKFILL PARSER 2.0 ERRORS
+-- THIS ONLY HANDLES ERRORS ie: `decoded_instruction:error::string is not null`
 {% macro decoded_instructions_backfill_retries_generate_views(program_id, start_date, end_date) %}
     {% set get_block_id_range_query %}
         select 

--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -75,6 +75,8 @@
     {% endfor %}
 {% endmacro %}
 
+
+-- DEPRECATE SOON, ONLY USE IF BACKFILLING PARSER 1.0 ERRORS
 {% macro decoded_instructions_backfill_missing_and_retries_generate_views(program_id) %}
     {% set start_block = 0 %}  /* we just pick the lowest possible value so that retry views are always run last (i.e. after main backfill is done) */
     {% set end_block = 239165744 %} /* legacy decoder not used after this block */
@@ -140,6 +142,110 @@
         ;""" %}
 
         {% do run_query(query) %}
+{% endmacro %}
+
+-- USE THIS TO BACKFILL PARSER 2.0 ERRORS
+{% macro decoded_instructions_backfill_retries_generate_views(program_id, start_date, end_date) %}
+    {% set get_block_id_range_query %}
+        select 
+            min(block_id),
+            max(block_id)
+        from {{ ref('silver__blocks') }}
+        where block_timestamp::date between '{{ start_date }}' and '{{ end_date }}'
+    {% endset %}
+    {% set range_results = run_query(get_block_id_range_query)[0] %}
+    
+    {% set min_block_id = range_results[0] %}
+    {% set max_block_id = range_results[1] %}
+    {% set step = 10000000 %}
+    {% set retry_start_timestamp = modules.datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") %}
+
+    {% for i in range(min_block_id, max_block_id, step) %}
+        {% if i == min_block_id %}
+            {% set start_block = i %}
+        {% else %}
+            {% set start_block = i+1 %}
+        {% endif %}
+
+        {% if i+step >= max_block_id %}
+            {% set end_block = max_block_id %}
+        {% else %}
+            {% set end_block = i+step %}
+        {% endif %}
+        {% set query %}
+            create or replace view streamline.decoded_instructions_backfill_{{ start_block }}_{{ end_block }}_retry_{{ program_id }} AS
+            with retries as (
+                select block_id, tx_id, index, inner_index
+                from {{ ref('silver__decoded_instructions_combined') }}
+                where program_id = '{{ program_id }}'
+                and succeeded
+                and decoded_instruction:error::string is not null
+                and block_id between {{ start_block }} and {{ end_block }}
+            ),
+            retry_events as (
+                select 
+                    e.block_id,
+                    e.tx_id,
+                    e.index,
+                    NULL as inner_index,
+                    e.instruction,
+                    e.program_id,
+                    e.block_timestamp,
+                    {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','e.program_id']) }} as id
+                from retries r
+                join {{ ref('silver__events') }} e 
+                    on r.block_id = e.block_id 
+                    and r.tx_id = e.tx_id 
+                    and r.index = e.index 
+                where e.program_id = '{{ program_id }}'
+                and e.block_id between {{ start_block }} and {{ end_block }}
+                and e.succeeded
+                and r.inner_index is null
+                union all
+                select
+                    e.block_id,
+                    e.tx_id,
+                    e.index,
+                    i.index as inner_index,
+                    i.value as instruction, 
+                    i.value :programId :: STRING AS inner_program_id,
+                    e.block_timestamp,
+                    {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','inner_program_id']) }} as id
+                from retries r
+                join {{ ref('silver__events') }} e 
+                    on r.block_id = e.block_id 
+                    and r.tx_id = e.tx_id 
+                    and r.index = e.index 
+                join table(flatten(inner_instruction:instructions)) i
+                where array_contains('{{ program_id }}'::variant, inner_instruction_program_ids)
+                and inner_program_id = '{{ program_id }}'
+                and e.block_id between {{ start_block }} and {{ end_block }}
+                and e.succeeded
+                and r.inner_index is not null
+                and r.inner_index = i.index
+            ),
+            completed_subset as (
+                select 
+                    *
+                from 
+                    {{ ref('streamline__complete_decoded_instructions_2') }}
+                where 
+                    program_id = '{{ program_id }}'
+                and 
+                    _inserted_timestamp >= '{{ retry_start_timestamp }}'
+            )
+            select 
+                e.*
+            from retry_events e 
+            left outer join completed_subset c 
+                    on c.complete_decoded_instructions_2_id = e.id
+            where 
+                c.complete_decoded_instructions_2_id is null
+            ;
+        {% endset %}
+
+        {% do run_query(query) %}
+    {% endfor %}
 {% endmacro %}
 
 {% macro decoded_instructions_backill_cleanup_views() %}


### PR DESCRIPTION
- New helper macro for retrying error events
  - Typical use case would be to backfill decodings after an IDL has been updated 

Example usage:
```
dbt run-operation decoded_instructions_backfill_retries_generate_views --args '{"program_id": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4", "start_date": "2024-02-02", "end_date": "2024-02-17"}'
```