### PR TITLE
An 4786/fix bonkswap incremental

### DIFF
--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -48,7 +48,7 @@ models:
               from_condition: >
                 program_id = 'BSwp6bEBihVLdqJRKGgzjcGLHkcTuzmSo1TQkHepzH8p' 
                 and event_type = 'swap' 
-                and _inserted_timestamp >= current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
+                and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
               to_condition: "_inserted_timestamp >= current_date - 7"
       - name: SIGNERS
       - name: SUCCEEDED

--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -41,6 +41,15 @@ models:
               field: tx_id
               from_condition: "program_id = 'M3mxk5W2tt27WGT7THox7PmgRDp4m6NEhL5xvxrBfS1' and event_type = 'buyNow' and _inserted_timestamp >= current_date - 7"
               to_condition: "_inserted_timestamp >= current_date - 7"
+          - dbt_utils.relationships_where:
+              name: dbt_utils_relationships_where_silver__decoded_instructions_combined_swaps_intermediate_bonkswap_tx_id
+              to: ref('silver__swaps_intermediate_bonkswap')
+              field: tx_id
+              from_condition: >
+                program_id = 'BSwp6bEBihVLdqJRKGgzjcGLHkcTuzmSo1TQkHepzH8p' 
+                and event_type = 'swap' 
+                and _inserted_timestamp >= current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
+              to_condition: "_inserted_timestamp >= current_date - 7"
       - name: SIGNERS
       - name: SUCCEEDED
       - name: INDEX

--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -48,6 +48,7 @@ models:
               from_condition: >
                 program_id = 'BSwp6bEBihVLdqJRKGgzjcGLHkcTuzmSo1TQkHepzH8p' 
                 and event_type = 'swap' 
+                and decoded_instruction:args:deltaIn:v::int > 200000
                 and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
               to_condition: "_inserted_timestamp >= current_date - 7"
       - name: SIGNERS

--- a/models/silver/swaps/silver__swaps_intermediate_bonkswap.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_bonkswap.sql
@@ -29,7 +29,7 @@
             {{ this }}
     )
     {% else %}
-        AND block_timestamp :: DATE BETWEEN '2023-04-12' AND '2024-01-01'
+        AND _inserted_timestamp::DATE BETWEEN '2024-01-26' AND '2024-03-01'
     {% endif %}
     {% endset %}
     

--- a/models/silver/swaps/silver__swaps_intermediate_bonkswap.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_bonkswap.sql
@@ -1,14 +1,17 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+
 {{ config(
     materialized = 'incremental',
     unique_key = ['swaps_intermediate_bonkswap_id'],
-    incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp::date >= LEAST(current_date-7,(select min(block_timestamp)::date from ' ~ generate_tmp_view_name(this) ~ '))'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     tags = ['scheduled_non_core'],
 ) }}
 
-WITH base AS (
-
+{% if execute %}
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.swaps_intermediate_bonkswap__intermediate_tmp AS
     SELECT
         *
     FROM
@@ -16,17 +19,32 @@ WITH base AS (
     WHERE
         program_id = 'BSwp6bEBihVLdqJRKGgzjcGLHkcTuzmSo1TQkHepzH8p'
         AND event_type = 'swap'
+        AND succeeded
 
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '1 hour'
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND block_timestamp :: DATE >= '2023-04-12'
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '1 hour'
+        FROM
+            {{ this }}
+    )
+    {% else %}
+        AND block_timestamp :: DATE BETWEEN '2023-04-12' AND '2024-01-01'
+    {% endif %}
+    {% endset %}
+    
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate(
+        "silver.swaps_intermediate_bonkswap__intermediate_tmp",
+        "block_timestamp::date"
+    ) %}
 {% endif %}
+
+WITH base AS (
+    SELECT
+        *
+    FROM
+        silver.swaps_intermediate_bonkswap__intermediate_tmp
 ),
 decoded AS (
     SELECT
@@ -36,9 +54,9 @@ decoded AS (
         INDEX,
         inner_index,
         decoded_instruction :args :xToY :: BOOLEAN AS xToY,
-        COALESCE(LEAD(inner_index) over (PARTITION BY tx_id, INDEX
-    ORDER BY
-        inner_index) -1, 999999) AS inner_index_end,
+        COALESCE(LEAD(inner_index) OVER (PARTITION BY tx_id, index
+            ORDER BY inner_index) -1, 999999
+        ) AS inner_index_end,
         program_id,
         silver.udf_get_account_pubkey_by_name(
             'swapper',
@@ -105,24 +123,16 @@ transfers AS (
         {{ ref('silver__transfers') }} A
         INNER JOIN (
             SELECT
-                DISTINCT tx_id
+                DISTINCT tx_id,
+                    block_timestamp::DATE AS block_date
             FROM
                 decoded
         ) d
-        ON d.tx_id = A.tx_id
+        ON d.block_date = A.block_timestamp::DATE
+        AND d.tx_id = A.tx_id
     WHERE
         A.succeeded
-
-{% if is_incremental() %}
-AND A._inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '1 day'
-    FROM
-        {{ this }}
-)
-{% else %}
-    AND A.block_timestamp :: DATE >= '2023-04-12'
-{% endif %}
+        AND {{ between_stmts }}
 ),
 pre_final AS (
     SELECT
@@ -155,9 +165,10 @@ pre_final AS (
         AND A.index = C.index_1
         AND ((C.inner_index_1 BETWEEN A.inner_index AND A.inner_index_end) or a.inner_index is null)
         AND C.amount <> 0
-        qualify(ROW_NUMBER() over (PARTITION BY A.tx_id, A.index, A.inner_INDEX
-    ORDER BY
-        inner_index)) = 1
+    QUALIFY
+        ROW_NUMBER() over (PARTITION BY A.tx_id, A.index, A.inner_INDEX
+            ORDER BY inner_index
+        ) = 1
 )
 SELECT
     block_id,

--- a/models/silver/swaps/silver__swaps_intermediate_bonkswap.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_bonkswap.sql
@@ -6,7 +6,6 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
-    tags = ['scheduled_non_core'],
 ) }}
 
 {% if execute %}


### PR DESCRIPTION
- Use block_timestamp::date dynamic predicate
- Use between_stmts for pruning transfers CTE
- Fix formatting
- Add relationship test between decoded_instructions_combined and swaps_intermediate_bonkswap
- temporarily remove model from scheduler so I can backfill then re-enable

```
-- full refresh on 2xl
13:31:56  1 of 1 OK created sql incremental model silver.swaps_intermediate_bonkswap ..... [SUCCESS 1 in 108.12s]

-- rest of the data via incremental on 2xl
13:54:31  1 of 1 OK created sql incremental model silver.swaps_intermediate_bonkswap ..... [SUCCESS 1 in 206.81s]

-- relationship test runs
14:50:51  2 of 16 PASS dbt_utils_relationships_where_silver__decoded_instructions_combined_swaps_intermediate_bonkswap_tx_id  [PASS in 1.95s]
```