### PR TITLE
An 5146/gold tests

### DIFF
--- a/macros/tests/reference_tx_missing.sql
+++ b/macros/tests/reference_tx_missing.sql
@@ -1,0 +1,22 @@
+{% test reference_tx_missing(model, reference_tables, id_column='tx_id') %}
+    {% set failures %}
+        SELECT
+            reference_table_name,
+            {{ id_column }} AS missing_tx_id
+        FROM (
+            {% for reference_table in reference_tables %}
+                SELECT
+                    '{{ reference_table }}' AS reference_table_name,
+                    {{ id_column }}
+                FROM {{ ref(reference_table) }}
+                WHERE {{ id_column }} NOT IN (SELECT {{ id_column }} FROM {{ model }} where modified_timestamp >= current_date - 7)
+                AND _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '1 HOUR'
+                {% if not loop.last %} UNION ALL {% endif %}
+            {% endfor %}
+        ) missing_tx_ids
+    {% endset %}
+
+    SELECT *
+    FROM ({{ failures }})
+{% endtest %}
+

--- a/models/gold/core/core__fact_sol_balances.yml
+++ b/models/gold/core/core__fact_sol_balances.yml
@@ -2,47 +2,74 @@ version: 2
 models:
   - name: core__fact_sol_balances
     description: "{{ doc('sol_balance_table_doc') }}"
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__sol_balances'
+          id_column: 'tx_id'
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: ACCOUNT_ADDRESS
         description: "{{ doc('balances_account') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: OWNER
         description: "{{ doc('sol_balances_owner') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: PRE_BALANCE
         description: "{{ doc('balances_pre_amount') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: BALANCE
         description: "{{ doc('balances_post_amount') }}" 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: FACT_SOL_BALANCES_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter  
       - name: MODIFIED_TIMESTAMP
-        description: '{{ doc("modified_timestamp") }}' 
+        description: '{{ doc("modified_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter  
           

--- a/models/gold/core/core__fact_token_balances.yml
+++ b/models/gold/core/core__fact_token_balances.yml
@@ -2,31 +2,45 @@ version: 2
 models:
   - name: core__fact_token_balances
     description: "{{ doc('token_balance_table_doc') }}"
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__token_balances'
+          id_column: 'tx_id'
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: ACCOUNT_ADDRESS
         description: "{{ doc('balances_account') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: OWNER
         description: "{{ doc('token_balances_block_owner') }}"
         tests:
@@ -35,14 +49,26 @@ models:
         description: "{{ doc('balances_pre_amount') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: BALANCE
         description: "{{ doc('balances_post_amount') }}" 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: FACT_TOKEN_BALANCES_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter    
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter    
       - name: MODIFIED_TIMESTAMP
         description: '{{ doc("modified_timestamp") }}' 
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
           

--- a/models/gold/defi/defi__fact_liquidity_pool_actions.yml
+++ b/models/gold/defi/defi__fact_liquidity_pool_actions.yml
@@ -2,50 +2,83 @@ version: 2
 models:
   - name: defi__fact_liquidity_pool_actions
     description: Table containing liquidity pools actions on Orca, Raydium, Saber and Meteora. 
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__liquidity_pool_actions_raydium'
+            - 'silver__liquidity_pool_actions_orca'
+            - 'silver__liquidity_pool_actions_saber'
+            - 'silver__liquidity_pool_actions_meteora'
+            - 'silver__liquidity_pool_actions_meteora_dlmm'
+            - 'silver__liquidity_pool_actions_meteora_multi'
+          id_column: 'tx_id'
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}" 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: ACTION
         description: Type of interaction performed with the liquidity pool
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: LIQUIDITY_PROVIDER
         description: "{{ doc('liquidity_provider') }}" 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: LIQUIDITY_POOL_ADDRESS
         description: "{{ doc('liquidity_pool_address') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: AMOUNT
         description: "{{ doc('amount') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: MINT
         description: "{{ doc('mint') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: FACT_LIQUIDITY_POOL_ACTIONS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter 
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter   
       - name: MODIFIED_TIMESTAMP
