### PR TITLE
Hotfix/streamline legacy tasks

### DIFF
--- a/tests/test_silver__blocks_tx_count_missing_7_days.sql
+++ b/tests/test_silver__blocks_tx_count_missing_7_days.sql
@@ -13,6 +13,5 @@ FROM
     ON b.block_id = b2.block_id
 WHERE
     b.block_id >= 226000000
-    AND b.block_timestamp BETWEEN CURRENT_DATE - 8
-    AND CURRENT_TIMESTAMP - INTERVAL '12 HOUR'
+    AND b.block_timestamp BETWEEN CURRENT_DATE - 8 AND CURRENT_TIMESTAMP - INTERVAL '12 HOUR'
     AND b2.block_id IS NULL

--- a/tests/test_silver__transactions_and_votes_missing_7_days.sql
+++ b/tests/test_silver__transactions_and_votes_missing_7_days.sql
@@ -12,8 +12,7 @@ WITH solscan_counts AS (
         JOIN solana.silver.blocks b
         ON b.block_id = s.block_id
     WHERE
-        b.block_timestamp :: DATE BETWEEN CURRENT_DATE - 8
-        AND CURRENT_DATE - INTERVAL '12 HOUR'
+        b.block_timestamp :: DATE BETWEEN CURRENT_DATE - 8 AND CURRENT_DATE - INTERVAL '12 HOUR'
 ),
 silver_counts AS (
     SELECT
@@ -28,8 +27,7 @@ silver_counts AS (
                 {{ ref('silver__transactions') }}
                 t
             WHERE
-                block_timestamp :: DATE BETWEEN CURRENT_DATE - 8
-                AND CURRENT_DATE - INTERVAL '12 HOUR'
+                block_timestamp :: DATE BETWEEN CURRENT_DATE - 8 AND CURRENT_DATE - INTERVAL '12 HOUR'
             UNION
             SELECT
                 block_id,
@@ -37,8 +35,7 @@ silver_counts AS (
             FROM
                 solana.silver.votes t
             WHERE
-                block_timestamp :: DATE BETWEEN CURRENT_DATE - 8
-                AND CURRENT_DATE - INTERVAL '12 HOUR'
+                block_timestamp :: DATE BETWEEN CURRENT_DATE - 8 AND CURRENT_DATE - INTERVAL '12 HOUR'
         )
     GROUP BY
         1

--- a/tests/test_streamline__snowflake_tasks_running.sql
+++ b/tests/test_streamline__snowflake_tasks_running.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        tags=["test_hourly"]
+    )
+}}
+
+WITH block_txs_real_time_task_counts AS (
+    SELECT 
+        count(*) AS success_count
+    FROM 
+        TABLE(solana.information_schema.task_history(
+            scheduled_time_range_start=>dateadd('hour',-1,current_timestamp()),
+            task_name=>'BULK_GET_BLOCK_TXS_REAL_TIME'))
+    WHERE
+        state = 'SUCCEEDED'
+),
+block_rewards_real_time_task_counts AS (
+    SELECT 
+        count(*) AS success_count
+    FROM 
+        TABLE(solana.information_schema.task_history(
+            scheduled_time_range_start=>dateadd('hour',-1,current_timestamp()),
+            task_name=>'BULK_GET_BLOCK_REWARDS_REAL_TIME'))
+    WHERE
+        state = 'SUCCEEDED'
+),
+blocks_real_time_task_counts AS (
+    SELECT 
+        count(*) AS success_count
+    FROM 
+        TABLE(solana.information_schema.task_history(
+            scheduled_time_range_start=>dateadd('hour',-1,current_timestamp()),
+            task_name=>'BULK_GET_BLOCKS_REAL_TIME'))
+    WHERE
+        state = 'SUCCEEDED'
+)
+SELECT
+    'block_txs_real_time' AS pipeline,
+    success_count
+FROM
+    block_txs_real_time_task_counts
+WHERE
+    success_count < 7
+UNION ALL
+SELECT
+    'blocks_real_time' AS pipeline,
+    success_count
+FROM
+    blocks_real_time_task_counts
+WHERE
+    success_count < 10
+UNION ALL
+SELECT
+    'block_rewards_real_time' AS pipeline,
+    success_count
+FROM
+    block_rewards_real_time_task_counts
+WHERE
+    success_count < 3


### PR DESCRIPTION
- Add a test to more quickly identify disruptions in solana legacy pipelines

```
16:31:08  1 of 1 PASS test_streamline__snowflake_tasks_running ........................... [PASS in 3.71s]
```

Also confirmed that it will fail when threshold is not met. I set the predicate for all 3 checks to `< 15` and got the below result

```
16:33:58  Completed with 1 error and 0 warnings:
16:33:58  
16:33:58  Failure in test test_streamline__snowflake_tasks_running (tests/test_streamline__snowflake_tasks_running.sql)
16:33:58    Got 3 results, configured to fail if != 0
16:33:58  
16:33:58    compiled Code at target/compiled/solana_models/tests/test_streamline__snowflake_tasks_running.sql
16:33:58  
16:33:58    See test failures:
  ------------------------------------------------------------
  select * from SOLANA.test_streamline.snowflake_tasks_running
  ------------------------------------------------------------
  ```