### PR TITLE
refactor token account ownership to not use intermediate layer

### DIFF
--- a/.github/workflows/dbt_run_token_account_owners_2.yml
+++ b/.github/workflows/dbt_run_token_account_owners_2.yml
@@ -1,0 +1,46 @@
+name: dbt_run_token_account_owners_2
+run-name: dbt_run_token_account_owners_2
+
+on:
+  workflow_dispatch:
+    branches:
+      - "main"
+  schedule:
+    - cron: '11,41 * * * *'
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -s "solana_models,tag:token_account_owners_2"

--- a/models/silver/accounts/silver__token_account_owners_2.sql
+++ b/models/silver/accounts/silver__token_account_owners_2.sql
@@ -1,0 +1,139 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = "delete+insert",
+    incremental_predicates = ['min_value_predicate', 'start_block_id', generate_view_name(this) ~ ".start_block_id >= " ~ generate_tmp_view_name(this) ~ ".start_block_id"],
+    unique_key = ["account_address"],
+    cluster_by = ["round(start_block_id,-5)"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(account_address, owner)'),
+    tags = ['token_account_owners_2']
+) }}
+
+
+WITH new_events AS (
+    SELECT 
+        account_address, 
+        owner, 
+        block_id AS start_block_id,
+        CASE 
+            WHEN event_type IN ('create','createIdempotent','createAccount','createAccountWithSeed') THEN 
+                0
+            WHEN event_type IN ('initializeAccount','initializeAccount2','initializeAccount3') THEN 
+                1
+            ELSE 2
+        END AS same_block_order_index,
+        _inserted_timestamp,
+    FROM 
+        {{ ref('silver__token_account_ownership_events') }}
+    WHERE
+        {% if is_incremental() %}
+        _inserted_timestamp > (SELECT max(_inserted_timestamp) FROM {{ this }})
+        {% else %}
+        _inserted_timestamp :: DATE = '2022-09-01'
+        {% endif %}
+    QUALIFY
+        row_number() OVER (PARTITION BY account_address, block_id ORDER BY same_block_order_index) = 1
+),
+{% if is_incremental() %}
+distinct_states AS (
+    SELECT
+        account_address,
+        MIN(start_block_id) AS min_block_id
+    FROM
+        new_events
+    GROUP BY
+        1
+),
+events_to_reprocess AS (
+    SELECT
+        C.account_address,
+        C.owner,
+        C.start_block_id,
+        C._inserted_timestamp,
+    FROM
+        {{ this }} C
+    JOIN 
+        distinct_states d
+        USING(account_address)
+    WHERE
+        C.start_block_id >= d.min_block_id
+        AND start_block_id <> coalesce(end_block_id,-1)
+        AND _inserted_timestamp <= (SELECT max(_inserted_timestamp) FROM new_events)
+),
+current_state AS (
+    SELECT 
+        C.account_address,
+        C.owner,
+        C.start_block_id,
+        C._inserted_timestamp,
+    FROM 
+        {{ this }} C
+    JOIN 
+        distinct_states d
+        USING(account_address)
+    WHERE
+        (
+            C.end_block_id >= d.min_block_id
+            OR 
+            C.end_block_id IS NULL 
+        )
+    QUALIFY
+        row_number() OVER (PARTITION BY account_address ORDER BY start_block_id) = 1
+),
+{% endif %}
+all_states AS (
+    SELECT 
+        account_address,
+        owner,
+        start_block_id,
+        _inserted_timestamp,
+        0 AS update_rank
+    FROM
+        new_events
+    
+    UNION ALL
+    SELECT
+        *,
+        1 AS update_rank
+    FROM
+        current_state
+    UNION ALL
+    SELECT 
+        *,
+        2 AS update_rank
+    FROM 
+        events_to_reprocess
+    
+),
+/* in case we have new events coming in for a block that has already been processed */
+all_states_deduped AS (
+    SELECT 
+        *
+    FROM
+        all_states
+    QUALIFY
+        row_number() OVER (PARTITION BY account_address, start_block_id ORDER BY update_rank) = 1
+),
+changed_states AS (
+    SELECT 
+        *
+    FROM 
+        all_states_deduped 
+    QUALIFY 
+        coalesce(lag(owner) OVER (PARTITION BY account_address ORDER BY start_block_id),'abc') <> owner
+)
+SELECT
+    account_address,
+    owner,
+    start_block_id,
+    LEAD(start_block_id) OVER (
+        PARTITION BY account_address
+        ORDER BY
+            start_block_id
+    ) AS end_block_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['account_address','start_block_id']) }} AS token_account_owners_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    changed_states


### PR DESCRIPTION
- Remove dependency on `silver.token_account_owners_intermediate` and instead use `silver.token_account_ownership_events` directly
  - This should remove some records that don't need to be updated, the existing model is too "conservative" (i.e. reprocesses more records than it has to)
  - Eliminating the intermediate model will improve `non-core` run time. Currently it takes ~5 mins to update the intermediate model

I tested this by comparing the incremental load results using the existing logic vs. refactored logic output

<img width="1391" alt="Screenshot 2024-07-26 at 9 28 38 AM" src="https://github.com/user-attachments/assets/aed49c22-d312-4eca-8b6f-b025e6e6d0dd">
<img width="1433" alt="Screenshot 2024-07-26 at 9 28 55 AM" src="https://github.com/user-attachments/assets/78f21b71-03b5-4fd1-939e-837c3e5c83f0">

All records output by the new logic exists in the output of the old logic. There are some records output by the old logic that is NOT in the new logic. However, I found that these records were unnecessary (i.e. they already exist in `token_account_owners` and don't actually need to be there)

```
16:37:56  1 of 1 OK created sql incremental model silver.token_account_owners_2 .......... [SUCCESS 241219 in 251.98s]
```

The plan is to surface the new logic as a new model so that we can run it in a parallel GH workflow to the existing and do a comparison after a few days worth of data has been loaded to the new model