-        description: '{{ doc("modified_timestamp") }}' 
+        description: '{{ doc("modified_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 

--- a/models/gold/defi/defi__fact_stake_pool_actions.yml
+++ b/models/gold/defi/defi__fact_stake_pool_actions.yml
@@ -2,54 +2,86 @@ version: 2
 models:
   - name: defi__fact_stake_pool_actions
     description: Deposit and withdraw actions with a given stake pool
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__stake_pool_actions_lido'
+            - 'silver__stake_pool_actions_generic'
+            - 'silver__stake_pool_actions_marinade'
+            - 'silver__stake_pool_actions_jito'
+          id_column: 'tx_id'
     columns:
       - name: STAKE_POOL_NAME
         description: "Name of stake pool action is performed against"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: INDEX
         description: Location of the stake pool action within a transaction
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: ACTION
         description: "{{ doc('stake_pool_action') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: STAKE_POOL
         description: "{{ doc('stake_pool') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: ADDRESS
         description: "{{ doc('stake_pool_address') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: AMOUNT
         description: "Amount in Lamports"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: TOKEN
         description: "Token utilized in the stake pool action"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: FACT_STAKE_POOL_ACTIONS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter    
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}' 
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter   
       - name: MODIFIED_TIMESTAMP
         description: '{{ doc("modified_timestamp") }}' 
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 

--- a/models/gold/defi/defi__fact_swaps.yml
+++ b/models/gold/defi/defi__fact_swaps.yml
@@ -5,47 +5,74 @@ models:
     recent_date_filter: &recent_date_filter
       config:
         where: block_timestamp >= current_date - 7
+    recent_modified_date_filter: &recent_modified_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__swaps'
+            - 'silver__swaps_intermediate_bonkswap'
+            - 'silver__swaps_intermediate_meteora'
+            - 'silver__swaps_intermediate_dooar'
+            - 'silver__swaps_intermediate_phoenix'
+            - 'silver__swaps_intermediate_raydium_clmm'
+            - 'silver__swaps_intermediate_raydium_stable'
+            - 'silver__swaps_intermediate_raydium_v4_amm'
+            - 'silver__swaps_pumpfun'
+          id_column: 'tx_id'
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_modified_date_filter
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}" 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SWAPPER
         description: Address that initiated the swap 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SWAP_FROM_AMOUNT
         description: Total amount of the token sent in to initiate the swap 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SWAP_FROM_MINT
         description: Token being sent or swapped from
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SWAP_TO_AMOUNT
         description: Total amount of the token received in the swap
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SWAP_TO_MINT
         description: Token being received or swapped for 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: Token being received or swapped for 
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+
       - name: SWAP_PROGRAM
         description: name of decentralized exchange used to perform the swap
         tests:
@@ -55,8 +82,16 @@ models:
         tests: 
           - not_null: *recent_date_filter
       - name: FACT_SWAPS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}' 
+        tests:
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter    
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter    
       - name: MODIFIED_TIMESTAMP
-        description: '{{ doc("modified_timestamp") }}' 
+        description: '{{ doc("modified_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist

--- a/models/gold/gov/gov__fact_stake_accounts.yml
+++ b/models/gold/gov/gov__fact_stake_accounts.yml
@@ -2,15 +2,25 @@ version: 2
 models:
   - name: gov__fact_stake_accounts
     description: "This table contains data for stake accounts by epoch, including the active amount staked, lockup information, and related information."
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__snapshot_stake_accounts'
+          id_column: 'stake_pubkey'
     columns:
       - name: epoch
         description: "Epoch when data was captured"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: stake_pubkey
         description: "Address of stake account"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: vote_pubkey
         description: "Vote account of the validator this stake is delegated to"
         tests:
