### PR TITLE
add filter to null authorized_voter test

### DIFF
--- a/models/silver/validator/silver__snapshot_vote_accounts.yml
+++ b/models/silver/validator/silver__snapshot_vote_accounts.yml
@@ -14,7 +14,8 @@ models:
       - name: authorized_voter
         description: "Account responsible for signing vote transactions"
         tests:
-          - not_null
+          - not_null:
+              where: authorized_withdrawer <> '11111111111111111111111111111111'
       - name: last_epoch_active
         description: "last epoch when vote account was active"
       - name: authorized_withdrawer


### PR DESCRIPTION
When the `authorized_withdrawer = '11111111111111111111111111111111'`, the `authorized_voter` is null, so adjusted test to exclude these

`5 of 16 PASS not_null_silver__snapshot_vote_accounts_authorized_voter .......... [PASS in 2.37s]`