### PR TITLE
adjust dates for some tests for older txs

### DIFF
--- a/models/silver/balances/silver__token_balances.yml
+++ b/models/silver/balances/silver__token_balances.yml
@@ -50,12 +50,18 @@ models:
         description:  "{{ doc('token_balances_pre_owner') }}"
         tests: 
           - not_null:
-              where: pre_token_amount <> 0 and _inserted_timestamp >= current_date - 7
+              where: >
+                pre_token_amount <> 0 
+                AND _inserted_timestamp >= current_date - 7
+                AND block_timestamp::date > '2021-12-14' /* token ownership is not provided in the raw data before this date */
       - name: POST_OWNER
         description:  "{{ doc('token_balances_post_owner') }}"
         tests: 
           - not_null:
-              where: post_token_amount <> 0 and _inserted_timestamp >= current_date - 7
+              where: >
+                post_token_amount <> 0 
+                AND _inserted_timestamp >= current_date - 7
+                AND block_timestamp::date > '2021-12-14' /* token ownership is not provided in the raw data before this date */
       - name: PRE_TOKEN_AMOUNT
         description: "{{ doc('balances_pre_amount') }}"
         tests: 

--- a/models/silver/program_logs/silver__transaction_logs_program_data.yml
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.yml
@@ -5,7 +5,7 @@ models:
       config:
         where: >
           _inserted_timestamp >= current_date - 7 
-          AND block_id > 127221709
+          AND block_id > 127221709 /* some legacy logs decoding format not handled, not compatible with new */
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -51,7 +51,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_null:
               row_condition: >
                 _inserted_timestamp >= current_date - 7
-                AND block_id > 127221709
+                AND block_id > 127221709 /* some legacy logs decoding format not handled, not compatible with new */
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/program_logs/silver__transaction_logs_program_data.yml
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.yml
@@ -3,13 +3,15 @@ models:
   - name: silver__transaction_logs_program_data
     recent_date_filter: &recent_date_filter
       config:
-        where: _inserted_timestamp >= current_date - 7
+        where: >
+          _inserted_timestamp >= current_date - 7 
+          AND block_id > 127221709
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null:
-              where: _inserted_timestamp >= current_date - 7  AND block_id > 39824213
+              where: _inserted_timestamp >= current_date - 7 AND block_id > 39824213
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
@@ -47,7 +49,9 @@ models:
           Error from `udf_get_logs_program_data` if unsuccessful
         tests:
           - dbt_expectations.expect_column_values_to_be_null:
-              row_condition: _inserted_timestamp >= current_date - 7
+              row_condition: >
+                _inserted_timestamp >= current_date - 7
+                AND block_id > 127221709
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/stats/silver__core_metrics_hourly.yml
+++ b/models/silver/stats/silver__core_metrics_hourly.yml
@@ -57,7 +57,9 @@ models:
                 - FLOAT
       - name: TOTAL_FEES
         tests:
-          - not_null
+          - not_null:
+              where:
+                block_timestamp_hour::date > '2020-03-16' /* ignore first set of metrics */
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - DECIMAL


### PR DESCRIPTION
- Ignore older block timestamps for certain tests that started failing due to backfill of blocks that were missing inner_instructions data

`dbt test -s silver__core_metrics_hourly.sql silver__token_balances silver__transaction_logs_program_data -t prod`
```
14:40:15  Finished running 53 tests, 11 hooks in 0 hours 6 minutes and 10.01 seconds (370.01s).
14:40:15  
14:40:15  Completed successfully
14:40:15  
14:40:15  Done. PASS=53 WARN=0 ERROR=0 SKIP=0 TOTAL=53
```