### PR TITLE
Encoded program data logs table

### DIFF
--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -57,6 +57,10 @@
             create_udf_get_account_pubkey_by_name(
             schema = "silver"
         ) }}
+        {{
+            create_udf_get_logs_program_data(
+            schema = "silver"
+        ) }}
         {% endset %}
         {% do run_query(sql) %}
     {% endif %}

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -305,30 +305,56 @@ handler = 'get_logs_program_data'
 as
 $$
 def get_logs_program_data(logs) -> list:
-    log_program_structure = []
-    program_data = []
-    current_index = -1
+    parent_program = ""
+    child_program = ""
+    parent_event_type = ""
+    child_event_type = ""
+    parent_index = -1
+    child_index = None
 
-    for log in logs:
+    for i, log in enumerate(logs):
         if log.endswith(" invoke [1]"):
-            current_program_id = log.replace("Program ","").replace(" invoke [1]","")
-            current_index += 1
-            log_program_structure.append(current_program_id)
-        
-        if log.endswith(" invoke [2]"):
-            inner_program_id = log.replace("Program ","").replace(" invoke [2]","")
-            log_program_structure.append(f"{current_program_id},{inner_program_id}")
-            current_program_id = inner_program_id
+            parent_program = log.replace("Program ","").replace(" invoke [1]","")
+            parent_index += 1
+            child_index = None
 
+            if logs[i+1].startswith("Program log: Instruction: "):
+                parent_event_type = logs[i+1].replace("Program log: Instruction: ","")
+            else:
+                parent_event_type = "UNKNOWN"
+        elif log.endswith(" invoke [2]"):
+            child_program = log.replace("Program ","").replace(" invoke [2]","")
+            child_index = child_index+1 if child_index is not None else 0
+
+            if logs[i+1].startswith("Program log: Instruction: "):
+                child_event_type = logs[i+1].replace("Program log: Instruction: ","")
+            else:
+                child_event_type = "UNKNOWN"
         
         if log.endswith(" success"):
-            current_program_id = log_program_structure[len(log_program_structure)-1]
-            if log_program_structure[len(log_program_structure)-1]:
-                current_program_id = current_program_id.split(",")[0]
-
+            current_program_id = child_program if child_program else parent_program
+            current_event_type = child_event_type if child_event_type else parent_event_type
+            current_index = parent_index
+            current_inner_index = child_index
+            if child_program:
+                child_program = ""
+            if child_event_type:
+                child_event_type = ""
+            if i+1 < len(logs) and not logs[i+1].endswith(" invoke [2]"):
+                child_index = None
+        else:
+            current_program_id = child_program if child_program else parent_program
+            current_event_type = child_event_type if child_event_type else parent_event_type
+            current_index = parent_index
+            current_inner_index = child_index
+        
         if log.startswith("Program data: "):
             data = log.replace("Program data: ","")
-            program_data.append({"data": data, "program_id": current_program_id, "index": current_index})
+            program_data.append({"data": data, 
+                                "program_id": current_program_id, 
+                                "index": current_index, 
+                                "inner_index": current_inner_index, 
+                                "event_type": current_event_type})
     
     return program_data if len(program_data) > 0 else None
 $$;

--- a/models/silver/program_logs/silver__transaction_logs_program_data.sql
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.sql
@@ -22,9 +22,9 @@ WITH base AS (
         succeeded
         {% if is_incremental() %}
         AND _inserted_timestamp >= (SELECT max(_inserted_timestamp) FROM {{ this }})
-        AND _inserted_timestamp < (SELECT max(_inserted_timestamp) + INTERVAL '1 DAY' FROM {{ this }})
+        AND _inserted_timestamp < (SELECT max(_inserted_timestamp) + INTERVAL '1 DAY' FROM {{ this }}) /* TODO remove when backfilled */
         {% else %}
-        AND _inserted_timestamp::date = '2024-05-20'
+        AND _inserted_timestamp::date = '2024-05-20' /* TODO change when ready to put on schedule */
         {% endif %}
 )
 select 

