### PR TITLE
reduce size per execution

### DIFF
--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -289,8 +289,8 @@
 {% endmacro %}
 
 {% macro decoded_instructions_backfill_calls() %}
-    {% set sql_limit = 100000000 %}
-    {% set producer_batch_size = 20000000 %}
+    {% set sql_limit = 20000000 %}
+    {% set producer_batch_size = 5000000 %}
     {% set worker_batch_size = 500000 %}
     {% set batch_call_limit = 1000 %}
 


### PR DESCRIPTION
- Reduce decoder backfill size per execution
  - The existing limits are no longer accurate due to the addition of `decoded_instructions_combined` which requires a join to `transactions`
  - non-core runs will still take longer but will stay under threshold of 30mins
  - This size was tested and comparison can be seen below
  
```
-- backfill causing long run time on decoded_instructions_combined
02:47:37  115 of 137 OK created sql incremental model silver.decoded_instructions_combined  [SUCCESS 100217842 in 2059.64s]
```

```
-- run time after size was reduced
14:20:12  46 of 137 OK created sql incremental model silver.decoded_instructions_combined  [SUCCESS 9600543 in 839.00s]
```

```
-- run time when no large backfill active
11:08:56  44 of 137 OK created sql incremental model silver.decoded_instructions_combined  [SUCCESS 4115519 in 175.71s]
```