### PR TITLE
add test for missing instructions/inner_instructions

### DIFF
--- a/models/silver/silver__transactions.yml
+++ b/models/silver/silver__transactions.yml
@@ -49,6 +49,16 @@ models:
         description: List of pre-transaction token balances for different token accounts
       - name: POST_TOKEN_BALANCES
         description: List of post-transaction token balances for different token accounts
+      - name: INSTRUCTIONS
+        description: "{{ doc('instruction') }}"
+        tests: 
+          - not_null:
+              where: block_timestamp::date > current_date - 30
+      - name: INNER_INSTRUCTIONS
+        description: "{{ doc('inner_instruction') }}"
+        tests: 
+          - not_null:
+              where: block_timestamp::date > current_date - 30
       - name: LOG_MESSAGES
         description: Array of log messages written by the program for this transaction
       - name: ADDRESS_TABLE_LOOKUPS


### PR DESCRIPTION
- Add `silver.transactions` test for `null` instructions 
- Add `silver.transactions` test for `null` inner_instructions 

Tests added to identify potential issues with raw data. This hasn't occurred since 2022 so it feels like overkill to add this to "self-healing" streamline requests as the addition would add some substantial run time to the existing process. 

```
15:25:10  5 of 14 PASS not_null_silver__transactions_INNER_INSTRUCTIONS .................. [PASS in 115.66s]
15:25:46  6 of 14 PASS not_null_silver__transactions_INSTRUCTIONS ........................ [PASS in 151.16s]
```