### PR TITLE
add recent date filter for tests

### DIFF
--- a/models/silver/swaps/silver__swaps_intermediate_jupiterv6.yml
+++ b/models/silver/swaps/silver__swaps_intermediate_jupiterv6.yml
@@ -38,56 +38,59 @@ models:
           excluded_tx_ids:
             - 2NAjXWibmqEFGVo4No3KsgSqfz9RXMnNY9DYCRs92ZYUuLPfdUXyw2Fs9L3w5UTJnxLs9pG6MXttBWweNMZ5ZFdk
             - 51KVhmiUuexhjgZodwgeLModrqx59faQ75dbrKcprtQLRVzQ7HqWSYEB9pk889R5MjfKLo9zQ5vbj1xKer78HKcc
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SWAPPER
         description: "{{ doc('swaps_swapper') }}"
         tests: 
           - not_null:
-              where: succeeded = TRUE
+              where: succeeded = TRUE AND _inserted_timestamp >= current_date - 7
       - name: FROM_AMT
         description:  "{{ doc('swaps_from_amt') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: FROM_MINT
         description:  "{{ doc('swaps_from_mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TO_AMT
         description:  "{{ doc('swaps_to_amt') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TO_MINT
         description:  "{{ doc('swaps_to_mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SWAP_INDEX
         description: "{{ doc('swaps_swap_index') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter


### PR DESCRIPTION
- Add a recent date test filter for jupiter tests
  - There are 10 records with NULL `from_mint` and `from_amt` that are going to be ignored because the transaction does not match the account details for whatever reason (ie. jupiter says we are swapping from USDC, but the transfers are USDT)
    - [example](https://solscan.io/tx/4bsU1ex4Q3DuFgfikF93reWhL2FU3Mgx3w6SAhPsx44b976Js5LSgVYNeZPBubYfMbntSZmsNWo3cwBw4TAp6sV)
  - We don't need to test old records over and over
  
