### PR TITLE
only send inner instrs if the account list is >1 for some programs

### DIFF
--- a/models/streamline/decode_instructions/streamline__decode_instructions_2_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_2_realtime.sql
@@ -57,7 +57,13 @@ event_subset AS (
         e.succeeded
     AND 
         i.value :programId :: STRING = b.program_id
-    
+    AND (
+            (
+                inner_program_id in ('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo')
+                AND array_size(i.value:accounts) > 1
+            )
+            OR inner_program_id not in ('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo')
+        )
 ),
 completed_subset AS (
     SELECT


### PR DESCRIPTION
- Some programs have inner instruction args that can't be decoded so we should not send them if we can identify them in SQL
  - [Examples](https://solscan.io/tx/pMEYwMvGx9Ek3ZeSUckTxs12jHnyZBfjifcYjaz16BRHig129T8jJA7MrcQcKcng5BfepFUCYCKbSWGfSo9k7zH)
    - `index=2,inner_index=4`
    - `indes=2,inner_index=8`
  - The current decoder implementation will output a decoded instruction like `{accounts: null, name: null...}`. Soon a decoder update release will output these as errors. By not sending these anymore we can prevent the error testing from falsely alerting