### PR TITLE
Streamline decoded logs backfill

### DIFF
--- a/.github/workflows/dbt_run_decode_logs_backfill.yml
+++ b/.github/workflows/dbt_run_decode_logs_backfill.yml
@@ -1,0 +1,45 @@
+name: dbt_run_decode_logs_backfill
+run-name: dbt_run_decode_logs_backfill
+
+on:
+  workflow_dispatch:
+    branches:
+      - "main"
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run-operation decoded_logs_backill_cleanup_views 
+          dbt run-operation decoded_logs_backfill_calls --vars '{"STREAMLINE_INVOKE_STREAMS": True}' 

--- a/.github/workflows/dbt_run_decode_logs_orchestrator.yml
+++ b/.github/workflows/dbt_run_decode_logs_orchestrator.yml
@@ -59,3 +59,8 @@ jobs:
         run: |
           dbt run-operation dispatch_github_workflow --args "{'workflow_name': 'dbt_run_decode_logs'}"
         if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJSON('["00", "30"]'), steps.capture_minute.outputs.formatted_minute) }}
+
+      - name: Run Backfill on minutes 45 every hour
+        run: |
+          dbt run-operation dispatch_github_workflow --args "{'workflow_name': 'dbt_run_decode_logs_backfill'}"
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJSON('["45"]'), steps.capture_minute.outputs.formatted_minute) }}

