### PR TITLE
remove block_id from SO, it is not working on SF due to black box error

### DIFF
--- a/models/silver/silver__events.sql
+++ b/models/silver/silver__events.sql
@@ -3,7 +3,7 @@
     unique_key = ['block_id','tx_id','index'],
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE','program_id'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}'), 
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, inner_instruction_program_ids)'),
     full_refresh = false,
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']


### PR DESCRIPTION
SO on `block_id` not working. Giving error `ambiguous column name 'BLOCK_ID'`. Dropping and re-adding was unsuccessfuly. The decision was made to remove it from SO as the explain plan seems to do fine w/o it for block point-lookups.

```
explain 
select *
from solana.silver.events 
where block_id = 178298940;
```
<img width="1028" alt="Screenshot 2024-04-24 at 7 48 56 AM" src="https://github.com/FlipsideCrypto/solana-models/assets/97470747/28e9e5d8-d039-4464-9727-48b69c02b154">

