### PR TITLE
Fix/solscan test for new silver transactions logic

### DIFF
--- a/tests/test_silver__transactions_and_votes_missing_7_days.sql
+++ b/tests/test_silver__transactions_and_votes_missing_7_days.sql
@@ -18,31 +18,27 @@ WITH solscan_counts AS (
 silver_counts AS (
     SELECT
         block_id,
-        SUM(transaction_count) AS transaction_count
+        count(tx_id) AS transaction_count
     FROM
         (
             SELECT
                 block_id,
-                COUNT(block_id) AS transaction_count
+                tx_id
             FROM
                 {{ ref('silver__transactions') }}
                 t
             WHERE
                 block_timestamp :: DATE BETWEEN CURRENT_DATE - 8
                 AND CURRENT_DATE - INTERVAL '12 HOUR'
-            GROUP BY
-                1
-            UNION ALL
+            UNION
             SELECT
                 block_id,
-                COUNT(block_id) AS transaction_count
+                tx_id
             FROM
                 solana.silver.votes t
             WHERE
                 block_timestamp :: DATE BETWEEN CURRENT_DATE - 8
                 AND CURRENT_DATE - INTERVAL '12 HOUR'
-            GROUP BY
-                1
         )
     GROUP BY
         1

--- a/tests/test_silver__transactions_partial_partitions.sql
+++ b/tests/test_silver__transactions_partial_partitions.sql
@@ -31,8 +31,6 @@ WITH max_loaded_part as (
         {{ ref('silver__transactions') }}
     WHERE
         _partition_id between (select max_partition_id-10 from max_loaded_part) and (select max_partition_id from max_loaded_part)
-    GROUP BY
-        1,2,3
     UNION
     SELECT
         block_id,
@@ -46,8 +44,6 @@ WITH max_loaded_part as (
         {% endif %}
     WHERE
         _partition_id between (select max_partition_id-10 from max_loaded_part) and (select max_partition_id from max_loaded_part)
-    GROUP BY
-        1,2,3
 ),
 C AS (
     SELECT


### PR DESCRIPTION
- Adjust `bronze` vs. `silver` transaction count comparison tests to account for the fact that `silver.transactions` and `silver.votes` can now have the same `tx_id` in both models
  - There will be a performance degradation as we now have to use `UNION` instead of `UNION ALL`. Should still be fine since these only run once per hour

Tests pass against prod w/ changed logic
```
(dbt-env) dbt test -s test_silver__transactions_partial_partitions -t prod
14:42:09  1 of 1 PASS test_silver__transactions_partial_partitions ....................... [PASS in 74.43s]

(dbt-env) dbt test -s test_silver__transactions_and_votes_missing_7_days -t prod
14:55:19  1 of 1 PASS test_silver__transactions_and_votes_missing_7_days ................. [PASS in 855.73s]
```