### PR TITLE
remove the test

### DIFF
--- a/.github/workflows/dbt_test.yml
+++ b/.github/workflows/dbt_test.yml
@@ -42,4 +42,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt test -s "solana_models,./models" "solana_models,tag:test_daily" --exclude tag:test_weekly tag:test_hourly
+          dbt test -s "solana_models,./models" "solana_models,tag:test_daily" --exclude tag:test_weekly tag:test_hourly "test_silver__transactions_missing_partitions"


### PR DESCRIPTION
- Remove this test, the newer solscan blocks tests already cover this and is able to self-recover unlike this test.