### PR TITLE
An 5088/gold optimization 2

### DIFF
--- a/models/gold/gov/gov__fact_stake_accounts.sql
+++ b/models/gold/gov/gov__fact_stake_accounts.sql
@@ -82,3 +82,4 @@ SELECT
   '2000-01-01' AS modified_timestamp
 FROM
   {{ ref('silver__historical_stake_account') }}
+{% endif %}

--- a/models/gold/gov/gov__fact_stake_accounts.sql
+++ b/models/gold/gov/gov__fact_stake_accounts.sql
@@ -1,8 +1,23 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'VALIDATOR' }}},
-  tags = ['scheduled_non_core']
+    materialized = 'incremental',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'VALIDATOR' }}},
+    unique_key = ['fact_stake_accounts_id'],
+    cluster_by = ['epoch','activation_epoch','deactivation_epoch'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(stake_pubkey, vote_pubkey)'),
+    tags = ['scheduled_non_core']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT MAX(modified_timestamp) AS max_modified_timestamp
+            FROM {{ this }}
+        {% endset %}
+
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
 
 SELECT
   epoch_recorded :: INT AS epoch,
@@ -37,6 +52,11 @@ SELECT
     ) AS modified_timestamp
 FROM
   {{ ref('silver__snapshot_stake_accounts') }}
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
+{% if not is_incremental() %}
 UNION ALL
 SELECT
   epoch_ingested_at :: INT AS epoch,

--- a/models/gold/gov/gov__fact_validators.sql
+++ b/models/gold/gov/gov__fact_validators.sql
@@ -5,7 +5,7 @@
     cluster_by = ['epoch','epoch_active'],
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(node_pubkey, vote_pubkey)'),
-    tags = ['scheduled_non_core','exclude_change_tracking']
+    tags = ['scheduled_non_core']
 ) }}
 
 {% if execute %}

--- a/models/gold/gov/gov__fact_validators.sql
+++ b/models/gold/gov/gov__fact_validators.sql
@@ -1,8 +1,23 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'VALIDATOR' }} },
-  tags = ['scheduled_non_core','exclude_change_tracking']
+    materialized = 'incremental',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'VALIDATOR' }}},
+    unique_key = ['fact_validators_id'],
+    cluster_by = ['epoch','epoch_active'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(node_pubkey, vote_pubkey)'),
+    tags = ['scheduled_non_core','exclude_change_tracking']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT MAX(modified_timestamp) AS max_modified_timestamp
+            FROM {{ this }}
+        {% endset %}
+
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
 
 SELECT
   epoch_recorded :: INT AS epoch,
@@ -42,6 +57,11 @@ SELECT
   ) AS modified_timestamp
 FROM
   {{ ref('silver__snapshot_validators_app_data') }}
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
+{% if not is_incremental() %}
 UNION ALL
 SELECT
   epoch_recorded :: INT AS epoch,
@@ -72,3 +92,4 @@ SELECT
   '2000-01-01' AS modified_timestamp
 FROM
   {{ ref('silver__historical_validator_app_data') }}
+{% endif %}

--- a/models/gold/gov/gov__fact_vote_accounts.sql
+++ b/models/gold/gov/gov__fact_vote_accounts.sql
@@ -82,3 +82,4 @@ SELECT
   '2000-01-01' AS modified_timestamp
 FROM
   {{ ref('silver__historical_vote_account') }}
+{% endif %}

--- a/models/gold/gov/gov__fact_vote_accounts.sql
+++ b/models/gold/gov/gov__fact_vote_accounts.sql
@@ -1,8 +1,23 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'VALIDATOR' }}},
-  tags = ['scheduled_non_core']
+    materialized = 'incremental',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'VALIDATOR' }}},
+    unique_key = ['fact_vote_accounts_id'],
+    cluster_by = ['epoch','last_epoch_active'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(vote_pubkey, node_pubkey, owner)'),
+    tags = ['scheduled_non_core']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT MAX(modified_timestamp) AS max_modified_timestamp
+            FROM {{ this }}
+        {% endset %}
+
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
 
 SELECT
   epoch_recorded :: INT AS epoch,
@@ -37,6 +52,11 @@ SELECT
     ) AS modified_timestamp
 FROM
   {{ ref('silver__snapshot_vote_accounts') }}
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
+{% if not is_incremental() %}
 UNION ALL
 SELECT
   epoch_ingested_at :: INT AS epoch,

