### PR TITLE
Auto heal block rewards and test

### DIFF
--- a/models/sources.yml
+++ b/models/sources.yml
@@ -113,3 +113,4 @@ sources:
     schema: test_silver 
     tables: 
       - name: transactions_and_votes_missing_7_days
+      - name: rewards_gaps

--- a/tests/test_silver__rewards_gaps.sql
+++ b/tests/test_silver__rewards_gaps.sql
@@ -1,0 +1,38 @@
+{{
+    config(
+        tags=["test_hourly"]
+    )
+}}
+
+WITH missing AS (
+    SELECT 
+        block_id
+    FROM 
+        solana.silver.blocks
+    WHERE 
+        block_timestamp < current_date - INTERVAL '12 HOUR'
+    EXCEPT
+    SELECT 
+        block_id
+    FROM 
+        {{ ref('streamline__complete_block_rewards') }}
+),
+first_block_of_epoch AS (
+    SELECT 
+        b.block_id
+    FROM 
+        solana.silver.blocks b
+    JOIN 
+        solana.silver.epoch e
+        ON b.block_id BETWEEN e.start_block AND e.end_block
+    QUALIFY
+        row_number() OVER (PARTITION BY e.epoch ORDER BY b.block_id) = 1
+)
+SELECT 
+    m.*,
+    f.block_id IS NOT NULL AS is_epoch_first_block
+FROM 
+    missing m
+LEFT JOIN 
+    first_block_of_epoch f
+    USING(block_id)


### PR DESCRIPTION
- Test for missing rewards in streamline table. Every block should have at least one reward record
- Identify any missing rewards that are from the first block of an epoch as these should be treated differently on retry
- Auto retry missing rewards

Current state, all missing are non-first epoch blocks
```
13:58:48  1 of 1 FAIL 42663 test_silver__rewards_gaps .................................... [FAIL 42663 in 20.06s]
```

Streamline realtime view successfully built
```
14:21:16  1 of 1 OK created sql view model streamline.all_unknown_block_rewards_real_time  [SUCCESS 1 in 1.84s]
```