### PR TITLE
joining by block date will improve pruning

### DIFF
--- a/models/silver/nfts/silver__nft_sales_magic_eden_v2.sql
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_v2.sql
@@ -9,6 +9,7 @@
 WITH txs AS (
 
     SELECT
+        block_timestamp::date as block_date,
         tx_id,
         succeeded,
         signers[0] :: STRING as signer, 
@@ -55,7 +56,8 @@ AND _inserted_timestamp >= (
 GROUP BY
     1,
     2, 
-    3
+    3,
+    4
 HAVING
     COUNT(
         tx_id
@@ -95,7 +97,8 @@ base_tmp AS (
         {{ ref('silver__events') }}
         e
         INNER JOIN txs t
-        ON t.tx_id = e.tx_id
+        ON t.block_date = e.block_timestamp::date
+        AND t.tx_id = e.tx_id
         AND t.max_event_index = e.index
         AND ARRAY_SIZE(
             e.inner_instruction :instructions
@@ -159,7 +162,8 @@ sellers AS (
         {{ ref('silver__events') }}
         e
         INNER JOIN txs t
-        ON t.tx_id = e.tx_id
+        ON t.block_date = e.block_timestamp::date
+        AND t.tx_id = e.tx_id
         AND t.max_event_index = e.index
         AND ARRAY_SIZE(
             e.inner_instruction :instructions


### PR DESCRIPTION
- Improve query pruning by using `block_timestamp::date` as first join condition

Current
<img width="269" alt="Screenshot 2024-03-14 at 7 06 49 AM" src="https://github.com/FlipsideCrypto/solana-models/assets/97470747/3f8dd01e-255c-4c29-996f-22a9f04d15fb">

After change
<img width="257" alt="Screenshot 2024-03-14 at 7 07 49 AM" src="https://github.com/FlipsideCrypto/solana-models/assets/97470747/29b69052-bda3-41e0-9d28-34465d951c5c">
