### PR TITLE
tmp turn off null checks for to/from cols

### DIFF
--- a/models/silver/swaps/silver__swaps_intermediate_jupiterv6.yml
+++ b/models/silver/swaps/silver__swaps_intermediate_jupiterv6.yml
@@ -72,20 +72,20 @@ models:
               where: succeeded = TRUE AND _inserted_timestamp >= current_date - 7
       - name: FROM_AMT
         description:  "{{ doc('swaps_from_amt') }}"
-        tests: 
-          - not_null: *recent_date_filter
+        # tests: 
+        #   - not_null: *recent_date_filter
       - name: FROM_MINT
         description:  "{{ doc('swaps_from_mint') }}"
-        tests: 
-          - not_null: *recent_date_filter
+        # tests: 
+        #   - not_null: *recent_date_filter
       - name: TO_AMT
         description:  "{{ doc('swaps_to_amt') }}"
-        tests: 
-          - not_null: *recent_date_filter
+        # tests: 
+        #   - not_null: *recent_date_filter
       - name: TO_MINT
         description:  "{{ doc('swaps_to_mint') }}"
-        tests: 
-          - not_null: *recent_date_filter
+        # tests: 
+        #   - not_null: *recent_date_filter  # TEMPORARILY DISABLE, turn back on when inner swap events decoding is complete and this model is refactored
       - name: SWAP_INDEX
         description: "{{ doc('swaps_swap_index') }}"
         tests: 


### PR DESCRIPTION
- Temporarily turn these off while we work on logs decoding + model refactor. Low impact as these usually have to do with "odd" txs and affect < 10 txs