### PR TITLE
add recency tests

### DIFF
--- a/models/silver/validator/silver__snapshot_block_production.yml
+++ b/models/silver/validator/silver__snapshot_block_production.yml
@@ -19,8 +19,11 @@ models:
       - name: end_slot
         description: "Final slot of the epoch"
       - name: _inserted_timestamp
-        description: "The inserted timestamp"
+        description: "{{ doc('_inserted_timestamp') }}"
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
 
 

--- a/models/silver/validator/silver__snapshot_stake_accounts.yml
+++ b/models/silver/validator/silver__snapshot_stake_accounts.yml
@@ -39,6 +39,9 @@ models:
       - name: stake_pubkey
         description: "Address of stake account"
       - name: _inserted_timestamp
-        description: "The inserted timestamp"
+        description: "{{ doc('_inserted_timestamp') }}"
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: hour
+              interval: 12

--- a/models/silver/validator/silver__snapshot_validators_app_data.yml
+++ b/models/silver/validator/silver__snapshot_validators_app_data.yml
@@ -78,7 +78,10 @@ models:
         description: "validator.app score for Vote distance"
       - name: www_url
         description: "url for the validator"
-      - name: _INSERTED_TIMESTAMP
+      - name: _inserted_timestamp
         description: "{{ doc('_inserted_timestamp') }}"
-        tests: 
+        tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: hour
+              interval: 12

--- a/models/silver/validator/silver__snapshot_vote_accounts.yml
+++ b/models/silver/validator/silver__snapshot_vote_accounts.yml
@@ -65,3 +65,10 @@ models:
         description: "Public key for the vote account"
         tests:
           - not_null
+      - name: _inserted_timestamp
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: hour
+              interval: 12

--- a/models/silver/validator/silver__snapshot_vote_accounts_extended_stats.yml
+++ b/models/silver/validator/silver__snapshot_vote_accounts_extended_stats.yml
@@ -44,8 +44,11 @@ models:
         tests:
           - not_null
       - name: _inserted_timestamp
-        description: "The inserted timestamp"
+        description: "{{ doc('_inserted_timestamp') }}"
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
 
     


### PR DESCRIPTION
add recency test on `_inserted_timestamp` for validator tables
- data should be inserted for these models around 0 UTC daily via `dbt_run_daily` (except for block_production), so timing it with `dbt_test` run at 9am UTC
  - 12 hr test for `vote_accounts` + `stake_accounts` + `validators_app_data` - expect new records from latest run
  - 2 day test for `snapshot_vote_accounts_extended_stats` + `snapshot_block_production`