### PR TITLE
Add b58 decoding to logs extraction udf

### DIFF
--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -341,6 +341,9 @@ def get_logs_program_data(logs) -> list:
     program_end_pattern = re.compile(r"Program ([a-zA-Z0-9]+) success")
     pattern = re.compile(r'invoke \[(?!1\])\d+\]')
 
+    if len(logs) == 1:
+        return None
+
     try:
         for i, log in enumerate(logs):
             if log == "Log truncated":

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -358,6 +358,18 @@ def get_logs_program_data(logs) -> list:
                     parent_event_type = "UNKNOWN"
 
                 current_ancestry = [(program,None,parent_event_type)]
+            elif log.startswith("Call BPF program "): # handle legacy BPF log format
+                program = log.replace("Call BPF program ","")
+                parent_index += 1
+
+                if i+1 < len(logs) and logs[i+1].startswith("Program log: Instruction: "):
+                    parent_event_type = logs[i+1].replace("Program log: Instruction: ","")
+                elif i+1 < len(logs) and logs[i+1].startswith("Program log: IX: "):
+                    parent_event_type = logs[i+1].replace("Program log: IX: ","")
+                else:
+                    parent_event_type = "UNKNOWN"
+
+                current_ancestry = [(program,None,parent_event_type)]
             elif bool(pattern.search(log)):
                 child_index = child_index+1 if child_index is not None else 0
                 current_program = pattern.sub('', log.replace("Program ","")).strip()

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -343,6 +343,9 @@ def get_logs_program_data(logs) -> list:
 
     try:
         for i, log in enumerate(logs):
+            if log == "Log truncated":
+                break
+
             if log.endswith(" invoke [1]"):
                 program = log.replace("Program ","").replace(" invoke [1]","")
                 parent_index += 1

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -358,8 +358,8 @@ def get_logs_program_data(logs) -> list:
                     parent_event_type = "UNKNOWN"
 
                 current_ancestry = [(program,None,parent_event_type)]
-            elif log.startswith("Call BPF program "): # handle legacy BPF log format
-                program = log.replace("Call BPF program ","")
+            elif log.startswith("Call BPF program ") or log.startswith("Upgraded program "): # handle legacy BPF log format
+                program = log.replace("Call BPF program ","").replace("Upgraded program ","")
                 parent_index += 1
 
                 if i+1 < len(logs) and logs[i+1].startswith("Program log: Instruction: "):

--- a/models/silver/program_logs/silver__transaction_logs_program_data.sql
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.sql
@@ -20,8 +20,8 @@ WITH base AS (
         {{ ref('silver__transactions') }}
     WHERE 
         succeeded
+        AND log_messages IS NOT NULL
         
-
         {% if is_incremental() %}
             {% if execute %}
             {{ get_batch_load_logic(this, 30, '2024-06-07') }}
@@ -29,7 +29,7 @@ WITH base AS (
         /* UNCOMMENT WHEN BACKFILLED 
         AND _inserted_timestamp >= (SELECT max(_inserted_timestamp) FROM {{ this }}) */
         {% else %}
-        AND _inserted_timestamp::date between '2022-08-12' and '2022-09-01'
+        AND _inserted_timestamp::date BETWEEN '2022-08-12' AND '2022-09-01'
         {% endif %}
 )
 SELECT 

--- a/models/silver/program_logs/silver__transaction_logs_program_data.yml
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.yml
@@ -44,6 +44,9 @@ models:
         description: "{{ doc('program_id') }}"
         tests: 
           - not_null: *recent_date_filter
+      - name: _UDF_ERROR
+        description: >
+          Error from `udf_get_logs_program_data` if unsuccessful
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/program_logs/silver__transaction_logs_program_data.yml
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.yml
@@ -47,6 +47,9 @@ models:
       - name: _UDF_ERROR
         description: >
           Error from `udf_get_logs_program_data` if unsuccessful
+        tests:
+          - dbt_expectations.expect_column_values_to_be_null:
+              row_condition: _inserted_timestamp >= current_date - 7
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
+++ b/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('silver__blocks') }}
 {{ config (
     materialized = "table",
     post_hook = if_data_call_function(


### PR DESCRIPTION
- Handle additional log extraction edge cases
  - Handle logs that end in `" success"` but are not actually program log end
  - Handle logs being truncated as last message
  - Handle logs being truncated but additional messages are rendered before it ends
  - Handle legacy BPG program log format
- Ignore txs with `NULL` log_messages in model
- Add `_udf_error` column to schema
- Fix missing doc ref comment for logs realtime query