--- a/models/gold/nft/nft__fact_nft_sales.sql
+++ b/models/gold/nft/nft__fact_nft_sales.sql
@@ -275,7 +275,7 @@ SELECT
     COALESCE (
         nft_sales_solanart_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['tx_id']
+            ['tx_id','mint']
         ) }}
     ) AS fact_nft_sales_id,
     COALESCE(
@@ -444,7 +444,7 @@ SELECT
     COALESCE (
         nft_sales_tensorswap_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['tx_id','mint','purchaser']
+            ['tx_id','index','inner_index','mint']
         ) }}
     ) AS fact_nft_sales_id,
     COALESCE(

--- a/models/gold/nft/nft__fact_nft_sales.sql
+++ b/models/gold/nft/nft__fact_nft_sales.sql
@@ -222,7 +222,7 @@ UNION ALL
 {% endif %}
 -- Only select from active models during incremental
 SELECT
-    'magic eden v2',
+    'magic eden v2' as marketplace,
     block_timestamp,
     block_id,
     tx_id,

--- a/models/gold/nft/nft__fact_nft_sales.sql
+++ b/models/gold/nft/nft__fact_nft_sales.sql
@@ -3,7 +3,7 @@
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }}},
     unique_key = ['fact_nft_sales_id'],
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
-    cluster_by = ['block_timestamp::DATE',,'is_compressed','program_id'],
+    cluster_by = ['block_timestamp::DATE','is_compressed','program_id'],
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, purchaser, seller, mint, marketplace)'),
     tags = ['scheduled_non_core']

--- a/models/gold/nft/nft__fact_nft_sales.sql
+++ b/models/gold/nft/nft__fact_nft_sales.sql
@@ -3,9 +3,9 @@
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }}},
     unique_key = ['fact_nft_sales_id'],
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
-    cluster_by = ['block_timestamp::DATE','marketplace','is_compressed','program_id'],
+    cluster_by = ['block_timestamp::DATE',,'is_compressed','program_id'],
     merge_exclude_columns = ["inserted_timestamp"],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, purchaser, seller, mint)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, purchaser, seller, mint, marketplace)'),
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/metadata/helius/silver__helius_nft_metadata.sql
+++ b/models/silver/metadata/helius/silver__helius_nft_metadata.sql
@@ -3,6 +3,7 @@
     unique_key = "mint",
     incremental_strategy = 'delete+insert',
     cluster_by = ['_inserted_timestamp::DATE'],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(mint,nft_name,nft_collection_id)'),
     tags = ['nft_api']
 ) }}
 

--- a/models/silver/metadata/silver__nft_collection.sql
+++ b/models/silver/metadata/silver__nft_collection.sql
@@ -3,6 +3,7 @@
     unique_key = "collection_id",
     incremental_strategy = 'merge',
     merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(collection_id,nft_collection_name)'),
     tags = ['nft_api']
 ) }}
 

--- a/models/silver/nfts/silver__nft_burn_actions.sql
+++ b/models/silver/nfts/silver__nft_burn_actions.sql
@@ -3,6 +3,7 @@
     unique_key = "CONCAT_WS('-', tx_id, index, inner_index, mint)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id,mint,burn_authority)'),
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_compressed_mints.sql
+++ b/models/silver/nfts/silver__nft_compressed_mints.sql
@@ -2,6 +2,8 @@
     materialized = 'incremental',
     unique_key = "tx_id",
     incremental_strategy = 'delete+insert',
+    cluster_by = ['block_timestamp::DATE'],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id,purchaser,mint)'),
     tags = ['compressed_nft']
 ) }}
 

--- a/models/silver/nfts/silver__nft_mint_actions.sql
+++ b/models/silver/nfts/silver__nft_mint_actions.sql
@@ -4,6 +4,7 @@
     incremental_strategy = 'delete+insert',
     incremental_predicates = ['block_timestamp::date >= LEAST(current_date-7,(select min(block_timestamp)::date from ' ~ generate_tmp_view_name(this) ~ '))'],
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id,mint,burn_authority)'),
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_mints.sql
+++ b/models/silver/nfts/silver__nft_mints.sql
@@ -3,6 +3,7 @@
     unique_key = "CONCAT_WS('-', initialization_tx_id, mint, purchaser, mint_currency)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id,purchaser,mint)'),
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_amm_sell_decoded.sql
+++ b/models/silver/nfts/silver__nft_sales_amm_sell_decoded.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     unique_key = "nft_sales_amm_sell_decoded_id",
-    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_exchange_art.sql
+++ b/models/silver/nfts/silver__nft_sales_exchange_art.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', tx_id, mint)",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_hadeswap.sql
+++ b/models/silver/nfts/silver__nft_sales_hadeswap.sql
@@ -2,7 +2,7 @@
   materialized = 'incremental',
   unique_key = "CONCAT_WS('-', tx_id, mint)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp::DATE'],
+  cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
   tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_hyperspace.sql
