### PR TITLE
request log decode for jup6 swaps called by a diff program than jup6

### DIFF
--- a/macros/helpers/decoded_logs_backfill_helpers.sql
+++ b/macros/helpers/decoded_logs_backfill_helpers.sql
@@ -12,7 +12,7 @@
     
     {% set min_block_id = range_results[0] %}
     {% set max_block_id = range_results[1] %}
-    {% set step = 10000000 %}
+    {% set step = 2000000 %}
 
     {% for i in range(min_block_id, max_block_id, step) %}
         {% if i == min_block_id %}
@@ -67,7 +67,7 @@
                 WHERE
                     e.block_id between {{ start_block }} and {{ end_block }}
                     AND e.succeeded
-                    AND e.program_id = '{{ program_id }}'
+                    AND array_contains('{{ program_id }}'::variant, e.inner_instruction_program_ids)
                     AND inner_program_id = '{{ program_id }}'
                     AND array_size(i.value:accounts::array) = 1
                 UNION ALL

--- a/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
+++ b/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
@@ -49,7 +49,7 @@ event_subset AS (
     WHERE
         e.block_timestamp >= CURRENT_DATE - 2   
         AND e.succeeded
-        AND ARRAY_CONTAINS('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'::variant, e.inner_instruction_program_ids)
+        AND array_contains('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'::variant, e.inner_instruction_program_ids)
         AND inner_program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
         AND array_size(i.value:accounts::array) = 1
     UNION ALL

--- a/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
+++ b/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
@@ -49,7 +49,7 @@ event_subset AS (
     WHERE
         e.block_timestamp >= CURRENT_DATE - 2   
         AND e.succeeded
-        AND e.program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
+        AND ARRAY_CONTAINS('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'::variant, e.inner_instruction_program_ids)
         AND inner_program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
         AND array_size(i.value:accounts::array) = 1
     UNION ALL


### PR DESCRIPTION
- Modify realtime and backfill queries so that jupiterv6 swaps initiated by a different program than jupiterv6 are still sent for decoding
- Decrease backfill step size