### PR TITLE
update tests for generic swaps and gold validators

### DIFF
--- a/models/gold/gov/gov__fact_validators.yml
+++ b/models/gold/gov/gov__fact_validators.yml
@@ -5,6 +5,10 @@ models:
     recent_date_filter: &recent_date_filter
       config:
         where: modified_timestamp >= current_date - 7
+    recent_date_filter_and_exclude_records: &recent_date_filter_and_exclude_records
+      config:
+        where: modified_timestamp >= current_date - 7 and fact_validators_id not in ('6bc02a10c28c15613f7f2928c28042f8','4dd0900961b16a7e72ebaacbffe44044','2f9e9b502eaa55c1e0c97ebd1005138a','849bcdc32080e7036196ee3946b7f108','69ede8ffd174d0d181ca941297a31d06')
+        # API response returned null values for these records from epochs 666-668 so excluding from tests
     tests:
       - reference_tx_missing:
           reference_tables:
@@ -30,7 +34,7 @@ models:
         description: "Active stake in SOL delegated to the validator"
         tests:
           - dbt_expectations.expect_column_to_exist
-          - not_null: *recent_date_filter
+          - not_null: *recent_date_filter_and_exclude_records
       - name: admin_warning
         description: "Admin warning for the validator"
         tests:
@@ -43,7 +47,7 @@ models:
         description: "% of rewards payout to the vote account"
         tests:
           - dbt_expectations.expect_column_to_exist
-          - not_null: *recent_date_filter
+          - not_null: *recent_date_filter_and_exclude_records
       - name: created_at
         description: "date when validator was created"
         tests:
@@ -61,7 +65,7 @@ models:
         description: "Status whether the validator is offline/delinquent"
         tests:
           - dbt_expectations.expect_column_to_exist
-          - not_null: *recent_date_filter
+          - not_null: *recent_date_filter_and_exclude_records
       - name: details
         description: "Details for the validator"
         tests:

--- a/models/gold/gov/gov__fact_validators.yml
+++ b/models/gold/gov/gov__fact_validators.yml
@@ -7,8 +7,8 @@ models:
         where: modified_timestamp >= current_date - 7
     recent_date_filter_and_exclude_records: &recent_date_filter_and_exclude_records
       config:
-        where: modified_timestamp >= current_date - 7 and fact_validators_id not in ('6bc02a10c28c15613f7f2928c28042f8','4dd0900961b16a7e72ebaacbffe44044','2f9e9b502eaa55c1e0c97ebd1005138a','849bcdc32080e7036196ee3946b7f108','69ede8ffd174d0d181ca941297a31d06')
-        # API response returned null values for these records from epochs 666-668 so excluding from tests
+        where: modified_timestamp >= current_date - 7 and NOT (node_pubkey = 'KtKiqBftjVcPR9WNi8dyoXoajj4xWtebf8enapgDv2Y' AND epoch in (666,667,668)) and NOT (node_pubkey = '2ViH5QVqCX3LjsCHBniMN2yfUEVc6W2cp9M6m6ZpVpxi' AND epoch = 667) and NOT (node_pubkey = 'isusUYC5gwsBpARY4Mf8wnFahMDVCtvPp91VBnR81yF' AND epoch = 668)
+        # API response returned null values for these validators from epochs 666-668 so excluding from tests
     tests:
       - reference_tx_missing:
           reference_tables:

--- a/models/silver/swaps/generic/silver__swaps_intermediate_generic.yml
+++ b/models/silver/swaps/generic/silver__swaps_intermediate_generic.yml
@@ -87,11 +87,6 @@ models:
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
- remove recency test from generic swaps
- exclude specific pubkeys from gold validators due to null response from API

tests:
- fact_validators
```
12:06:33  Finished running 37 data tests, 11 project hooks in 0 hours 0 minutes and 38.94 seconds (38.94s).
12:06:33  
12:06:33  Completed successfully
12:06:33  
12:06:33  Done. PASS=37 WARN=0 ERROR=0 SKIP=0 TOTAL=37
```
- silver__swaps_intermediate_generic
```
12:10:01  Finished running 10 data tests, 11 project hooks in 0 hours 2 minutes and 30.67 seconds (150.67s).
12:10:01  
12:10:01  Completed successfully
12:10:01  
12:10:01  Done. PASS=10 WARN=0 ERROR=0 SKIP=0 TOTAL=10
```