### PR TITLE
An 4732/swap duplicates

### DIFF
--- a/models/bronze/labels/bronze__labels.sql
+++ b/models/bronze/labels/bronze__labels.sql
@@ -1,7 +1,6 @@
 {{ config(
-      materialized='view'
-    ) 
-}}
+    materialized = 'view'
+) }}
 
 SELECT
     system_created_at,
@@ -14,9 +13,12 @@ SELECT
     address_name,
     project_name,
     _is_deleted,
+    modified_timestamp,
     labels_combined_id
-FROM  {{ source(
+FROM
+    {{ source(
         'crosschain_silver',
         'labels_combined'
     ) }}
-WHERE blockchain = 'solana'
+WHERE
+    blockchain = 'solana'

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -119,7 +119,7 @@ SELECT
     to_mint AS swap_to_mint,
     program_id,
     l.address_name AS swap_program,
-    concat_ws('-',tx_id,swap_index) as _log_id,
+    concat_ws('-',tx_id,swap_index,swap_program) as _log_id,
     swaps_intermediate_bonkswap_id as fact_swaps_id,
     s.inserted_timestamp,
     s.modified_timestamp
@@ -142,7 +142,7 @@ SELECT
     to_mint AS swap_to_mint,
     program_id,
     l.address_name AS swap_program,
-    concat_ws('-',tx_id,swap_index) as _log_id,
+    concat_ws('-',tx_id,swap_index,swap_program) as _log_id,
     swaps_intermediate_meteora_id as fact_swaps_id,
     s.inserted_timestamp,
     s.modified_timestamp
@@ -165,7 +165,7 @@ SELECT
     to_mint AS swap_to_mint,
     program_id,
     l.address_name AS swap_program,
-    concat_ws('-',tx_id,swap_index) as _log_id,
+    concat_ws('-',tx_id,swap_index,swap_program) as _log_id,
     swaps_intermediate_dooar_id as fact_swaps_id,
     s.inserted_timestamp,
     s.modified_timestamp
@@ -188,7 +188,7 @@ SELECT
     to_mint AS swap_to_mint,
     program_id,
     l.address_name AS swap_program,
-    concat_ws('-',tx_id,swap_index) as _log_id,
+    concat_ws('-',tx_id,swap_index,swap_program) as _log_id,
     swaps_intermediate_phoenix_id as fact_swaps_id,
     s.inserted_timestamp,
     s.modified_timestamp


### PR DESCRIPTION
- fix duplicate` _log_id`s by concatenating the program. Some silver tables aggregate swaps in a tx while others return individual swaps, so duplicates `log_id` can exist
- select modified_timestamp in bronze, so that the silver table inserts only new records