### PR TITLE
An 4786/fix meteora swaps incremental

### DIFF
--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -41,6 +41,16 @@ models:
               field: tx_id
               from_condition: "program_id = 'M3mxk5W2tt27WGT7THox7PmgRDp4m6NEhL5xvxrBfS1' and event_type = 'buyNow' and _inserted_timestamp >= current_date - 7"
               to_condition: "_inserted_timestamp >= current_date - 7"
+          - dbt_utils.relationships_where:
+              name: dbt_utils_relationships_where_silver__decoded_instructions_combined_meteora_swaps_tx_id
+              to: ref('silver__swaps_intermediate_meteora')
+              field: tx_id
+              from_condition: >
+                program_id IN ('LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB') 
+                and event_type = 'swap' 
+                and coalesce(decoded_instruction:args:inAmount, decoded_instruction:args:amountIn)::int > 0
+                and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
+              to_condition: "_inserted_timestamp >= current_date - 7"
       - name: SIGNERS
       - name: SUCCEEDED
       - name: INDEX

--- a/models/silver/swaps/silver__swaps_intermediate_meteora.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_meteora.sql
@@ -1,80 +1,142 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+
 {{ config(
     materialized = 'incremental',
     unique_key = ['swaps_intermediate_meteora_id'],
-    incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp::date >= LEAST(current_date-7,(select min(block_timestamp)::date from ' ~ generate_tmp_view_name(this) ~ '))'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     tags = ['scheduled_non_core'],
 ) }}
 
-WITH base AS (
-
+{% if execute %}
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.swaps_intermediate_meteora__intermediate_tmp AS
     SELECT
         *
     FROM
         {{ ref('silver__decoded_instructions_combined') }}
     WHERE
-        program_id in ('LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo', -- DLMM program
-                       'Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB' -- AMM program
-                        )
-    AND 
-        event_type = 'swap'
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '1 hour'
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND block_timestamp :: DATE >= '2022-07-14'
+        program_id IN (
+            'LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo',
+            -- DLMM program
+            'Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB' -- AMM program
+        )
+        AND event_type = 'swap'
+        AND succeeded
+
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '1 hour'
+        FROM
+            {{ this }}
+    )
+    {% else %}
+        AND block_timestamp :: DATE >= '2022-07-14'
+    {% endif %}
+    {% endset %}
+    
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate(
+        "silver.swaps_intermediate_meteora__intermediate_tmp",
+        "block_timestamp::date"
+    ) %}
 {% endif %}
