### PR TITLE
add succeeded column

### DIFF
--- a/models/silver/silver___post_token_balances.sql
+++ b/models/silver/silver___post_token_balances.sql
@@ -11,6 +11,7 @@ SELECT
     block_timestamp,
     block_id,
     tx_id,
+    succeeded,
     b.index,
     b.value :accountIndex :: INTEGER AS account_index,
     t.account_keys [account_index] :pubkey :: STRING AS account,

--- a/models/silver/silver___post_token_balances.yml
+++ b/models/silver/silver___post_token_balances.yml
@@ -24,6 +24,10 @@ models:
         description: "{{ doc('tx_id') }}"
         tests:
           - not_null
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null
       - name: INDEX
         description: Location of the post token balance entry within the array for a transaction
         tests: 

--- a/models/silver/silver___pre_token_balances.sql
+++ b/models/silver/silver___pre_token_balances.sql
@@ -11,6 +11,7 @@ SELECT
     block_timestamp,
     block_id,
     tx_id,
+    succeeded,
     b.index,
     b.value :accountIndex :: INTEGER AS account_index,
     t.account_keys [account_index] :pubkey :: STRING AS account,

--- a/models/silver/silver___pre_token_balances.yml
+++ b/models/silver/silver___pre_token_balances.yml
@@ -24,6 +24,10 @@ models:
         description: "{{ doc('tx_id') }}"
         tests:
           - not_null
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null
       - name: INDEX
         description: Location of the pre token balance entry within the array for a transaction
         tests: 


### PR DESCRIPTION
Add succeeded column to _pre_token_balances and _post_token_balances
- no impact on models referencing these tables
- will use ad-hoc query in SF to update historical records after column is added - ie:
```
UPDATE solana.silver._pre_token_balances a
SET a.succeeded = b.succeeded
FROM (
Select tx_id,succeeded from solana.silver.transactions
where block_timestamp::date = '2024-01-06'
) as b
WHERE a.tx_id = b.tx_id
and a.block_timestamp::date = '2024-01-06';
```