### PR TITLE
An 4746/fix c nft parsing

### DIFF
--- a/.github/workflows/dbt_run_nft_compressed_mints_realtime.yml
+++ b/.github/workflows/dbt_run_nft_compressed_mints_realtime.yml
@@ -46,3 +46,5 @@ jobs:
           dbt run -s models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
           dbt run -s models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
           dbt run -s models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+          dbt run -s models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+          dbt run -s models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
@@ -24,6 +24,7 @@
             m.block_timestamp,
             m.block_id,
             m.tx_id,
+            m.index,
             m._inserted_timestamp
         FROM
             {{ ref('silver__nft_compressed_mints_onchain') }} m
@@ -80,6 +81,7 @@ base AS (
         JOIN {{ ref('silver__events') }}
         e
         ON C.tx_id = e.tx_id
+        AND C.index = e.index
         JOIN TABLE(FLATTEN(e.inner_instruction :instructions)) ii
     WHERE
         e.program_id IN (

--- a/models/silver/nfts/silver__nft_compressed_mints_onchain.sql
+++ b/models/silver/nfts/silver__nft_compressed_mints_onchain.sql
@@ -86,7 +86,7 @@ FROM
   )
 WHERE
   succeeded
-  AND program_id = '1atrmQs3eq1N2FEYWu6tyTXbCjP4uQwExpjtnhXtS8h' -- lazy_transactions
+  AND program_id IN ('1atrmQs3eq1N2FEYWu6tyTXbCjP4uQwExpjtnhXtS8h','F9SixdqdmEBP5kprp2gZPZNeMmfHJRCTMFjN22dx3akf') -- lazy_transactions
   AND f.value :programId = 'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY' -- bubblegum
 
 {% if is_incremental() %}


### PR DESCRIPTION
- Add CTE to filter out transactions that have already run through the compressed mints decoder
- Add onchain mint events for `F9SixdqdmEBP5kprp2gZPZNeMmfHJRCTMFjN22dx3akf` because it uses bubblegum
- Add txs from additional program `F9SixdqdmEBP5kprp2gZPZNeMmfHJRCTMFjN22dx3akf` to be decoded
- Increase workflow job calls by 2