### PR TITLE
change schedule to avoid clashing with streamline run when test table…

### DIFF
--- a/.github/workflows/dbt_test_hourly.yml
+++ b/.github/workflows/dbt_test_hourly.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run at xx:20 UTC hourly (see https://crontab.guru)
-    - cron: '20 */1 * * *'
+    - cron: '14 */1 * * *'
     
 env:
   DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"


### PR DESCRIPTION
When the test table is re-created and the view is also executed at the same time, we could get a clash where the view query will fail. Adjust the timing of the hourly run to minimize this possibility