### PR TITLE
An 4786/fix dooarswap incremental

### DIFF
--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -51,6 +51,16 @@ models:
                 and coalesce(decoded_instruction:args:inAmount, decoded_instruction:args:amountIn)::int > 0
                 and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
               to_condition: "_inserted_timestamp >= current_date - 7"
+          - dbt_utils.relationships_where:
+              name: dbt_utils_relationships_where_silver__decoded_instructions_combined_swaps_intermedia_dooar_tx_id
+              to: ref('silver__swaps_intermediate_dooar')
+              field: tx_id
+              from_condition: >
+                program_id = 'Dooar9JkhdZ7J3LHN3A7YCuoGRUggXhQaG4kijfLGU2j'
+                and event_type = 'swap' 
+                and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
+                and block_timestamp::date <> '2022-07-04' /* upstream issue with missing inner instructions in events for some blocks in this date, remove this when it gets resolved */
+              to_condition: "_inserted_timestamp >= current_date - 7"
       - name: SIGNERS
       - name: SUCCEEDED
       - name: INDEX

--- a/models/silver/swaps/silver__swaps_intermediate_dooar.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_dooar.sql
@@ -5,7 +5,6 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
-    tags = ['scheduled_non_core'],
 ) }}
 
 {% if execute %}


### PR DESCRIPTION
- Use block_timestamp::date dynamic predicate
- Use between_stmts for pruning transfers CTE
- Fix formatting
- Add relationship test between decoded_instructions_combined and swaps_intermediate_bonkswap
- temporarily remove model from scheduler so I can backfill then re-enable

```
-- full refresh on M
17:16:30  1 of 1 OK created sql incremental model silver.swaps_intermediate_dooar ........ [SUCCESS 1 in 2280.36s]

-- incremental on M
14:02:26  1 of 1 OK created sql incremental model silver.swaps_intermediate_dooar ........ [SUCCESS 572 in 20.18s]

-- relationship test runs
13:59:07  2 of 16 PASS dbt_utils_relationships_where_silver__decoded_instructions_combined_swaps_intermedia_dooar_tx_id  [PASS in 3.24s]
```