### PR TITLE
Hotfix solana txs votes

### DIFF
--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -128,10 +128,20 @@ qualifying_transactions AS (
         (
         coalesce(instructions [0] :programId :: STRING,'') <> 'Vote111111111111111111111111111111111111111'
         OR
+        /* small amount of txs have non-compute instructions after the vote */
         i.value:programId::string NOT IN ('Vote111111111111111111111111111111111111111','ComputeBudget111111111111111111111111111111')
     )
     GROUP BY 1
     HAVING array_size(program_ids) > 0
+    UNION ALL
+    /* some txs have no instructions at all, this is being filtered out above so we need to make sure we grab these */
+    SELECT
+        tx_id,
+        null
+    FROM
+        pre_final
+    WHERE
+        array_size(instructions) = 0
 )
 SELECT
     block_timestamp,


### PR DESCRIPTION
- Modify `silver.transactions` logic to handle txs that could have non-vote/non-compute instructions within a vote transaction

To reconcile I ran a few partitions through both the existing and new model logic. These vote txs with non-vote instructions are rare so the expectation would be for these 2 versions to produce no diffs of the new one to have slightly more (1 to 2 txs). In the real-time samples I tested, they produced no diffs. In the partition where I know one of these existed, they produced the expected diff.

<img width="1449" alt="Screenshot 2024-07-23 at 8 37 10 AM" src="https://github.com/user-attachments/assets/8fa51cb5-348d-4707-ac6d-a6bd68610562">
<img width="1121" alt="Screenshot 2024-07-23 at 8 43 05 AM" src="https://github.com/user-attachments/assets/31c40104-817a-40de-8a09-3f1a1bd3e793">
<img width="1167" alt="Screenshot 2024-07-23 at 8 44 29 AM" src="https://github.com/user-attachments/assets/a6001dac-f246-4b34-befb-374cb5d8fd1a">

Also there does not seem to be any noticeable performance degradation for runtime (expected 1-2mins)

<img width="311" alt="Screenshot 2024-07-23 at 8 38 58 AM" src="https://github.com/user-attachments/assets/609c7ace-5580-4493-a995-39017cf69196">
