### PR TITLE
deprecate hyperspace and lido

### DIFF
--- a/models/gold/defi/defi__fact_stake_pool_actions.sql
+++ b/models/gold/defi/defi__fact_stake_pool_actions.sql
@@ -21,23 +21,12 @@ SELECT
     stake_pool,
     amount,
     'SOL' AS token,
-    COALESCE (
-        stake_pool_actions_lido_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['tx_id','index']
-        ) }}
-    ) AS fact_stake_pool_actions_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    stake_pool_actions_lido_id AS fact_stake_pool_actions_id,
+    inserted_timestamp,
+    modified_timestamp
 FROM
     {{ ref(
-        'silver__stake_pool_actions_lido'
+        'silver__stake_pool_actions_lido_view'
     ) }}
 {% if is_incremental() %}
 WHERE modified_timestamp >= (

--- a/models/gold/nft/nft__fact_nft_sales.sql
+++ b/models/gold/nft/nft__fact_nft_sales.sql
@@ -219,6 +219,31 @@ SELECT
 FROM
     {{ ref('silver__nft_sales_solsniper_v1_events_view') }}
 UNION ALL
+SELECT
+    'hyperspace',
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    program_id,
+    purchaser,
+    seller,
+    mint,
+    sales_amount,
+    NULL as tree_authority,
+    NULL as merkle_tree,
+    NULL as leaf_index,
+    FALSE as is_compressed,
+    nft_sales_hyperspace_id AS fact_nft_sales_id,
+    inserted_timestamp,
+    modified_timestamp
+FROM
+    {{ ref('silver__nft_sales_hyperspace_view') }}
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
+UNION ALL
 {% endif %}
 -- Only select from active models during incremental
 SELECT
@@ -324,42 +349,6 @@ SELECT
     ) AS modified_timestamp
 FROM
     {{ ref('silver__nft_sales_hadeswap') }}
-{% if is_incremental() %}
-WHERE
-    modified_timestamp >= '{{ max_modified_timestamp }}'
-{% endif %}
-UNION ALL
-SELECT
-    'hyperspace',
-    block_timestamp,
-    block_id,
-    tx_id,
-    succeeded,
-    program_id,
-    purchaser,
-    seller,
-    mint,
-    sales_amount,
-    NULL as tree_authority,
-    NULL as merkle_tree,
-    NULL as leaf_index,
-    FALSE as is_compressed,
-    COALESCE (
-        nft_sales_hyperspace_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['tx_id','mint']
-        ) }}
-    ) AS fact_nft_sales_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
-FROM
-    {{ ref('silver__nft_sales_hyperspace') }}
 {% if is_incremental() %}
 WHERE
     modified_timestamp >= '{{ max_modified_timestamp }}'

--- a/models/silver/nfts/silver___nft_distinct_mints.sql
+++ b/models/silver/nfts/silver___nft_distinct_mints.sql
@@ -168,7 +168,7 @@ SELECT
     mint,
     _inserted_timestamp
 FROM
-    {{ ref('silver__nft_sales_hyperspace') }}
+    {{ ref('silver__nft_sales_hyperspace_view') }}
 
 {% if is_incremental() %}
 WHERE

--- a/models/silver/nfts/silver__nft_sales_hyperspace.sql
+++ b/models/silver/nfts/silver__nft_sales_hyperspace.sql
@@ -3,7 +3,9 @@
     unique_key = "CONCAT_WS('-', tx_id, mint)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    tags = ['scheduled_non_core'],
+    full_refresh = false,
+    enabled = false,
 ) }}
 
 WITH base_table AS (

--- a/models/silver/nfts/silver__nft_sales_hyperspace_view.sql
+++ b/models/silver/nfts/silver__nft_sales_hyperspace_view.sql
@@ -1,0 +1,24 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+  block_timestamp,
+  block_id,
+  tx_id,
+  succeeded,
+  program_id,
+  purchaser,
+  seller,
+  mint,
+  sales_amount,
+  _inserted_timestamp,
+  nft_sales_hyperspace_id,
+  inserted_timestamp,
+  modified_timestamp,
+  _invocation_id
+FROM
+  {{ source(
+    'solana_silver',
+    'nft_sales_hyperspace'
+  ) }}

--- a/models/silver/staking/silver__stake_pool_actions_lido.sql
+++ b/models/silver/staking/silver__stake_pool_actions_lido.sql
@@ -4,7 +4,9 @@
     incremental_strategy = 'merge',
     cluster_by = ['block_timestamp::DATE','modified_timestamp::date'],
     merge_exclude_columns = ["inserted_timestamp"],
-    tags = ['scheduled_non_core']
+    tags = ['scheduled_non_core'],
+    full_refresh = false,
+    enabled = false,
 ) }}
 
 WITH base_lido_events AS (

--- a/models/silver/staking/silver__stake_pool_actions_lido_view.sql
+++ b/models/silver/staking/silver__stake_pool_actions_lido_view.sql
@@ -1,0 +1,28 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT 
+    tx_id,
+    block_id,
+    block_timestamp,
+    index,
+    succeeded,
+    action,
+    stake_pool,
+    stake_pool_withdraw_authority,
+    stake_pool_deposit_authority,
+    address,
+    reserve_stake_address,
+    amount,
+    _inserted_timestamp,
+    _unique_key,
+    stake_pool_actions_lido_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
+FROM
+  {{ source(
+    'solana_silver',
+    'stake_pool_actions_lido'
+  ) }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -86,6 +86,8 @@ sources:
       - name: nft_sales_solsniper_v1_events
       - name: swaps_intermediate_jupiterv6
       - name: nft_sales_amm_sell
+      - name: nft_sales_hyperspace
+      - name: stake_pool_actions_lido
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
- Lido shut down on Solana months ago and the random staking tx's still using the program have been non-existent
- Hyperspace shut down on 9/17 https://x.com/hyperspacexyz/status/1830983003138318758

Runs for new views and related models:
```
20:32:10  2 of 4 OK created sql view model silver.stake_pool_actions_lido_view ........... [SUCCESS 1 in 2.50s]
20:32:10  1 of 4 OK created sql view model silver.nft_sales_hyperspace_view .............. [SUCCESS 1 in 2.68s]
20:32:21  3 of 4 OK created sql incremental model defi.fact_stake_pool_actions ........... [SUCCESS 6 in 10.47s]
20:32:21  4 of 4 OK created sql incremental model nft.fact_nft_sales ..................... [SUCCESS 80 in 10.83s]
```