### PR TITLE
deprecate silver__snapshot_stake_accounts

### DIFF
--- a/.github/workflows/dbt_run_daily.yml
+++ b/.github/workflows/dbt_run_daily.yml
@@ -48,7 +48,7 @@ jobs:
           dbt run-operation run_sp_snapshot_get_stake_accounts
           dbt run-operation run_sp_snapshot_get_vote_program_accounts
           dbt run -s models/bronze/bronze__validators_app_api.sql models/bronze/bronze__vote_accounts.sql models/bronze/bronze__stake_program_accounts.sql models/bronze/bronze__vote_accounts_extended_stats.sql
-          dbt run -s models/silver/validator/silver__snapshot_stake_accounts.sql models/silver/validator/silver__snapshot_validators_app_data.sql models/silver/validator/silver__snapshot_vote_accounts.sql models/silver/validator/silver__snapshot_vote_accounts_extended_stats.sql
+          dbt run -s models/silver/validator/silver__snapshot_validators_app_data.sql models/silver/validator/silver__snapshot_vote_accounts.sql models/silver/validator/silver__snapshot_vote_accounts_extended_stats.sql
           dbt run -s "solana_models,tag:nft_api"
           dbt run -s "solana_models,tag:daily"
 

--- a/models/gold/gov/gov__fact_stake_accounts.sql
+++ b/models/gold/gov/gov__fact_stake_accounts.sql
@@ -1,85 +1,106 @@
-{{ config(
+{{ 
+  config(
     materialized = 'incremental',
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'VALIDATOR' }}},
+    meta = { 'database_tags': { 'table': { 'PURPOSE': 'VALIDATOR' }}},
     unique_key = ['fact_stake_accounts_id'],
-    cluster_by = ['epoch','activation_epoch','deactivation_epoch'],
+    cluster_by = ['epoch', 'activation_epoch', 'deactivation_epoch'],
     merge_exclude_columns = ["inserted_timestamp"],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(stake_pubkey, vote_pubkey)'),
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(stake_pubkey, vote_pubkey)'),
     tags = ['scheduled_non_core']
-) }}
+  ) 
+}}
+
+{% set v1_cutoff_epoch = 669 %}
 
 {% if execute %}
     {% if is_incremental() %}
         {% set query %}
-            SELECT MAX(modified_timestamp) AS max_modified_timestamp
-            FROM {{ this }}
+            SELECT 
+              max(modified_timestamp) AS max_modified_timestamp
+            FROM 
+              {{ this }}
         {% endset %}
-
         {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
     {% endif %}
 {% endif %}
 
 SELECT
-  epoch_recorded :: INT AS epoch,
-  stake_pubkey,
-  vote_pubkey,
-  authorized_staker,
-  authorized_withdrawer,
-  lockup,
-  rent_exempt_reserve,
-  credits_observed,
-  activation_epoch,
-  deactivation_epoch,
-  active_stake,
-  warmup_cooldown_rate,
-  type_stake,
-  program,
-  account_sol,
-  rent_epoch,
-  COALESCE (
-  snapshot_stake_accounts_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['epoch', 'stake_pubkey']
-        ) }}
-    ) AS fact_stake_accounts_id,
-  COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-  COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    epoch_recorded::INT AS epoch,
+    stake_pubkey,
+    vote_pubkey,
+    authorized_staker,
+    authorized_withdrawer,
+    lockup,
+    rent_exempt_reserve,
+    credits_observed,
+    activation_epoch,
+    deactivation_epoch,
+    active_stake,
+    warmup_cooldown_rate,
+    type_stake,
+    program,
+    account_sol,
+    rent_epoch,
+    snapshot_stake_accounts_2_id AS fact_stake_accounts_id,
+    inserted_timestamp,
+    modified_timestamp
 FROM
-  {{ ref('silver__snapshot_stake_accounts') }}
-{% if is_incremental() %}
+    {{ ref('silver__snapshot_stake_accounts_2') }}
 WHERE