@@ -63,13 +73,24 @@ models:
         description: "SOL held in this account"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: rent_epoch
         description: "Epoch at which this account will next owe rent"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: FACT_STAKE_ACCOUNTS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter    
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}' 
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter   
       - name: MODIFIED_TIMESTAMP
         description: '{{ doc("modified_timestamp") }}' 
+        tests:
+          - dbt_expectations.expect_column_to_exist

--- a/models/gold/gov/gov__fact_validators.yml
+++ b/models/gold/gov/gov__fact_validators.yml
@@ -2,23 +2,35 @@ version: 2
 models:
   - name: gov__fact_validators
     description: "This table contains validator data by epoch, sourced from the Validators.app API"
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__snapshot_validators_app_data'
+          id_column: 'node_pubkey'
     columns:
       - name: epoch
         description: "The epoch when data was recorded"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: node_pubkey
         description: "Account for the validator node"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: vote_pubkey
         description: "vote account for the validator"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: active_stake
         description: "Active stake in SOL delegated to the validator"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: admin_warning
         description: "Admin warning for the validator"
         tests:
@@ -31,10 +43,12 @@ models:
         description: "% of rewards payout to the vote account"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: created_at
         description: "date when validator was created"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: data_center_key
         description: "identifier for the data center"
         tests:
@@ -47,6 +61,7 @@ models:
         description: "Status whether the validator is offline/delinquent"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: details
         description: "Details for the validator"
         tests:
@@ -73,21 +88,34 @@ models:
           - dbt_expectations.expect_column_to_exist
       - name: validator_name
         description: "Name of the validator"
+        tests:
+          - dbt_expectations.expect_column_to_exist
       - name: software_version
         description: "Solana mainnet version"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: updated_at
         description: "Last date validator was updated"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: www_url
         description: "url for the validator"
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: FACT_VALIDATORS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: MODIFIED_TIMESTAMP
-        description: '{{ doc("modified_timestamp") }}' 
+        description: '{{ doc("modified_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist

--- a/models/gold/gov/gov__fact_vote_accounts.yml
+++ b/models/gold/gov/gov__fact_vote_accounts.yml
@@ -2,15 +2,26 @@ version: 2
 models:
   - name: gov__fact_vote_accounts
     description: "This table contains data for each vote account by epoch, including the validator's public key, voting weight, commission rate, and related information."
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__snapshot_vote_accounts'
+          id_column: 'vote_pubkey'
     columns:
       - name: epoch
         description: "Epoch when data was captured"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: authorized_voter
         description: "Account responsible for signing vote transactions"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null:
+              where: (modified_timestamp >= current_date - 7) and authorized_withdrawer <> '11111111111111111111111111111111'
       - name: last_epoch_active
         description: "last epoch when vote account was active"
         tests:
@@ -19,26 +30,32 @@ models:
         description: "Account responsible for signing stake withdrawal transactions"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: commission
         description: "% of rewards payout to the vote account"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: epoch_credits
         description: "Credits earned by the end of epochs, containing epoch/credits/previous credits"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: last_timestamp_slot
         description: "Last slot voted on"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: last_timestamp
         description: "The timestamp when last slot was voted on"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: node_pubkey
         description: "pubkey for the Solana validator node"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: prior_voters
         description: "Prior voters for the vote account"
         tests:
@@ -51,25 +68,39 @@ models:
         description: "Votes during epoch"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: account_sol
         description: "SOL assigned to this account"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: owner
         description: "Program account that owns the vote account"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: rent_epoch
         description: "Epoch at which this account will next owe rent"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: vote_pubkey
         description: "Public key for the vote account"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: FACT_VOTE_ACCOUNTS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter  
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter   
       - name: MODIFIED_TIMESTAMP
-        description: '{{ doc("modified_timestamp") }}' 
+        description: '{{ doc("modified_timestamp") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist

