### PR TITLE
Cleanup/decrease test time and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ solana:
 ```
 
 ### Notes
-- `block_id` column in our data models matches what [Solcan](https://solscan.io/) classifies as `Block`.  This value is same as what is referred to as `Slot`.
+- `block_id` column in our data models matches what [Solscan](https://solscan.io/) classifies as `Block`.  This value is same as what is referred to as `Slot`.
 
 ### Resources:
 - Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)

--- a/models/descriptions/__overview__.md
+++ b/models/descriptions/__overview__.md
@@ -21,6 +21,7 @@ There is more information on how to use dbt docs in the last section of this doc
 
 **Core Dimension Tables:**
 - [dim_labels](#!/model/model.solana_models.core__dim_labels)
+- [dim_idls](#!/model/model.solana_models.core__dim_idls)
 
 **Core Fact Tables:**
 - [fact_blocks](#!/model/model.solana_models.core__fact_blocks)
@@ -28,17 +29,23 @@ There is more information on how to use dbt docs in the last section of this doc
 - [fact_transactions](#!/model/model.solana_models.core__fact_transactions)
 - [fact_transfers](#!/model/model.solana_models.core__fact_transfers)
 - [fact_decoded_instructions](#!/model/model.solana_models.core__fact_decoded_instructions)
+- [fact_token_account_owners](#!/model/model.solana_models.core__fact_token_account_owners)
 
 **Core Convenience Tables:**
 - [ez_signers](#!/model/model.solana_models.core__ez_signers)
 - [ez_events_decoded](#!/model/model.solana_models.core__ez_events_decoded)
 
 ### DeFi Tables (`Solana`.`DEFI`.`<table_name>`)
+- [ez_dex_swaps](#!/model/model.solana_models.defi__ez_dex_swaps)
 - [fact_liquidity_pool_actions](#!/model/model.solana_models.defi__fact_liquidity_pool_actions)
 - [fact_stake_pool_actions](#!/model/model.solana_models.defi__fact_stake_pool_actions)
 - [fact_swaps](#!/model/model.solana_models.defi__fact_swaps)
+- [fact_bridge_activity](#!/model/model.solana_models.defi__fact_bridge_activity)
+- [fact_token_burn_actions](#!/model/model.solana_models.defi__fact_token_burn_actions)
+- [fact_token_mint_actions](#!/model/model.solana_models.defi__fact_token_mint_actions)
 
 ### Governance Tables (`Solana`.`GOV`.`<table_name>`)
+- [dim_epoch](#!/model/model.solana_models.gov__dim_epoch)
 - [ez_staking_lp_actions](#!/model/model.solana_models.gov__ez_staking_lp_actions)
 - [fact_gauges_creates](#!/model/model.solana_models.gov__fact_gauges_create)
 - [fact_gauges_votes](#!/model/model.solana_models.gov__fact_gauges_votes)
@@ -51,17 +58,27 @@ There is more information on how to use dbt docs in the last section of this doc
 - [fact_block_production](#!/model/model.solana_models.gov__fact_block_production)
 - [fact_validators](#!/model/model.solana_models.gov__fact_validators)
 - [fact_votes_agg_block](#!/model/model.solana_models.gov__fact_votes_agg_block)
+- [fact_rewards_fees](#!/model/model.solana_models.gov__fact_rewards_fees)
+- [fact_rewards_rent](#!/model/model.solana_models.gov__fact_rewards_rent)
+- [fact_rewards_staking](#!/model/model.solana_models.gov__fact_rewards_staking)
+- [fact_rewards_voting](#!/model/model.solana_models.gov__fact_rewards_voting)
 
 ### NFT Tables (`Solana`.`NFT`.`<table_name>`)
 - [dim_nft_metadata](#!/model/model.solana_models.nft__dim_nft_metadata)
 - [fact_nft_mints](#!/model/model.solana_models.nft__fact_nft_mints)
 - [fact_nft_sales](#!/model/model.solana_models.nft__fact_nft_sales)
+- [fact_nft_burn_actions](#!/model/model.solana_models.nft__fact_nft_burn_actions)
+- [fact_nft_mint_actions](#!/model/model.solana_models.nft__fact_nft_mint_actions)
 
 ### Price Tables (`Solana`.`PRICE`.`<table_name>`)
 - [dim_asset_metadata](#!/model/model.solana_models.price__dim_asset_metadata)
 - [fact_prices_ohlc_hourly](#!/model/model.solana_models.price__fact_prices_ohlc_hourly)
 - [ez_asset_metadata](#!/model/model.solana_models.price__ez_asset_metadata)
 - [ez_prices_hourly](#!/model/model.solana_models.price__ez_prices_hourly)
+
+### Stats Tables (`Solana`.`STATS`.`<table_name>`)
+- [ez_core_metrics](#!/model/model.solana_models.stats__ez_core_metrics)
+
 
 ## **Data Model Overview**
 

--- a/models/gold/defi/defi__fact_swaps.yml
+++ b/models/gold/defi/defi__fact_swaps.yml
@@ -2,6 +2,9 @@ version: 2
 models:
   - name: defi__fact_swaps
     description: This table contains swaps performed on Jupiter, Orca, Raydium, Saber, Bonkswap, Dooar, Phoenix and Meteora swap programs. Intermediate swaps are aggregated over the DEX programs, so the values showcase the final mint/amount swap values. Ie. a swap on Jupiter that swaps SOL->USDC->mSOL->ETH would show the initial amount in and the final amount out of SOL->ETH. For Phoenix, we are not capturing swaps where there are separate transactions for placing the order and filling the order. 
+    recent_date_filter: &recent_date_filter
+      config:
+        where: inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -46,11 +49,11 @@ models:
       - name: SWAP_PROGRAM
         description: name of decentralized exchange used to perform the swap
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: _LOG_ID
         description: "Combination of TX_ID and event index"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: FACT_SWAPS_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP

--- a/models/silver/silver___inner_instructions.yml
+++ b/models/silver/silver___inner_instructions.yml
@@ -1,36 +1,38 @@
 version: 2
 models:
   - name: silver___inner_instructions
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null:
-              where: block_id > 39824213
+          - not_null: *recent_date_filter
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: Location of the inner_instruction within the inner_instructions of a transaction
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: MAPPED_INSTRUCTION_INDEX
         description: Specifies the instruction which this inner_instruction applies
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: VALUE
         description: json object that contains the inner instruction
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter

--- a/models/silver/silver___inner_instructions.yml
+++ b/models/silver/silver___inner_instructions.yml
@@ -35,4 +35,4 @@ models:
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 
-          - not_null: *recent_date_filter
+          - not_null

--- a/models/silver/tokens/silver__token_mint_actions.yml
+++ b/models/silver/tokens/silver__token_mint_actions.yml
@@ -9,6 +9,9 @@ models:
             - INNER_INDEX
             - MINT
           where: block_timestamp::date > current_date - 30
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -21,11 +24,11 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
@@ -33,26 +36,26 @@ models:
       - name: INDEX 
         description: "Location of the event within the instructions of a transaction"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INNER_INDEX 
         description: "Location of the event within the inner instructions of a transaction"
       - name: EVENT_TYPE 
         description: "{{ doc('event_type') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT 
         description: "{{ doc('mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT_AMOUNT
         description: Number of tokens burned
         tests: 
-          - not_null:
+          - not_null: *recent_date_filter
               where: event_type in ('mintToChecked', 'mintTo')
       - name: MINT_AUTHORITY
         description: Account address authorizing burn
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TOKEN_ACCOUNT
         description: The account address where tokens are minted to
       - name: SIGNERS
@@ -60,10 +63,10 @@ models:
       - name: DECIMAL
         description: "{{ doc('decimal') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT_STANDARD_TYPE
         description: "{{ doc('mint_standard_type') }}"
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter

--- a/models/silver/tokens/silver__token_mint_actions.yml
+++ b/models/silver/tokens/silver__token_mint_actions.yml
@@ -69,4 +69,4 @@ models:
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 
-          - not_null: *recent_date_filter
+          - not_null


### PR DESCRIPTION
- update and cleanup docs
- Use `recent_date_filter` on long-running tests
  - ie `PASS not_null_defi__fact_swaps_SWAP_PROGRAM ........................ [PASS in 12559.07s]` -> now `[PASS in 942.85s]`
  - `PASS not_null_silver___inner_instructions_VALUE .................... [PASS in 1843.08s]` -> now `[PASS in 261.95s]`