-    modified_timestamp >= '{{ max_modified_timestamp }}'
-{% endif %}
+    epoch > {{ v1_cutoff_epoch }}
+    {% if is_incremental() %}
+    AND modified_timestamp >= '{{ max_modified_timestamp }}'
+    {% endif %}
+UNION ALL
+SELECT
+    epoch_recorded::INT AS epoch,
+    stake_pubkey,
+    vote_pubkey,
+    authorized_staker,
+    authorized_withdrawer,
+    lockup,
+    rent_exempt_reserve,
+    credits_observed,
+    activation_epoch,
+    deactivation_epoch,
+    active_stake,
+    warmup_cooldown_rate,
+    type_stake,
+    program,
+    account_sol,
+    rent_epoch,
+    coalesce(snapshot_stake_accounts_id, {{ dbt_utils.generate_surrogate_key(['epoch', 'stake_pubkey']) }}) AS fact_stake_accounts_id,
+    coalesce(inserted_timestamp, '2000-01-01') AS inserted_timestamp,
+    coalesce(modified_timestamp, '2000-01-01') AS modified_timestamp
+FROM
+    {{ ref('silver__snapshot_stake_accounts') }}
+WHERE
+    epoch <= {{ v1_cutoff_epoch }}
+    {% if is_incremental() %}
+    AND modified_timestamp >= '{{ max_modified_timestamp }}'
+    {% endif %}
 {% if not is_incremental() %}
 UNION ALL
 SELECT
-  epoch_ingested_at :: INT AS epoch,
-  stake_pubkey,
-  vote_pubkey,
-  authorized_staker,
-  authorized_withdrawer,
-  lockup,
-  rent_exempt_reserve,
-  credits_observed,
-  activation_epoch,
-  deactivation_epoch,
-  active_stake,
-  warmup_cooldown_rate,
-  type_stake,
-  program,
-  account_sol,
-  rent_epoch,
-  {{ dbt_utils.generate_surrogate_key(
-        ['epoch', 'stake_pubkey']
-  ) }} AS fact_stake_accounts_id,
-  '2000-01-01' as inserted_timestamp,
-  '2000-01-01' AS modified_timestamp
+    epoch_ingested_at::INT AS epoch,
+    stake_pubkey,
+    vote_pubkey,
+    authorized_staker,
+    authorized_withdrawer,
+    lockup,
+    rent_exempt_reserve,
+    credits_observed,
+    activation_epoch,
+    deactivation_epoch,
+    active_stake,
+    warmup_cooldown_rate,
+    type_stake,
+    program,
+    account_sol,
+    rent_epoch,
+    {{ dbt_utils.generate_surrogate_key(['epoch', 'stake_pubkey']) }} AS fact_stake_accounts_id,
+    '2000-01-01' AS inserted_timestamp,
+    '2000-01-01' AS modified_timestamp
 FROM
-  {{ ref('silver__historical_stake_account') }}
+    {{ ref('silver__historical_stake_account') }}
 {% endif %}

--- a/models/gold/gov/gov__fact_stake_accounts.yml
+++ b/models/gold/gov/gov__fact_stake_accounts.yml
@@ -8,7 +8,7 @@ models:
     tests:
       - reference_tx_missing:
           reference_tables:
-            - 'silver__snapshot_stake_accounts'
+            - 'silver__snapshot_stake_accounts_2'
           id_column: 'stake_pubkey'
     columns:
       - name: epoch


### PR DESCRIPTION
- Deprecate `silver__snapshot_stake_accounts`
  - Only use it for epochs `<= 669`
  - Records from epochs `> 670` will use `silver__snapshot_stake_accounts_2`
  - Remove from schedule daily run

The gold table can be reset to epoch 669 then re-run with new code
```
delete from solana_dev.gov.fact_stake_accounts
where epoch >= 670;
```

Run and tests on M for the new records (epoch >= 670)
```
14:53:33  Finished running 1 incremental model, 27 data tests, 11 project hooks in 0 hours 2 minutes and 17.15 seconds (137.15s).
14:53:34  
14:53:34  Completed successfully
14:53:34  
14:53:34  Done. PASS=28 WARN=0 ERROR=0 SKIP=0 TOTAL=28
```

Reconciliation in DEV shows all the records with epoch `>= 670` come from the new table
```
select 
    epoch_recorded::INT AS epoch,
    stake_pubkey,
    vote_pubkey,
    authorized_staker,
    authorized_withdrawer,
    lockup,
    rent_exempt_reserve,
    credits_observed,
    activation_epoch,
    deactivation_epoch,
    active_stake,
    warmup_cooldown_rate,
    type_stake,
    program,
    account_sol,
    rent_epoch,
from solana_dev.silver.snapshot_stake_accounts_2
where epoch_recorded >= 670
except
select 
    epoch,
    stake_pubkey,
    vote_pubkey,
    authorized_staker,
    authorized_withdrawer,
    lockup,
    rent_exempt_reserve,
    credits_observed,
    activation_epoch,
    deactivation_epoch,
    active_stake,
    warmup_cooldown_rate,
    type_stake,
    program,
    account_sol,
    rent_epoch,
from solana_dev.gov.fact_stake_accounts
where epoch >= 670;
```