--- a/models/silver/program_logs/silver__transaction_logs_program_data.sql
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.sql
@@ -1,0 +1,49 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "transaction_logs_program_data_id",
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id)'),
+    merge_exclude_columns = ["inserted_timestamp"],
+) }}
+
+
+WITH base AS (
+    SELECT 
+        block_timestamp,
+        block_id,
+        tx_id,
+        succeeded,
+        silver.udf_get_logs_program_data(log_messages) AS program_data_logs,
+        _inserted_timestamp
+    FROM 
+        {{ ref('silver__transactions') }}
+    WHERE 
+        succeeded
+        {% if is_incremental() %}
+        AND _inserted_timestamp >= (SELECT max(_inserted_timestamp) FROM {{ this }})
+        AND _inserted_timestamp < (SELECT max(_inserted_timestamp) + INTERVAL '1 DAY' FROM {{ this }})
+        {% else %}
+        AND _inserted_timestamp::date = '2024-05-20'
+        {% endif %}
+)
+select 
+    t.block_timestamp,
+    t.block_id,
+    t.tx_id,
+    t.succeeded,
+    l.value:index::int as index,
+    l.index as log_index,
+    l.value:data::string as data,
+    l.value:program_id::string as program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id','index','log_index']
+    ) }} AS transaction_logs_program_data_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+from 
+    base t
+join 
+    table(flatten(program_data_logs)) l

--- a/models/silver/program_logs/silver__transaction_logs_program_data.sql
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.sql
@@ -20,11 +20,16 @@ WITH base AS (
         {{ ref('silver__transactions') }}
     WHERE 
         succeeded
+        
+
         {% if is_incremental() %}
-        AND _inserted_timestamp >= (SELECT max(_inserted_timestamp) FROM {{ this }})
-        AND _inserted_timestamp < (SELECT max(_inserted_timestamp) + INTERVAL '1 DAY' FROM {{ this }}) /* TODO remove when backfilled */
+            {% if execute %}
+            {{ get_batch_load_logic(this, 30, '2024-06-07') }}
+            {% endif %}
+        /* UNCOMMENT WHEN BACKFILLED 
+        AND _inserted_timestamp >= (SELECT max(_inserted_timestamp) FROM {{ this }}) */
         {% else %}
-        AND _inserted_timestamp::date = '2024-05-20' /* TODO change when ready to put on schedule */
+        AND _inserted_timestamp::date between '2022-08-12' and '2022-09-01'
         {% endif %}
 )
 SELECT 

--- a/models/silver/program_logs/silver__transaction_logs_program_data.yml
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.yml
@@ -1,0 +1,68 @@
+version: 2
+models:
+  - name: silver__transaction_logs_program_data
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: _inserted_timestamp >= current_date - 7  AND block_id > 39824213
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: LOG_INDEX
+        description: >
+          Position of program data log for a specific transaction.
+          Used to differentiate logs with the same index.
+        tests: 
+          - not_null: *recent_date_filter
+      - name: DATA
+        description: >
+          The encoded program data
+        tests: 
+          - not_null: *recent_date_filter
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null
+      - name: TRANSACTION_LOGS_PROGRAM_DATA_ID
+        description: '{{ doc("pk") }}'   
+        tests: 
+          - unique: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        tests: 
+          - not_null:
+              name: test_silver__not_null_transaction_logs_program_data__invocation_id
+              <<: *recent_date_filter


### PR DESCRIPTION
- Create UDF to get program data messages from log messages
- Add table to output encoded program data that is stored in the tx log messages
  - TXs with no such logs are excluded
  - Only successful txs
  - This will be used by streamline models for decoding logs
  - Purposely no schedule at this time

```
-- full refresh on M (1 day's worth of data)
14:33:25  1 of 1 OK created sql incremental model silver.transaction_logs_program_data ... [SUCCESS 1 in 111.63s]

-- incremental on M
14:42:36  1 of 15 OK created sql incremental model silver.transaction_logs_program_data .. [SUCCESS 5069080 in 48.27s]

-- tests pass on dev (except recency as expected)
14:49:08  Done. PASS=14 WARN=0 ERROR=1 SKIP=0 TOTAL=15
```