+++ b/models/silver/nfts/silver__nft_sales_hyperspace.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', tx_id, mint)",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_magic_eden_cnft.sql
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_cnft.sql
@@ -3,6 +3,7 @@
     unique_key = ['nft_sales_magic_eden_cnft_id'],
     incremental_strategy = 'delete+insert',
     merge_exclude_columns = ["inserted_timestamp"],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_magic_eden_v2.sql
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_v2.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "tx_id",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_solanart.sql
+++ b/models/silver/nfts/silver__nft_sales_solanart.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', tx_id, mint)",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_solsniper.sql
+++ b/models/silver/nfts/silver__nft_sales_solsniper.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     unique_key = ['nft_sales_solsniper_id'],
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_non_core']
 ) }}

--- a/models/silver/nfts/silver__nft_sales_solsniper_cnft.sql
+++ b/models/silver/nfts/silver__nft_sales_solsniper_cnft.sql
@@ -3,6 +3,7 @@
     unique_key = ['nft_sales_solsniper_cnft_id'],
     incremental_strategy = 'delete+insert',
     merge_exclude_columns = ["inserted_timestamp"],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_tensorswap.sql
+++ b/models/silver/nfts/silver__nft_sales_tensorswap.sql
@@ -5,7 +5,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     unique_key = "nft_sales_tensorswap_id",
-    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/nfts/silver__nft_sales_tensorswap_cnft.sql
+++ b/models/silver/nfts/silver__nft_sales_tensorswap_cnft.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     unique_key = ['nft_sales_tensorswap_cnft_id'],
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_non_core']
 ) }}

--- a/models/silver/silver__staking_lp_actions.sql
+++ b/models/silver/silver__staking_lp_actions.sql
@@ -2,8 +2,9 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', block_id, tx_id, index)",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','event_type'],
     full_refresh = false,
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id)'),
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/silver__staking_lp_actions_labeled.sql
+++ b/models/silver/silver__staking_lp_actions_labeled.sql
@@ -2,7 +2,8 @@
     materialized = 'incremental',
     unique_key = ['block_id','tx_id','index'],
     incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','event_type'],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id,stake_authority,withdraw_authority,stake_account)'),
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/validator/silver__snapshot_stake_accounts.sql
+++ b/models/silver/validator/silver__snapshot_stake_accounts.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', epoch_recorded, stake_pubkey)",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['_inserted_timestamp::DATE'],
+    cluster_by = ['modified_timestamp::DATE'],
     tags = ['validator']
 ) }}
 

--- a/models/silver/validator/silver__snapshot_validators_app_data.sql
+++ b/models/silver/validator/silver__snapshot_validators_app_data.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', epoch_recorded, node_pubkey)",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['_inserted_timestamp::DATE'],
+    cluster_by = ['modified_timestamp::DATE'],
     tags = ['validator']
 ) }}
 

--- a/models/silver/validator/silver__snapshot_vote_accounts.sql
+++ b/models/silver/validator/silver__snapshot_vote_accounts.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = "CONCAT_WS('-', epoch_recorded, vote_pubkey)",
     incremental_strategy = 'delete+insert',
-    cluster_by = ['_inserted_timestamp::DATE'],
+    cluster_by = ['modified_timestamp::DATE'],
     tags = ['validator']
 ) }}
 


### PR DESCRIPTION
Search optimization and clustering for NFT and GOV schema

1. For larger/complex core views with union/join logic, convert to table and update silver clustering
- add logic to select from legacy views only during FR
- includes: `gov.fact_stake_accounts`, `gov.fact_validators`, `gov.fact_vote_accounts`, `nft.fact_nft_sales`)

3. For views with simpler logic, add SO and clustering to silver references

FR successful for core tables (on 2xl):
```
-- 23:47:48  2 of 5 OK created sql incremental model gov.fact_validators .................... [SUCCESS 1 in 23.25s]
-- 23:47:53  3 of 5 OK created sql incremental model gov.fact_vote_accounts ................. [SUCCESS 1 in 28.33s]
-- 23:48:27  4 of 5 OK created sql incremental model nft.fact_nft_sales ..................... [SUCCESS 1 in 61.76s]
-- 23:48:37  1 of 5 OK created sql incremental model gov.fact_stake_accounts ................ [SUCCESS 1 in 71.95s]
```
Incremental runs for core tables (on medium):
```
02:59:22  3 of 5 OK created sql incremental model gov.fact_vote_accounts ................. [SUCCESS 6300 in 7.92s]
02:59:23  4 of 5 OK created sql incremental model nft.fact_nft_sales ..................... [SUCCESS 266 in 8.62s]
02:59:24  2 of 5 OK created sql incremental model gov.fact_validators .................... [SUCCESS 1512 in 9.75s]
02:59:35  1 of 5 OK created sql incremental model gov.fact_stake_accounts ................ [SUCCESS 1442330 in 20.77s]
```