--- a/macros/helpers/decoded_logs_backfill_helpers.sql
+++ b/macros/helpers/decoded_logs_backfill_helpers.sql
@@ -1,0 +1,162 @@
+{% macro decoded_logs_backfill_generate_views(program_id, start_date, end_date, priority=None) %}
+    {% set get_block_id_range_query %}
+        SELECT 
+            min(block_id),
+            max(block_id)
+        FROM
+            {{ ref('silver__blocks') }}
+        WHERE
+            block_timestamp::date BETWEEN '{{ start_date }}' AND '{{ end_date }}'
+    {% endset %}
+    {% set range_results = run_query(get_block_id_range_query)[0] %}
+    
+    {% set min_block_id = range_results[0] %}
+    {% set max_block_id = range_results[1] %}
+    {% set step = 10000000 %}
+
+    {% for i in range(min_block_id, max_block_id, step) %}
+        {% if i == min_block_id %}
+            {% set start_block = i %}
+        {% else %}
+            {% set start_block = i+1 %}
+        {% endif %}
+
+        {% if i+step >= max_block_id %}
+            {% set end_block = max_block_id %}
+        {% else %}
+            {% set end_block = i+step %}
+        {% endif %}
+
+        {% set suffix %}
+            {%- if priority is none -%}
+                {{ '%011d' % start_block }}_{{ '%011d' % end_block }}_{{ program_id }}
+            {%- else -%}
+                {{ '%02d' % priority }}_{{ '%011d' % start_block }}_{{ '%011d' % end_block }}_{{ program_id }}
+            {%- endif -%}
+        {% endset %}
+
+        {% set query %}
+            CREATE OR REPLACE VIEW streamline.decoded_logs_backfill_{{ suffix }} AS 
+            WITH completed_subset AS (
+                SELECT
+                    block_id,
+                    program_id,
+                    complete_decoded_logs_id as id
+                FROM
+                    {{ ref('streamline__complete_decoded_logs') }}
+                WHERE
+                    program_id = '{{ program_id }}'
+                AND
+                    block_id BETWEEN {{ start_block }} AND {{ end_block }}
+            ),
+            event_subset AS (
+                SELECT
+                    i.value :programId :: STRING AS inner_program_id,
+                    e.tx_id,
+                    e.index,
+                    i.index AS inner_index,
+                    NULL AS log_index,
+                    i.value AS instruction,
+                    e.block_id,
+                    e.block_timestamp,
+                    {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','log_index','inner_program_id']) }} as id
+                FROM
+                    {{ ref('silver__events') }} e
+                JOIN
+                    table(flatten(e.inner_instruction:instructions)) i 
+                WHERE
+                    e.block_id between {{ start_block }} and {{ end_block }}
+                    AND e.succeeded
+                    AND e.program_id = '{{ program_id }}'
+                    AND inner_program_id = '{{ program_id }}'
+                    AND array_size(i.value:accounts::array) = 1
+                UNION ALL
+                SELECT 
+                    program_id,
+                    tx_id,
+                    index,
+                    inner_index,
+                    log_index,
+                    object_construct('accounts',[],'data',data,'programId',program_id) as instruction,
+                    block_id,
+                    block_timestamp,
+                    {{ dbt_utils.generate_surrogate_key(['block_id','tx_id','index','inner_index','log_index','program_id']) }} as id
+                FROM
+                    {{ ref('silver__transaction_logs_program_data') }} 
+                WHERE 
+                    block_id between {{ start_block }} and {{ end_block }}
+                    AND program_id = '{{ program_id }}'
+                    AND succeeded
+            )
+            SELECT 
+                e.inner_program_id as program_id,
+                e.tx_id,
+                e.index,
+                e.inner_index,
+                e.log_index,
+                e.instruction,
+                e.block_id,
+                e.block_timestamp
+            FROM
+                event_subset e
+            LEFT OUTER JOIN
+                completed_subset c
+                ON c.program_id = e.inner_program_id
+                AND c.block_id = e.block_id
+                AND c.id = e.id
+            WHERE
+                c.block_id IS NULL
+        {% endset %}
+
+        {% do run_query(query) %}
+    {% endfor %}
+{% endmacro %}
+
+{% macro decoded_logs_backill_cleanup_views() %}
+    {% set results = run_query("""select
+            table_schema,
+            table_name
+        from information_schema.views
+        where table_name like 'DECODED_LOGS_BACKFILL_%'
+        order by 2 desc
+        limit 1;""").columns %}
+    
+    {% set schema_names = results[0].values() %}
+    {% set table_names = results[1].values() %}
+    {% for table_name in table_names %}
+        {% set has_requests = run_query("""select 1 from """ ~ schema_names[0] ~ """.""" ~ table_name ~ """ limit 1""").columns[0].values()[0] %}
+        {% if not has_requests %}
+            {% do run_query("""drop view """ ~ schema_names[0] ~ """.""" ~ table_name) %}
+            {% do run_query("""insert into """ ~ ref('streamline__complete_decoded_logs_backfill') ~ """ values('""" ~ schema_names[0] ~ """','""" ~ table_name ~ """')""") %}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+
+{% macro decoded_logs_backfill_calls() %}
+    {% set sql_limit = 20000000 %}
+    {% set producer_batch_size = 5000000 %}
+    {% set worker_batch_size = 500000 %}
+    {% set batch_call_limit = 1000 %}
+
+    {% set results = run_query("""select
+            table_schema,
+            table_name
+        from information_schema.views
+        where table_name like 'DECODED_LOGS_BACKFILL_%'
+        except 
+        select 
+            schema_name,
+            table_name
+        from """ ~ ref('streamline__complete_decoded_logs_backfill') ~ """
+        order by 2 desc
+        limit 1;""").columns %}
+    {% set schema_names = results[0].values() %}
+    {% set table_names = results[1].values() %}
+    {% for table_name in table_names %}
+        {% set udf_call = if_data_call_function(
+        func = schema_names[0] ~ ".udf_bulk_instructions_decoder(object_construct('sql_source', '" ~ table_name ~ "', 'external_table', 'decoded_logs', 'sql_limit', '" ~ sql_limit ~ "', 'producer_batch_size', '" ~ producer_batch_size ~ "', 'worker_batch_size', '" ~ worker_batch_size ~ "', 'batch_call_limit', '" ~ batch_call_limit ~ "', 'call_type', 'backfill_logs'))",
+        target = schema_names[0] ~ "." ~ table_name) %}
+        
+        {% do run_query(udf_call) %}
+    {% endfor %}
+{% endmacro %}

--- a/models/streamline/decode_logs/streamline__complete_decoded_logs_backfill.sql
+++ b/models/streamline/decode_logs/streamline__complete_decoded_logs_backfill.sql
@@ -1,0 +1,10 @@
+{{ config (
+    materialized = 'incremental',
+    unique_key = 'table_name',
+    full_refresh = false,
+    tags = ['streamline_decoder_logs'],
+) }}
+
+select 
+    'placeholder'::string as schema_name,
+    'placeholder'::string as table_name


### PR DESCRIPTION
- Add decoded logs backfill helper macros
- Add decoded logs backfill workflow
- Add to orchestrator
- Add model to store completed views

Call in dev to decode 20M records
```
(dbt-env) dbt run-operation decoded_logs_backfill_calls --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -t dev
15:56:10  Running with dbt=1.7.4
15:56:11  Registered adapter: snowflake=1.7.0
15:56:11  Unable to do partial parsing because config vars, config profile, or config target have changed
15:56:20  Found 336 models, 1948 tests, 49 seeds, 11 operations, 5 analyses, 68 sources, 0 exposures, 0 metrics, 1087 macros, 0 groups, 0 semantic models
15:56:22  Running macro `if_data_call_function`: Calling udf STREAMLINE.udf_bulk_instructions_decoder(object_construct('sql_source', 'DECODED_LOGS_BACKFILL_00263254653_00270056081_JUP6LKBZBJS1JKKWAPDHNY74ZCZ3TLUZOI5QNYVTAV4', 'external_table', 'decoded_logs', 'sql_limit', '20000000', 'producer_batch_size', '5000000', 'worker_batch_size', '500000', 'batch_call_limit', '1000', 'call_type', 'backfill_logs')) on STREAMLINE.DECODED_LOGS_BACKFILL_00263254653_00270056081_JUP6LKBZBJS1JKKWAPDHNY74ZCZ3TLUZOI5QNYVTAV4
```

20M records in `streamline.solana_dev`
```
select count(*)
from streamline.solana_dev.decoded_logs
where _partition_by_created_date_hour >= current_date;
```