### PR TITLE
refactor logic to use new passthrough data, make backwards compatible

### DIFF
--- a/models/silver/parser/silver__decoded_logs.sql
+++ b/models/silver/parser/silver__decoded_logs.sql
@@ -15,6 +15,9 @@
     tags = ['scheduled_non_core']
 ) }}
 
+{% set CUTOVER_DATETIME = modules.datetime.datetime.strptime("2024-07-16 17:00:00", "%Y-%m-%d %H:%M:%S") %}
+{% set use_legacy_logic = False %}
+
 /* run incremental timestamp value first then use it as a static value */
 {% if execute %}
     {% if is_incremental() %}
@@ -28,38 +31,43 @@
         {% set max_inserted_timestamp = run_query(max_inserted_query).columns[0].values()[0] %}
     {% endif %}
 
-    {% set create_tmp_query %}
-        CREATE OR REPLACE TEMPORARY TABLE silver.decoded_logs__intermediate_tmp AS
-        SELECT
-            block_timestamp,
-            block_id,
-            tx_id,
-            index,
-            inner_index,
-            log_index,
-            program_id,
-            data,
-            _inserted_timestamp,
-        FROM
+    {% if max_inserted_timestamp.replace(tzinfo=None) < CUTOVER_DATETIME %}
+        {% set use_legacy_logic = True %}
+        {% set create_tmp_query %}
+            CREATE OR REPLACE TEMPORARY TABLE silver.decoded_logs__intermediate_tmp AS
+            SELECT
+                block_timestamp,
+                block_id,
+                tx_id,
+                index,
+                inner_index,
+                log_index,
+                program_id,
+                data,
+                _inserted_timestamp,
+            FROM
+                {% if is_incremental() %}
+                {{ ref('bronze__streamline_decoded_logs') }} A
+                {% else %}
+                {{ ref('bronze__streamline_FR_decoded_logs') }} A
+                {% endif %}
+            JOIN
+                {{ ref('silver__blocks') }}
+                USING(block_id)
             {% if is_incremental() %}
-            {{ ref('bronze__streamline_decoded_logs') }} A
-            {% else %}
-            {{ ref('bronze__streamline_FR_decoded_logs') }} A
+            WHERE
+                A._inserted_timestamp >= '{{ max_inserted_timestamp }}'
+                AND A._partition_by_created_date_hour >= dateadd('hour', -2, date_trunc('hour','{{ max_inserted_timestamp }}'::timestamp_ntz))
             {% endif %}
-        JOIN
-            {{ ref('silver__blocks') }}
-            USING(block_id)
-        {% if is_incremental() %}
-        WHERE
-            A._inserted_timestamp >= '{{ max_inserted_timestamp }}'
-            AND A._partition_by_created_date_hour >= dateadd('hour', -2, date_trunc('hour','{{ max_inserted_timestamp }}'::timestamp_ntz))
-        {% endif %}
-    {% endset %}
-    {% do run_query(create_tmp_query) %}
+        {% endset %}
+        {% do run_query(create_tmp_query) %}
 
-    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.decoded_logs__intermediate_tmp","block_timestamp::date") %}
+        {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.decoded_logs__intermediate_tmp","block_timestamp::date") %}
+    {% endif %}
+
 {% endif %}
 
+{% if use_legacy_logic %}
 WITH txs AS (
     SELECT
         block_timestamp,
@@ -100,3 +108,35 @@ QUALIFY
         PARTITION BY decoded_logs_id
         ORDER BY d._inserted_timestamp DESC
     ) = 1
+{% else %}
+SELECT
+    value:request_data:block_timestamp::timestamp_ntz AS block_timestamp,
+    block_id,
+    tx_id,
+    index,
+    inner_index,
+    log_index,
+    value:request_data:signers::array AS signers,
+    value:request_data:succeeded::boolean AS succeeded,
+    program_id,
+    data AS decoded_log,
+    decoded_log:name::string AS event_type,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['tx_id', 'index', 'inner_index','log_index']) }} AS decoded_logs_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    {% if is_incremental() %}
+    {{ ref('bronze__streamline_decoded_logs') }}
+    {% else %}
+    {{ ref('bronze__streamline_FR_decoded_logs') }}
+    {% endif %}
+{% if is_incremental() %}
+WHERE
+    _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+    AND _partition_by_created_date_hour >= dateadd('hour', -2, date_trunc('hour','{{ max_inserted_timestamp }}'::timestamp_ntz))
+{% endif %}
+QUALIFY
+    row_number() OVER (PARTITION BY decoded_logs_id ORDER BY _inserted_timestamp DESC) = 1
+{% endif %}

--- a/models/silver/parser/silver__decoded_logs.sql
+++ b/models/silver/parser/silver__decoded_logs.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('silver__blocks') }}
+-- depends_on: {{ ref('silver__transactions') }}
 -- depends_on: {{ ref('bronze__streamline_decoded_logs') }}
 -- depends_on: {{ ref('bronze__streamline_FR_decoded_logs') }}
 {{ config(


### PR DESCRIPTION
- Use new metadata for column values so we don't have to do joins to `silver.blocks` or `silver.transactions`
  - This will improve performance overall but specifically backfill performance when we have to do larger lookbacks
  - This is backwards compatible in case there is a need to re-run the model for older dates
- I spoofed the cutover date to test the backwards compatibility
  - [Query](https://app.snowflake.com/zsniary/exa10207/#/compute/history/queries/01b5bb03-0506-9dc0-3d4f-83023c3a680b/detail?autoRefreshInSeconds=0) that creates the tmp table query to get `between_stmts` 
  - [Query](https://app.snowflake.com/zsniary/exa10207/#/compute/history/queries/01b5bb03-0506-8b9f-3d4f-83023c3a5b7f/detail?autoRefreshInSeconds=0) running old model logic that uses join to `silver.transactions`
  
  
```
-- incremental on M
14:17:31  1 of 1 OK created sql incremental model silver.decoded_logs .................... [SUCCESS 398117 in 14.56s]

-- new data visible in dev
select *
from solana_dev.silver.decoded_logs
where _inserted_timestamp > '2024-07-17 12:11:05';
```
