### PR TITLE
decoded metadata and update inner jup swaps model

### DIFF
--- a/models/silver/metadata/silver__decoded_metadata.sql
+++ b/models/silver/metadata/silver__decoded_metadata.sql
@@ -1,0 +1,108 @@
+-- depends_on: {{ ref('silver__mint_actions') }}
+
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['decoded_metadata_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    merge_exclude_columns = ["inserted_timestamp"],
+    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+    tags = ['scheduled_non_core']
+) }}
+
+{% if execute %}
+    {% set base_query %}
+    CREATE
+    OR REPLACE temporary TABLE silver.decoded_metadata__intermediate_tmp AS
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__mint_actions') }}
+    WHERE
+        event_type IN (
+            'initializeMint',
+            'initializeMint2'
+        )
+        AND succeeded
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '1 hour'
+    FROM
+        {{ this }}
+)
+{% else %}
+    AND _inserted_timestamp :: DATE >= '2022-08-12'
+{% endif %}
+
+{% endset %}
+{% do run_query(base_query) %}
+{% set between_stmts = fsc_utils.dynamic_range_predicate(
+    "silver.decoded_metadata__intermediate_tmp",
+    "block_timestamp::date"
+) %}
+{% endif %}
+
+WITH base_mints AS (
+    SELECT
+        *
+    FROM
+        silver.decoded_metadata__intermediate_tmp
+),
+base_decoded AS (
+    SELECT
+        *
+    FROM
+        {{ ref('silver__decoded_instructions_combined') }}
+    WHERE
+        succeeded
+        AND program_id = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
+        AND {{ between_stmts }}
+),
+metadata AS (
+    SELECT
+        *,
+        silver.udf_get_account_pubkey_by_name(
+            'mint',
+            decoded_instruction :accounts
+        ) :: STRING AS mint,
+        decoded_instruction :args :createMetadataAccountArgsV3 :data :name :: STRING AS token_name,
+        decoded_instruction :args :createMetadataAccountArgsV3 :data :symbol :: STRING AS symbol
+    FROM
+        base_decoded
+    WHERE
+        event_type = 'CreateMetadataAccountV3'
+    UNION ALL
+    SELECT
+        *,
+        silver.udf_get_account_pubkey_by_name(
+            'mint',
+            decoded_instruction :accounts
+        ) :: STRING AS mint,
+        decoded_instruction :args :createArgs :V1 :assetData :name :: STRING AS token_name,
+        decoded_instruction :args :createArgs :V1 :assetData :symbol :: STRING AS symbol
+    FROM
+        base_decoded
+    WHERE
+        event_type = 'Create'
+)
+SELECT
+    A.block_timestamp,
+    A.block_id,
+    A.tx_id,
+    A.mint,
+    A.decimal,
+    b.token_name,
+    b.symbol,
+    a._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['a.mint']) }} AS decoded_metadata_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    base_mints A
+    LEFT JOIN metadata b
+    ON A.mint = b.mint
+qualify(ROW_NUMBER() over (PARTITION BY a.mint ORDER BY a._inserted_timestamp DESC)) = 1
+

--- a/models/silver/metadata/silver__decoded_metadata.yml
+++ b/models/silver/metadata/silver__decoded_metadata.yml
@@ -1,0 +1,62 @@
+version: 2
+models:
+  - name: silver__decoded_metadata
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - MINT
+          where: block_timestamp::date > current_date - 30
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null: *recent_date_filter
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: DECIMAL
+        description: "{{ doc('decimal') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: TOKEN_NAME
+        description: "Name of the token"
+      - name: SYMBOL
+        description: "Symbol of the token"
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
+          - not_null
+      - name: DECODED_METADATA_ID
+        description: '{{ doc("pk") }}' 
+        tests: 
+          - unique: *recent_date_filter  
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'  
+        tests: 
+          - not_null: *recent_date_filter 
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        tests: 
+          - not_null: 
+              name: test_silver__not_null_decoded_metadata__invocation_id
+              <<: *recent_date_filter
+   

--- a/models/silver/swaps/jupiter/v6/silver__swaps_inner_intermediate_jupiterv6.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_inner_intermediate_jupiterv6.sql
@@ -127,33 +127,12 @@ swappers AS (
     QUALIFY
         row_number() OVER (PARTITION BY tx_id, index, coalesce(inner_index, -1) ORDER BY _inserted_timestamp DESC) = 1
 ),
-distinct_mints AS (
-    SELECT DISTINCT
-        mint
-    FROM (
-        SELECT DISTINCT
-            from_mint AS mint
-        FROM
-            base
-        UNION ALL 
-        SELECT DISTINCT
-            to_mint
-        FROM
-            base
-    )
-),
 token_decimals AS (
-    SELECT DISTINCT
+    SELECT 
         mint,
         decimal
     FROM
-        {{ ref('silver__mint_actions') }}
-    INNER JOIN
-        distinct_mints
-        USING(mint)
-    WHERE
-        succeeded
-        AND decimal IS NOT NULL
+        {{ ref('silver__decoded_metadata') }}
     UNION ALL 
     SELECT 
         'So11111111111111111111111111111111111111112',


### PR DESCRIPTION
- Create `silver__decoded_metadata` table containing decimal and available metadata for tokens
   - [design diagram](https://www.figma.com/board/HmO4271WUo9ZBxII13m1vO/native_metadata?node-id=0-1&t=2Oq12j3IyszMgilt-0)
- update `silver__swaps_inner_intermediate_jupiterv6` to use new table = now runs in 1/3rd of the time
   - existing model runtime: `[SUCCESS 339299 in 180.25s]`
   - updated model runtime: `[SUCCESS 339299 in 53.32s]`

```
Full test (without recency filters)

Finished running 5 tests, 11 hooks in 0 hours 0 minutes and 19.05 seconds (19.05s). 
Completed successfully 
Done. PASS=5 WARN=0 ERROR=0 SKIP=0 TOTAL=5

Incremental

1 of 1 OK created sql incremental model silver.decoded_metadata ................ [SUCCESS 6250 in 12.73s]

FR on 2xl

1 of 1 OK created sql incremental model silver.decoded_metadata ................ [SUCCESS 1 in 62.22s]
```

