### PR TITLE
upgrade to dbt 1.8.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-dbt-snowflake>=1.4,<1.8
+dbt-core>=1.8,<1.9
+dbt-snowflake>=1.8,<1.9
 protobuf==4.25.3


### PR DESCRIPTION
- Requires separate installation of `dbt-core` and `dbt-snowflake`
- Python required to be >= `v3.11`

To install locally, run below command in your virtual environment
`pip install dbt-core~=1.8 dbt-snowflake~=1.8`