### PR TITLE
add qualify to dedupe bronze data

### DIFF
--- a/models/silver/silver___blocks_tx_count.sql
+++ b/models/silver/silver___blocks_tx_count.sql
@@ -20,3 +20,5 @@ WHERE
             {{ this }}
     )
 {% endif %}
+QUALIFY 
+    row_number() over (partition by block_id order by _inserted_timestamp, transaction_count desc) = 1


### PR DESCRIPTION
- Solscan bronze data had an [instance](https://github.com/FlipsideCrypto/solana-models/actions/runs/8706745527/job/23880062549) where it duplicated the same batch of requests and the silver model failed because it was not deduping
  - I re-ran the model w/ qualify and it was successful
  ```
  14:05:31  1 of 1 OK created sql incremental model silver._blocks_tx_count ................ [SUCCESS 10726 in 5.43s]
  ```