### PR TITLE
recency test on inserted_timestamp

### DIFF
--- a/models/silver/validator/silver__snapshot_stake_accounts.yml
+++ b/models/silver/validator/silver__snapshot_stake_accounts.yml
@@ -42,6 +42,9 @@ models:
         description: "{{ doc('_inserted_timestamp') }}"
         tests:
           - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        tests: 
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: hour
               interval: 12

--- a/models/silver/validator/silver__snapshot_validators_app_data.yml
+++ b/models/silver/validator/silver__snapshot_validators_app_data.yml
@@ -82,6 +82,9 @@ models:
         description: "{{ doc('_inserted_timestamp') }}"
         tests:
           - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        tests: 
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: hour
               interval: 12

--- a/models/silver/validator/silver__snapshot_vote_accounts.yml
+++ b/models/silver/validator/silver__snapshot_vote_accounts.yml
@@ -69,6 +69,9 @@ models:
         description: "{{ doc('_inserted_timestamp') }}"
         tests:
           - not_null
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        tests: 
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: hour
               interval: 12


### PR DESCRIPTION
change recency test to be on inserted_timestamp. New records won't always be grabbed during the runs but we expect the runs to update the inserted_timestamp each time.