+
+WITH base AS (
+    SELECT
+        *
+    FROM
+        silver.swaps_intermediate_meteora__intermediate_tmp
 ),
 decoded AS (
     SELECT
         block_timestamp,
         block_id,
         tx_id,
-        index,
+        INDEX,
         inner_index,
-        COALESCE(LEAD(inner_index) over (PARTITION BY tx_id, INDEX
-        ORDER BY
-        inner_index) -1, 999999) AS inner_index_end,
+        COALESCE(LEAD(inner_index) OVER (PARTITION BY tx_id, index 
+            ORDER BY inner_index) -1, 999999
+        ) AS inner_index_end,
         program_id,
-        silver.udf_get_account_pubkey_by_name('user', decoded_instruction:accounts) as swapper,
-        silver.udf_get_account_pubkey_by_name('userTokenIn', decoded_instruction:accounts) as source_token_account,
-        silver.udf_get_account_pubkey_by_name('tokenXMint', decoded_instruction:accounts) as source_mint,
-        silver.udf_get_account_pubkey_by_name('tokenYMint', decoded_instruction:accounts) as destination_mint,
-        silver.udf_get_account_pubkey_by_name('userTokenOut', decoded_instruction:accounts) as destination_token_account,
-        silver.udf_get_account_pubkey_by_name('reserveY', decoded_instruction:accounts) as program_destination_token_account,
-        silver.udf_get_account_pubkey_by_name('reserveX', decoded_instruction:accounts) as program_source_token_account,
+        silver.udf_get_account_pubkey_by_name(
+            'user',
+            decoded_instruction :accounts
+        ) AS swapper,
+        silver.udf_get_account_pubkey_by_name(
+            'userTokenIn',
+            decoded_instruction :accounts
+        ) AS source_token_account,
+        silver.udf_get_account_pubkey_by_name(
+            'tokenXMint',
+            decoded_instruction :accounts
+        ) AS source_mint,
+        silver.udf_get_account_pubkey_by_name(
+            'tokenYMint',
+            decoded_instruction :accounts
+        ) AS destination_mint,
+        silver.udf_get_account_pubkey_by_name(
+            'userTokenOut',
+            decoded_instruction :accounts
+        ) AS destination_token_account,
+        silver.udf_get_account_pubkey_by_name(
+            'reserveY',
+            decoded_instruction :accounts
+        ) AS program_destination_token_account,
+        silver.udf_get_account_pubkey_by_name(
+            'reserveX',
+            decoded_instruction :accounts
+        ) AS program_source_token_account,
         _inserted_timestamp
     FROM
         base
-    where program_id = 'LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo'
-    union all
+    WHERE
+        program_id = 'LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo'
+    UNION ALL
     SELECT
         block_timestamp,
         block_id,
         tx_id,
-        index,
+        INDEX,
         inner_index,
-        COALESCE(LEAD(inner_index) over (PARTITION BY tx_id, INDEX
-        ORDER BY
-        inner_index) -1, 999999) AS inner_index_end,
+        COALESCE(LEAD(inner_index) OVER (PARTITION BY tx_id, index 
+            ORDER BY
+            inner_index) -1, 999999
+        ) AS inner_index_end,
         program_id,
-        silver.udf_get_account_pubkey_by_name('user', decoded_instruction:accounts) as swapper,
-        silver.udf_get_account_pubkey_by_name('userSourceToken', decoded_instruction:accounts) as source_token_account,
-        null as source_mint,
-        null as destination_mint,
-        silver.udf_get_account_pubkey_by_name('userDestinationToken', decoded_instruction:accounts) as destination_token_account,
-        silver.udf_get_account_pubkey_by_name('aTokenVault', decoded_instruction:accounts) as program_destination_token_account,
-        silver.udf_get_account_pubkey_by_name('bTokenVault', decoded_instruction:accounts) as program_source_token_account,
+        silver.udf_get_account_pubkey_by_name(
+            'user',
+            decoded_instruction :accounts
+        ) AS swapper,
+        silver.udf_get_account_pubkey_by_name(
+            'userSourceToken',
+            decoded_instruction :accounts
+        ) AS source_token_account,
+        NULL AS source_mint,
+        NULL AS destination_mint,
+        silver.udf_get_account_pubkey_by_name(
+            'userDestinationToken',
+            decoded_instruction :accounts
+        ) AS destination_token_account,
+        silver.udf_get_account_pubkey_by_name(
+            'aTokenVault',
+            decoded_instruction :accounts
+        ) AS program_destination_token_account,
+        silver.udf_get_account_pubkey_by_name(
+            'bTokenVault',
+            decoded_instruction :accounts
+        ) AS program_source_token_account,
         _inserted_timestamp
     FROM
         base
-    where program_id = 'Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB'
-    and (decoded_instruction:args:amountIn::int <> 0 or decoded_instruction:args:inAmount::int <> 0)
+    WHERE
+        program_id = 'Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB'
+        AND (
+            decoded_instruction :args :amountIn :: INT <> 0
+            OR decoded_instruction :args :inAmount :: INT <> 0
+        )
 ),
 transfers AS (
     SELECT
@@ -85,69 +147,104 @@ transfers AS (
         {{ ref('silver__transfers') }} A
         INNER JOIN (
             SELECT
-                DISTINCT tx_id
+                DISTINCT 
+                    tx_id,
+                    block_timestamp::DATE AS block_date
             FROM
                 decoded
         ) d
-        ON d.tx_id = A.tx_id
+        ON d.block_date = A.block_timestamp::DATE
+        AND d.tx_id = A.tx_id
     WHERE
         A.succeeded
-
-{% if is_incremental() %}
-AND A._inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '1 day'
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND A.block_timestamp :: DATE >= '2022-07-14'
-{% endif %}
+        AND {{ between_stmts }}
 ),
-pre_final as (
-SELECT
-    A.block_id,
-    A.block_timestamp,
-    A.program_id,
-    A.tx_id,
-    A.index,
-    A.inner_index,
-    A.inner_index_end,
-    coalesce (b.succeeded,d.succeeded) AS succeeded,
-    A.swapper,
-    coalesce (b.amount,d.amount) AS from_amt,
-    coalesce(b.mint,d.mint) AS from_mint,
-    coalesce(C.amount,e.amount) AS to_amt,
-    coalesce(c.mint,e.mint) AS to_mint,
-    A._inserted_timestamp
-FROM
-    decoded A
-    left JOIN transfers b
-    ON A.tx_id = b.tx_id
-    AND A.source_token_account = b.source_token_account
-    AND A.program_source_token_account = b.dest_token_account
-    AND A.index = b.index_1
-    AND ((b.inner_index_1 BETWEEN A.inner_index AND A.inner_index_end) or a.inner_index is null)
-    left JOIN transfers C
-    ON A.tx_id = C.tx_id
-    AND A.destination_token_account = C.dest_token_account
-    AND A.program_destination_token_account = C.source_token_account
-    AND A.index = C.index_1
-    AND ((C.inner_index_1 BETWEEN A.inner_index AND A.inner_index_end) or a.inner_index is null)
-    left JOIN transfers d
-    ON A.tx_id = d.tx_id
-    AND A.source_token_account = d.source_token_account
-    AND A.program_destination_token_account = d.dest_token_account
-    AND A.index = d.index_1
-    AND ((d.inner_index_1 BETWEEN A.inner_index AND A.inner_index_end) or a.inner_index is null)
-    left JOIN transfers e
-    ON A.tx_id = e.tx_id
-    AND A.destination_token_account = e.dest_token_account
-    AND A.program_source_token_account = e.source_token_account
-    AND A.index = e.index_1
-    AND ((e.inner_index_1 BETWEEN A.inner_index AND A.inner_index_end) or a.inner_index is null)
-    qualify(ROW_NUMBER() over (PARTITION BY A.tx_id, A.index, A.inner_INDEX ORDER BY inner_index)) = 1)
-
+pre_final AS (
+    SELECT
+        A.block_id,
+        A.block_timestamp,
+        A.program_id,
+        A.tx_id,
+        A.index,
+        A.inner_index,
+        A.inner_index_end,
+        COALESCE (
+            b.succeeded,
+            d.succeeded
+        ) AS succeeded,
+        A.swapper,
+        COALESCE (
+            b.amount,
+            d.amount
+        ) AS from_amt,
+        COALESCE(
+            b.mint,
+            d.mint
+        ) AS from_mint,
+        COALESCE(
+            C.amount,
+            e.amount
+        ) AS to_amt,
+        COALESCE(
+            C.mint,
+            e.mint
+        ) AS to_mint,
+        A._inserted_timestamp
+    FROM
+        decoded A
+        LEFT JOIN transfers b
+        ON A.tx_id = b.tx_id
+        AND A.source_token_account = b.source_token_account
+        AND A.program_source_token_account = b.dest_token_account
+        AND A.index = b.index_1
+        AND (
+            (
+                b.inner_index_1 BETWEEN A.inner_index
+                AND A.inner_index_end
+            )
+            OR A.inner_index IS NULL
+        )
+        LEFT JOIN transfers C
+        ON A.tx_id = C.tx_id
+        AND A.destination_token_account = C.dest_token_account
+        AND A.program_destination_token_account = C.source_token_account
+        AND A.index = C.index_1
+        AND (
+            (
+                C.inner_index_1 BETWEEN A.inner_index
+                AND A.inner_index_end
+            )
+            OR A.inner_index IS NULL
+        )
+        LEFT JOIN transfers d
+        ON A.tx_id = d.tx_id
+        AND A.source_token_account = d.source_token_account
+        AND A.program_destination_token_account = d.dest_token_account
+        AND A.index = d.index_1
+        AND (
+            (
+                d.inner_index_1 BETWEEN A.inner_index
+                AND A.inner_index_end
+            )
+            OR A.inner_index IS NULL
+        )
+        LEFT JOIN transfers e
+        ON A.tx_id = e.tx_id
+        AND A.destination_token_account = e.dest_token_account
+        AND A.program_source_token_account = e.source_token_account
+        AND A.index = e.index_1
+        AND (
+            (
+                e.inner_index_1 BETWEEN A.inner_index
+                AND A.inner_index_end
+            )
+            OR A.inner_index IS NULL
+        ) 
+    QUALIFY 
+        ROW_NUMBER() over (PARTITION BY A.tx_id, A.index, A.inner_INDEX
+            ORDER BY inner_index
+        ) = 1
+)
 SELECT
     block_id,
     block_timestamp,

--- a/models/silver/swaps/silver__swaps_intermediate_meteora.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_meteora.sql
@@ -6,7 +6,6 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
-    tags = ['scheduled_non_core'],
 ) }}
 
 {% if execute %}


