### PR TITLE
refactor incremental to use dynamically generated string literals for pruning

### DIFF
--- a/models/silver/silver__blocks.sql
+++ b/models/silver/silver__blocks.sql
@@ -7,48 +7,42 @@
   full_refresh = false
 ) }}
 
-{% if is_incremental() %}
-WITH last_loaded_timestamp AS (
+{% if execute %}
+  {% set max_inserted_query %}
   SELECT
-    COALESCE(MAX(_inserted_timestamp), '2022-08-12T00:00:00' :: timestamp_ntz) AS max_inserted_timestamp
+      MAX(_inserted_timestamp) AS _inserted_timestamp
   FROM
     {{ this }}
-),
-base_blocks AS (
-  SELECT
-    *
-  FROM
-    {{ ref('bronze__blocks2') }}
-  WHERE
-    _inserted_date >= (
+  {% endset %}
+  {% set max_inserted_timestamp = run_query(max_inserted_query).columns[0].values()[0] %}
+
+  {% if is_incremental() %}
+  {% set get_dates_to_load_query %}
+    WITH base_blocks AS (
       SELECT
-        DATEADD(
-          'day',
-          -1,
-          max_inserted_timestamp :: DATE
-        )
+        *
       FROM
-        last_loaded_timestamp
+        {{ ref('bronze__blocks2') }}
+      WHERE
+        _inserted_date >= '{{max_inserted_timestamp}}'::date - INTERVAL '1 DAY'
     )
-),
-next_date_to_load AS (
-  SELECT
-    MIN(_inserted_timestamp) AS load_timestamp,
-    MIN(_inserted_date) AS load_date
-  FROM
-    base_blocks
-  WHERE
-    _inserted_timestamp > (
-      SELECT
-        max_inserted_timestamp
-      FROM
-        last_loaded_timestamp
-    )
-),
-{% else %}
-WITH
+    SELECT
+      MIN(_inserted_timestamp) AS load_timestamp,
+      MIN(_inserted_date) AS load_date
+    FROM
+      base_blocks
+    WHERE
+      _inserted_timestamp > '{{max_inserted_timestamp}}'
+  {% endset %}
+
+  {% set get_dates_to_load_columns = run_query(get_dates_to_load_query).columns %}
+  {% set load_timestamp = get_dates_to_load_columns[0].values()[0] %}
+  {% set load_date = get_dates_to_load_columns[1].values()[0] %}
+  {% endif %}
 {% endif %}
-pre_final AS (
+
+
+WITH pre_final AS (
   SELECT
     VALUE :block_id :: INTEGER AS block_id,
     TO_TIMESTAMP_NTZ(
@@ -63,39 +57,17 @@ pre_final AS (
     _inserted_date,
     _inserted_timestamp
   FROM
-    {% if is_incremental() %}
-      base_blocks
-    {% else %}
-      {{ ref('bronze__blocks2') }}
-    {% endif %}
+    {{ ref('bronze__blocks2') }}
   WHERE
     block_id IS NOT NULL
     AND error IS NULL
-
-{% if is_incremental() %}
-AND _inserted_date = (
-  SELECT
-    load_date
-  FROM
-    next_date_to_load
-  LIMIT
-    1
-)
-AND _inserted_timestamp >= (
-  SELECT
-    load_timestamp
-  FROM
-    next_date_to_load
-  LIMIT
-    1
-)
-{% else %}
-  AND _inserted_date = '2022-08-12'
-{% endif %}
-
-qualify(ROW_NUMBER() over(PARTITION BY block_id
-ORDER BY
-  _inserted_date DESC)) = 1
+    {% if is_incremental() %}
+    AND _inserted_date = '{{load_date}}'
+    AND _inserted_timestamp >= '{{load_timestamp}}'
+    {% else %}
+    AND _inserted_date = '2022-08-12'
+    {% endif %}
+  qualify(ROW_NUMBER() over(PARTITION BY block_id ORDER BY _inserted_date DESC)) = 1
 )
 SELECT
   block_id,


### PR DESCRIPTION
- Use generated static timestamp/date values for query pruning in incremental logic
- Tested by compiling with `-t prod` so that it looks at the realtime streamline data
  `dbt compile -s models/silver/silver__blocks.sql -t prod` 
  - Took the output and ran it in snowflake

<img width="1472" alt="Screenshot 2024-07-12 at 9 42 42 AM" src="https://github.com/user-attachments/assets/b50698ce-04b8-4532-8301-b49684cb6818">
