### PR TITLE
remove logs from workflow

### DIFF
--- a/.github/workflows/dbt_run_decode_instructions.yml
+++ b/.github/workflows/dbt_run_decode_instructions.yml
@@ -41,4 +41,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s models/streamline/decode_instructions/streamline__decode_instructions_2_realtime.sql models/streamline/decode_instructions/streamline__decode_logs_realtime.sql
+          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s models/streamline/decode_instructions/streamline__decode_instructions_2_realtime.sql


### PR DESCRIPTION
- Remove the current logs decoding path from workflows. Will be replaced soon w/ new pipeline

statement to remove decoded logs data from `decoded_instructions` and `decoded_instructions_combined`. Data is currently unused and will be re-decoded as we backfill using new pipeline
```
delete from solana.silver.decoded_instructions_combined
where program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
and event_type = 'SwapEvent';

delete from solana.silver.decoded_instructions
where program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
and decoded_instruction:name::string = 'SwapEvent';
```