### PR TITLE
add CTEs to get decimals via livequery if data is delayed from bronze

### DIFF
--- a/models/silver/swaps/jupiter/v6/silver__swaps_inner_intermediate_jupiterv6.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_inner_intermediate_jupiterv6.sql
@@ -141,45 +141,133 @@ token_decimals AS (
     SELECT 
         'GyD5AvrcZAhSP5rrhXXGPUHri6sbkRpq67xfG3x8ourT',
         9
-)
-SELECT 
-    b.block_timestamp,
-    b.block_id,
-    b.tx_id,
-    b.index,
-    b.inner_index,
-    row_number() OVER (PARTITION BY b.tx_id, b.index, s.inner_index ORDER BY b.inner_index)-1 AS swap_index, /* we want the swap index as it relates to the top level swap instruction */
-    b.succeeded,
-    b.program_id AS swap_program_id,
-    'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4' AS aggregator_program_id,
-    s.swapper,
-    b.from_mint,
-    b.from_amount * pow(10,-d.decimal) AS from_amount,
-    b.to_mint,
-    b.to_amount * pow(10,-d2.decimal) AS to_amount,
-    b._inserted_timestamp,
-    {{ dbt_utils.generate_surrogate_key(['b.tx_id','b.index','b.inner_index']) }} as swaps_inner_intermediate_jupiterv6_id,
-    sysdate() as inserted_timestamp,
-    sysdate() as modified_timestamp,
-    '{{ invocation_id }}' AS _invocation_id
-FROM 
-    base b
-LEFT OUTER JOIN
-    swappers s
-    ON b.tx_id = s.tx_id
-    AND b.index = s.index
-    AND (
-            s.inner_index IS NULL 
-            OR
-            (
-                b.inner_index > s.inner_index
-                AND (b.inner_index < s.next_summary_swap_index 
-                    OR s.next_summary_swap_index IS NULL)
+),
+pre_final AS (
+    SELECT 
+        b.block_timestamp,
+        b.block_id,
+        b.tx_id,
+        b.index,
+        b.inner_index,
+        row_number() OVER (PARTITION BY b.tx_id, b.index, s.inner_index ORDER BY b.inner_index)-1 AS swap_index, /* we want the swap index as it relates to the top level swap instruction */
+        b.succeeded,
+        b.program_id AS swap_program_id,
+        'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4' AS aggregator_program_id,
+        s.swapper,
+        b.from_mint,
+        b.from_amount AS from_amount_int,
+        b.from_amount * pow(10,-d.decimal) AS from_amount,
+        b.to_mint,
+        b.to_amount AS to_amount_int,
+        b.to_amount * pow(10,-d2.decimal) AS to_amount,
+        b._inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['b.tx_id','b.index','b.inner_index']) }} as swaps_inner_intermediate_jupiterv6_id,
+        sysdate() as inserted_timestamp,
+        sysdate() as modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
+    FROM 
+        base b
+    LEFT OUTER JOIN
+        swappers s
+        ON b.tx_id = s.tx_id
+        AND b.index = s.index
+        AND (
+                s.inner_index IS NULL 
+                OR
+                (
+                    b.inner_index > s.inner_index
+                    AND (b.inner_index < s.next_summary_swap_index 
+                        OR s.next_summary_swap_index IS NULL)
+                )
             )
-        )
+    LEFT OUTER JOIN
+        token_decimals d
+        ON b.from_mint = d.mint
+    LEFT OUTER JOIN
+        token_decimals d2
+        ON b.to_mint = d2.mint
+),
+distinct_missing_decimals AS (
+    SELECT DISTINCT
+        to_mint AS mint
+    FROM
+        pre_final
+    WHERE
+        to_amount IS NULL
+    UNION
+    SELECT DISTINCT
+        from_mint
+    FROM
+        pre_final
+    WHERE
+        from_amount IS NULL
+),
+get_missing_decimals AS (
+    SELECT
+        mint,
+        solana.live.udf_api(
+            'POST',
+            '{service}/{Authentication}',
+            OBJECT_CONSTRUCT(
+                'Content-Type',
+                'application/json'
+            ),
+            OBJECT_CONSTRUCT(
+                'id',
+                1,
+                'jsonrpc',
+                '2.0',
+                'method',
+                'getAccountInfo',
+                'params',
+                ARRAY_CONSTRUCT(
+                    mint,
+                    OBJECT_CONSTRUCT(
+                        'encoding',
+                        'jsonParsed'
+                    )
+                )
+            ),
+            'Vault/prod/solana/quicknode/mainnet'
+        ):data:result:value:data:parsed:info:decimals::int AS decimal
+    FROM
+        distinct_missing_decimals
+)
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    index,
+    inner_index,
+    swap_index, /* we want the swap index as it relates to the top level swap instruction */
+    succeeded,
+    swap_program_id,
+    aggregator_program_id,
+    swapper,
+    from_mint,
+    CASE
+        WHEN from_amount IS NULL THEN
+            from_amount_int * pow(10, -d.decimal)
+        ELSE
+            from_amount
+    END AS from_amount,
+    to_mint,
+    CASE
+        WHEN to_amount IS NULL THEN
+            to_amount_int * pow(10, -d2.decimal)
+        ELSE
+            to_amount
+    END AS to_amount,
+    _inserted_timestamp,
+    swaps_inner_intermediate_jupiterv6_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
+FROM
+    pre_final
 LEFT OUTER JOIN
-    token_decimals d
-    ON b.from_mint = d.mint
+    get_missing_decimals d
+    ON from_mint = d.mint
 LEFT OUTER JOIN
-    token_decimals d2
-    ON b.to_mint = d2.mint    
+    get_missing_decimals d2
+    ON to_mint = d2.mint


### PR DESCRIPTION
Some amounts are intermittently being set to NULL during decimal adjustment when the mint is not found in `decoded_metadata`. This can happen if a block arrives late in bronze or there is some issue with the modeling upstream. In order to mitigate this issue we can use LiveQuery to query for any missing token decimals and re-apply the decimal adjustment as the final step(s) of the model

You can test now in DEV by doing
```
delete from solana_dev.silver.swaps_inner_intermediate_jupiterv6
where _inserted_timestamp >= '2024-08-12 15:37:15.000';

dbt run -s models/silver/swaps/jupiter/v6/silver__swaps_inner_intermediate_jupiterv6.sql -t dev
```

Incremental on M
```
15:14:07  1 of 1 OK created sql incremental model silver.swaps_inner_intermediate_jupiterv6  [SUCCESS 2383524 in 91.47s]
```

Tests now pass in dev data
```
15:19:50  Finished running 23 data tests, 11 project hooks in 0 hours 0 minutes and 27.98 seconds (27.98s).
15:19:50  
15:19:50  Completed successfully
15:19:50  
15:19:50  Done. PASS=23 WARN=0 ERROR=0 SKIP=0 TOTAL=23
```