### PR TITLE
add pumpfun to realtime

### DIFF
--- a/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
+++ b/models/streamline/decode_logs/streamline__decode_logs_realtime.sql
@@ -26,7 +26,7 @@ WITH idl_in_play AS (
     FROM
         {{ ref('silver__verified_idls') }}
     WHERE   
-        program_id IN ('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY')
+        program_id IN ('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
 ),
 event_subset AS (
     SELECT


### PR DESCRIPTION
Add Pumpfun logs to requests for logs decoder

- DML to remove events from silver.decoded_instructions_combined and silver.decoded_instructions (`withdraw` events are the only ones without 'logs' so excluded those)

```
delete from solana.silver.decoded_instructions_combined
where program_id = '6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P'
and (event_type <> 'withdraw' or event_type is null)
and inner_index is not null;

delete from solana.silver.decoded_instructions 
where program_id = '6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P'
and (decoded_instruction:name::string <> 'withdraw' or decoded_instruction:error is not null)
and inner_index is not null;
```

- Command to run backfill for last two days
`dbt run-operation decoded_logs_backfill_generate_views --args '{"program_id": "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P", "start_date": "2024-08-11", "end_date": "2024-08-13"}' -t prod`