### PR TITLE
remove jupv6

### DIFF
--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -49,63 +49,8 @@ WHERE
     modified_timestamp::date < '{{ backfill_to_date }}'
 {% endif %}
 )
-/* TODO: DEPRECATE - remove jupiter swaps from this table, we will only cover individual dexes moving forward. Aggregator(s) get their own model(s) */
 ,
 swaps_individual as (
-SELECT
-    block_timestamp,
-    block_id,
-    tx_id,
-    succeeded,
-    swapper,
-    from_amt AS swap_from_amount,
-    from_mint AS swap_from_mint,
-    to_amt AS swap_to_amount,
-    to_mint AS swap_to_mint,
-    program_id,
-    swap_index,
-    swaps_intermediate_jupiterv6_id as fact_swaps_id,
-    inserted_timestamp,
-    modified_timestamp
-FROM
-    {{ ref('silver__swaps_intermediate_jupiterv6_view') }}
-WHERE 
-    block_timestamp::date < '2023-08-03'
-{% if is_incremental() %}
-AND
-    modified_timestamp >= '{{ max_modified_timestamp }}'
-{% else %}
-AND
-    modified_timestamp::date < '{{ backfill_to_date }}'
-{% endif %}
-UNION ALL
-SELECT
-    block_timestamp,
-    block_id,
-    tx_id,
-    succeeded,
-    swapper,
-    from_amount AS swap_from_amount,
-    from_mint AS swap_from_mint,
-    to_amount AS swap_to_amount,
-    to_mint AS swap_to_mint,
-    program_id,
-    swap_index,
-    swaps_intermediate_jupiterv6_id as fact_swaps_id,
-    inserted_timestamp,
-    modified_timestamp
-FROM
-    {{ ref('silver__swaps_intermediate_jupiterv6_2') }}
-WHERE
-    block_timestamp::date >= '2023-08-03'
-{% if is_incremental() %}
-AND
-    modified_timestamp >= '{{ max_modified_timestamp }}'
-{% else %}
-AND 
-    modified_timestamp::date < '{{ backfill_to_date }}'
-{% endif %}
-UNION ALL
 SELECT
     block_timestamp,
     block_id,

--- a/models/gold/defi/defi__fact_swaps.yml
+++ b/models/gold/defi/defi__fact_swaps.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: defi__fact_swaps
-    description: This table contains swaps performed on Jupiter, Orca, Raydium, Saber, Bonkswap, Dooar, Phoenix and Meteora swap programs. Intermediate swaps are aggregated over the DEX programs, so the values showcase the final mint/amount swap values. Ie. a swap on Jupiter that swaps SOL->USDC->mSOL->ETH would show the initial amount in and the final amount out of SOL->ETH. For Phoenix, we are not capturing swaps where there are separate transactions for placing the order and filling the order. 
+    description: This table contains swaps performed on Jupiter (V4 and V5), Orca, Raydium, Saber, Bonkswap, Dooar, Phoenix and Meteora swap programs. Intermediate swaps are aggregated over the DEX programs, so the values showcase the final mint/amount swap values. Ie. a swap on Jupiter that swaps SOL->USDC->mSOL->ETH would show the initial amount in and the final amount out of SOL->ETH. For Phoenix, we are not capturing swaps where there are separate transactions for placing the order and filling the order. 
     recent_date_filter: &recent_date_filter
       config:
         where: block_timestamp >= current_date - 7


### PR DESCRIPTION
Remove jupv6 swaps from `fact_swaps`, as these now live in separate tables

DML to delete:
```
delete from solana.defi.fact_swaps
where program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4';
```

fact_swaps incremental run in dev:
```
16:56:20  Finished running 1 incremental model, 11 hooks in 0 hours 0 minutes and 52.50 seconds (52.50s).
16:56:20  
16:56:20  Completed successfully
```
