### PR TITLE
debridge - check succeeded for nulls

### DIFF
--- a/models/silver/bridges/silver__bridge_debridge_transfers.yml
+++ b/models/silver/bridges/silver__bridge_debridge_transfers.yml
@@ -64,7 +64,8 @@ models:
       - name: MINT
         description:  "{{ doc('mint') }}"
         tests: 
-          - not_null
+          - not_null:
+              where: succeeded
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('tx_id') }}"
         tests: 


### PR DESCRIPTION
Some records in `silver.transfers` have `null` mints, but the issue is only around unsuccessful txs 