### PR DESCRIPTION
- Use `block_timestamp::date` dynamic predicate
- Use `between_stmts` for pruning `transfers` CTE
- Fix formatting
- Add relationship test between `decoded_instructions_combined` and `swaps_intermediate_meteora`
- **temporarily** remove model from scheduler so I can backfill then re-enable

```
-- full refresh on M
15:10:25  1 of 1 OK created sql incremental model silver.swaps_intermediate_meteora ...... [SUCCESS 1 in 3144.92s]

-- incremental
16:03:31  1 of 1 OK created sql incremental model silver.swaps_intermediate_meteora ...... [SUCCESS 31459 in 18.54s]

-- relationship test
15:40:52  2 of 14 PASS dbt_utils_relationships_where_silver__decoded_instructions_combined_meteora_swaps_tx_id  [PASS in 5.55s]
```

```
-- sample tx fixed compared to current
select 'fixed', tx_id, swap_index, swapper, from_amt, from_mint, to_amt, to_mint
from solana_dev.silver.swaps_intermediate_meteora
where tx_id = 'w8HVLXtC3HvVhefGwociSxdauKmvmfjFzuLGivRPxsgU2sHfTgysBZkF9nbwkPr93WPPrfySARYkY4fvxhfrEq8'
UNION ALL
select 'current', tx_id, swap_index, swapper, from_amt, from_mint, to_amt, to_mint
from solana.silver.swaps_intermediate_meteora
where tx_id = 'w8HVLXtC3HvVhefGwociSxdauKmvmfjFzuLGivRPxsgU2sHfTgysBZkF9nbwkPr93WPPrfySARYkY4fvxhfrEq8'
order by 1,2,3;
```