### PR TITLE
add test for new dca signers

### DIFF
--- a/tests/test_silver__decoded_logs_jupiter_dca_signers.sql
+++ b/tests/test_silver__decoded_logs_jupiter_dca_signers.sql
@@ -1,0 +1,12 @@
+SELECT DISTINCT 
+    signers[0]::string AS signer
+FROM
+    {{ ref('silver__decoded_logs') }} 
+WHERE 
+    program_id = 'DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M'
+    AND event_type = 'Filled'
+    AND _inserted_timestamp >= current_date - 7
+    AND signer NOT IN ('DCAKxn5PFNN1mBREPWGdk1RXg5aVH9rPErLfBFEi2Emb',
+        'DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw',
+        'DCAKuApAuZtVNYLk3KTAVW9GLWVvPbnb5CxxRRmVgcTr'
+    )


### PR DESCRIPTION
- Add test to detect if a new DCA signer is used by Jupiter

```
16:45:27  15 of 16 PASS test_silver__decoded_logs_jupiter_dca_signers .................... [PASS in 4.01s]
```