--- a/models/gold/nft/nft__fact_nft_sales.yml
+++ b/models/gold/nft/nft__fact_nft_sales.yml
@@ -2,66 +2,108 @@ version: 2
 models:
   - name: nft__fact_nft_sales
     description: NFT sales on Solana that occur on Magic Eden, Yawww, Opensea, the SMB marketplace, Solanart, Solport, Coral Cube, Hyperspace, Hadeswap, Exchange Art, Tensorswap and Solsniper.  
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
+    tests:
+      - reference_tx_missing:
+          reference_tables:
+            - 'silver__nft_sales_magic_eden_v2'
+            - 'silver__nft_sales_solanart'
+            - 'silver__nft_sales_hadeswap'
+            - 'silver__nft_sales_hyperspace'
+            - 'silver__nft_sales_exchange_art'
+            - 'silver__nft_sales_amm_sell_decoded'
+            - 'silver__nft_sales_tensorswap'
+            - 'silver__nft_sales_solsniper'
+            - 'silver__nft_sales_tensorswap_cnft'
+            - 'silver__nft_sales_magic_eden_cnft'
+            - 'silver__nft_sales_solsniper_cnft'
+          id_column: 'tx_id'
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID 
         description: "{{ doc('program_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: PURCHASER
         description: "{{ doc('purchaser') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SELLER
         description: "{{ doc('seller') }}"
         tests: 
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: SALES_AMOUNT
         description: "{{ doc('sales_amount') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: MARKETPLACE
         description: "{{ doc('marketplace') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: TREE_AUTHORITY
         description: "{{ doc('tree_authority') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null:
+              where: (modified_timestamp >= current_date - 7) and IS_COMPRESSED
       - name: MERKLE_TREE
         description: "{{ doc('merkle_tree') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null:
+              where: (modified_timestamp >= current_date - 7) and IS_COMPRESSED
       - name: LEAF_INDEX
         description: "{{ doc('leaf_index') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null:
+              where: (modified_timestamp >= current_date - 7) and IS_COMPRESSED
       - name: IS_COMPRESSED
         description: "{{ doc('is_compressed') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
       - name: FACT_NFT_SALES_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter
+          - unique: *recent_date_filter 
       - name: INSERTED_TIMESTAMP
-        description: '{{ doc("inserted_timestamp") }}'   
+        description: '{{ doc("inserted_timestamp") }}'  
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null: *recent_date_filter 
       - name: MODIFIED_TIMESTAMP
         description: '{{ doc("modified_timestamp") }}' 


### PR DESCRIPTION
Add tests to gold incremental tables
- create `reference_tx_missing` test to compare id's between gold table and multiple referenced silver tables
- tests for uniqueness, recency, and nulls

Example of failed test for `reference_tx_missing` -- deleted a tensorswap sale in `nft.fact_nft_sales` and test alerted successfully:

```
19:27:56  Completed with 1 error and 0 warnings:
Failure in test reference_tx_missing_nft__fact_nft_sales_tx_id__silver__nft_sales_magic_eden_v2__silver__nft_sales_solanart__silver__nft_sales_hadeswap__silver__nft_sales_hyperspace__silver__nft_sales_exchange_art__silver__nft_sales_amm_sell_decoded__silver__nft_sales_tensorswap__silver__nft_sales_solsniper__silver__nft_sales_tensorswap_cnft__silver__nft_sales_magic_eden_cnft__silver__nft_sales_solsniper_cnft (models/gold/nft/nft__fact_nft_sales.yml) 
19:27:56 Got 1 result, configured to fail if != 0 
19:27:56 compiled Code at target/compiled/solana_models/models/gold/nft/nft__fact_nft_sales.yml/reference_tx_missing_nft__fact_7e70cad00219051bcc650ee67f385166.sql 
19:27:56 See test failures: ---------------------------------------------------------------------- select * from SOLANA_DEV.reference_tx_missing_nft.fact_nft_sales_tx_id
```

Successful test runs:
```
19:55:16  Finished running 9 incremental models, 11 hooks in 0 hours 1 minutes and 33.59 seconds (93.59s). 19:55:16 19:55:16  Completed successfully 19:55:16 19:55:16  Done. PASS=9 WARN=0 ERROR=0 SKIP=0 TOTAL=9
```

