### PR TITLE
spread work across more workers

### DIFF
--- a/macros/helpers/decoded_logs_backfill_helpers.sql
+++ b/macros/helpers/decoded_logs_backfill_helpers.sql
@@ -133,9 +133,9 @@
 {% endmacro %}
 
 {% macro decoded_logs_backfill_calls() %}
-    {% set sql_limit = 20000000 %}
-    {% set producer_batch_size = 5000000 %}
-    {% set worker_batch_size = 500000 %}
+    {% set sql_limit = 18000000 %} /* TODO switch this back to 20000000 after phoenix logs backfill completed */
+    {% set producer_batch_size = 6000000 %} /* TODO switch this back to 5000000 after phoenix logs backfill completed */
+    {% set worker_batch_size = 150000 %} /* TODO switch this back to 500000 after phoenix logs backfill completed */
     {% set batch_call_limit = 1000 %}
 
     {% set results = run_query("""select


### PR DESCRIPTION
- Based on testing at scale in dev, the phoenix log decoding backfill takes longer to run per instruction so we need to spread the work across more workers
  - This is expected. We basically have to run the decoder twice per instruction (one time to get the # of fields in args since it's dynamic, then a second time to do the actual decoding)
  - Sample [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsolana-api-dev-WorkerLogsDecoderBackfill-jeB7VB9ug0tQ/log-events/2024$252F07$252F12$252F$255B$2524LATEST$255D027b4e25b4d44ecc8398511364a77967) with the updated values
- This is a temporary change and we can revert back to original values once the backfill is doen