### PR TITLE
Stake account states

### DIFF
--- a/.github/workflows/dbt_run_streamline_stake_accounts_snapshot.yml
+++ b/.github/workflows/dbt_run_streamline_stake_accounts_snapshot.yml
@@ -1,0 +1,45 @@
+name: dbt_run_streamline_stake_accounts_snapshot
+run-name: dbt_run_streamline_stake_accounts_snapshot
+
+on:
+  schedule:
+    # Runs 01:22 daily (see https://crontab.guru)
+    - cron: '22 1 * * *'
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt build -s "solana_models,tag:streamline_stake_accounts"
+

--- a/models/streamline/stake_accounts/streamline__stake_account_states.sql
+++ b/models/streamline/stake_accounts/streamline__stake_account_states.sql
@@ -1,0 +1,96 @@
+{{ config(
+    materialized = 'table',
+    unique_key = ['account_address'],
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['streamline_stake_accounts']
+) }}
+
+{% set stake_program_address = 'Stake11111111111111111111111111111111111111' %}
+
+WITH base_stake_account_events AS (
+    /* 
+        This first select is a very special case...
+        It seems this account's creation / delegation event is listed as "FAILED" on very old blocks (646291, 646008)
+        and there are no subsequent successful creation / delegations
+        I can't find another case of this but looking on explorers the data is the same...
+        It has an active delegation but the creation/delegation event is from a failed TX
+        The code below is to manually include this one account so that it is marked as `is_active=TRUE`
+    */
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        -1 AS inner_index,
+        event_type,
+        CASE
+            WHEN event_type = 'merge' THEN
+                instruction:parsed:info:source::string
+            WHEN event_type = 'split' THEN
+                instruction:parsed:info:newSplitAccount::string
+            ELSE
+                instruction:parsed:info:stakeAccount::string
+        END AS account_address,
+        FROM
+            {{ ref('silver__events') }}
+        WHERE 
+            program_id = '{{ stake_program_address }}'
+            AND instruction:parsed:info:stakeAccount::string = '7BUrMkGxj7weJQLZf8yNLSQUUA1uWxwr6tkMx4wn9pzn'
+    UNION ALL
+    SELECT 
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        -1 AS inner_index,
+        event_type,
+        CASE
+            WHEN event_type = 'merge' THEN
+                instruction:parsed:info:source::string
+            WHEN event_type = 'split' THEN
+                instruction:parsed:info:newSplitAccount::string
+            ELSE
+                instruction:parsed:info:stakeAccount::string
+        END AS account_address,
+    FROM
+        {{ ref('silver__events') }}
+    WHERE 
+        program_id = '{{ stake_program_address }}'
+        AND succeeded
+    UNION ALL
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        e.index,
+        i.index AS inner_index,
+        i.value:parsed:type::string AS inner_event_type,
+        CASE
+            WHEN inner_event_type = 'merge' THEN
+                i.value:parsed:info:source::string
+            WHEN inner_event_type = 'split' THEN
+                i.value:parsed:info:newSplitAccount::string
+            ELSE
+                i.value:parsed:info:stakeAccount::string
+        END AS account_address,
+    FROM
+        {{ ref('silver__events') }} e
+    JOIN
+        TABLE(flatten(e.inner_instruction:instructions)) i 
+    WHERE 
+        array_contains('{{ stake_program_address }}'::variant, inner_instruction_program_ids)
+        AND i.value :programId :: STRING = '{{ stake_program_address }}'
+        AND succeeded
+)
+SELECT 
+    block_id,
+    block_timestamp,
+    account_address,
+    event_type NOT IN ('deactivate','deactivateDelinquent','merge') AS is_active,
+    event_type = 'delegate' AS is_delegated,
+FROM
+    base_stake_account_events
+WHERE
+    event_type IN ('initialize','delegate','deactivate','deactivateDelinquent','split','merge')
+QUALIFY
+    row_number() OVER (PARTITION BY account_address ORDER BY block_id DESC, index DESC, inner_index DESC) = 1

--- a/models/streamline/stake_accounts/streamline__stake_account_states.yml
+++ b/models/streamline/stake_accounts/streamline__stake_account_states.yml
@@ -1,0 +1,27 @@
+version: 2
+models:
+  - name: streamline__stake_account_states
+    description: >
+      The purpose of this model is to feed into a streamline view to request current account data for all "current" accounts owned by the stake program
+      This model is an APPROXIMATION of current stake account states. All stake program owned accounts are included + maybe some that are not owned by the program anymore.
+      There is also a likelihood that a small percentage of accounts listed as `IS_ACTIVE=TRUE` is not actually active. 
+      These caveats should be accounted for downstream after retrieving the data from the node.
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+      - name: ACCOUNT_ADDRESS
+        description: Stake account address we want to retrieve account info for
+        tests:
+          - not_null
+      - name: IS_ACTIVE
+        description: Whether the stake account is currently active
+        tests:
+          - not_null
+      - name: IS_DELEGATED
+        description: Whether the stake account is currently delegated
+        tests:
+          - not_null


### PR DESCRIPTION
- Create a table to hold current stake account state values
  - To be used downstream to power streamline requests for account information

To test against prod data...
1. `dbt compile -s streamline__stake_account_states -t prod`
2. Copy the query from `target/compiled/solana_models/models/streamline/stake_accounts/streamline__stake_account_states.sql`
3. Prefix query with `CREATE OR REPLACE TRANSIENT TABLE solana_dev.streamline.stake_account_states_prod AS`
4. Run it in snowflake
5. Get the `max(_inserted_timestamp)` from the current snapshots table
```
select max(_inserted_timestamp) 
from solana.silver.snapshot_stake_accounts;
```
6. Input into this query
```
WITH diffs AS (
    select distinct stake_pubkey
    from solana.silver.snapshot_stake_accounts
    where _inserted_timestamp = '< CURRENT MAX INSERTED >'
    except
    select distinct account_address
    from solana_dev.silver.stake_account_states_prod
    where 
        (is_active
        OR (not is_active and block_timestamp >= current_date - 2)
        )
)
select *
from diffs 
join
    solana.silver.snapshot_stake_accounts
    using(stake_pubkey)
where _inserted_timestamp = '< CURRENT MAX INSERTED >'
and deactivation_epoch > epoch_recorded;
```

Currently there are 11 diffs that should be resolved when [this](https://team-1612274056224.atlassian.net/browse/AN-5045) is done backfilling

Also can see execution time and success in dev `dbt build -s streamline__stake_account_states -t dev`
```
-- Run on M

16:50:48  1 of 5 OK created sql table model streamline.stake_account_states .............. [SUCCESS 1 in 106.08s]
16:50:51  Finished running 1 table model, 4 tests, 11 hooks in 0 hours 2 minutes and 2.06 seconds (122.06s).
16:50:51  
16:50:51  Completed successfully
16:50:51  
16:50:51  Done. PASS=5 WARN=0 ERROR=0 SKIP=0 TOTAL=5
```