### PR TITLE
take the first set if multiple inner swaps use jup agg

### DIFF
--- a/models/silver/swaps/silver__swaps_intermediate_jupiterv6.sql
+++ b/models/silver/swaps/silver__swaps_intermediate_jupiterv6.sql
@@ -36,6 +36,8 @@
             AND _inserted_timestamp :: DATE >= '2023-09-14'
             AND _inserted_timestamp :: DATE < '2023-09-30'
         {% endif %}
+        QUALIFY
+            row_number() OVER (PARTITION BY tx_id, index ORDER BY coalesce(inner_index,-1)) = 1
     {% endset %}
     {% do run_query(base_query) %}
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.swaps_intermediate_jupiterv6__intermediate_tmp","block_timestamp::date") %}


### PR DESCRIPTION
- Patch fix issue with multiple jupiter agg swap calls within a single instruction
  - Only output the 1st set of swaps in cases jupiter is called by a wrapper program

We currently have 4 instances of this happening, the qualify statement will remove these

```
-- count of jupiter swaps to be added to model before change
1035125

-- count after
1035120
```

Affected records now only output 1 row
<img width="1242" alt="Screenshot 2024-05-24 at 7 11 04 AM" src="https://github.com/FlipsideCrypto/solana-models/assets/97470747/65beb540-2ac7-4ecc-8595-066ac028f413">
