### PR TITLE
increase Solanart recency test to 14 days

### DIFF
--- a/models/silver/nfts/silver__nft_sales_solanart.yml
+++ b/models/silver/nfts/silver__nft_sales_solanart.yml
@@ -13,7 +13,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 14
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
- Solanart hasnt seen a sale in a few days, but there's still some listing/delisting activity
- change recency test to 14 days and if no events then we can deprecate