### PR TITLE
fix issue with subquery pruning not happening

### DIFF
--- a/models/streamline/decode_instructions/streamline__decode_instructions_2_pyth_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_2_pyth_realtime.sql
@@ -70,12 +70,7 @@ completed_subset AS (
     FROM
         {{ ref('streamline__complete_decoded_instructions_2') }}
     WHERE
-        block_id >= (
-            SELECT
-                MIN(block_id)
-            FROM
-                event_subset
-        )
+        block_id >= {{ min_block_id }}
 )
 SELECT
     e.program_id,


### PR DESCRIPTION
- @eric-laurello and I discovered that dynamic pruning was no longer happening via subquery on `complete_decoded_instructions_2` as of about a week ago. This is causing run time performance degradation.
- To fix, get the min block in a pre-model query and then use it in the model 