### PR TITLE
add dca related columns and tests

### DIFF
--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
@@ -99,6 +99,25 @@ models:
         description:  "{{ doc('swaps_to_amt') }}"
         tests: 
           - not_null: *recent_date_filter
+      - name: IS_DCA_SWAP
+        description: "Whether the swap was initiated by a Jupiter DCA"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "= True"
+              config:
+                where: >
+                  swapper IN ('DCAKuApAuZtVNYLk3KTAVW9GLWVvPbnb5CxxRRmVgcTr','DCAKxn5PFNN1mBREPWGdk1RXg5aVH9rPErLfBFEi2Emb','DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw')
+                  AND _inserted_timestamp >= current_date - 7
+                  AND block_timestamp >= '2024-08-23' /* remove when DCA is backfilled */
+      - name: DCA_REQUESTER
+        description: "Original address that requested the DCA swap"
+        tests:
+          - not_null:
+              config:
+                where: >
+                  is_dca_swap
+                  AND _inserted_timestamp >= current_date - 7
+                  AND block_timestamp >= '2024-08-23' /* remove when DCA is backfilled */
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
@@ -100,7 +100,7 @@ models:
         tests: 
           - not_null: *recent_date_filter
       - name: IS_DCA_SWAP
-        description: "Whether the swap was initiated by a Jupiter DCA"
+        description: "Whether the swap was initiated by a Jupiter DCA. If value is NULL then it is NOT a DCA Swap"
         tests:
           - dbt_utils.expression_is_true:
               expression: "= True"


### PR DESCRIPTION
- Add DCA related columns
  - Flag to indicate whether a swap was initiated by Jupiter DCA
  - List the original wallet that requested the DCA if the above is true
  - Add tests for new columns
- Will require backfill for new columns once the decoder is fully backfilled for DCA logs. See comments for backfill query

Incremental on M
```
16:29:34  1 of 1 OK created sql incremental model silver.swaps_intermediate_jupiterv6_2 .. [SUCCESS 92451 in 126.06s]
```

Tests pass on dev
```
16:23:32  Finished running 23 data tests, 11 project hooks in 0 hours 0 minutes and 31.92 seconds (31.92s).
16:23:32  
16:23:32  Completed successfully
16:23:32  
16:23:32  Done. PASS=23 WARN=0 ERROR=0 SKIP=0 TOTAL=23
```