### PR TITLE
add tag to exclude from test; add back events_inner

### DIFF
--- a/.github/workflows/dbt_test.yml
+++ b/.github/workflows/dbt_test.yml
@@ -42,4 +42,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt test -s "solana_models,./models" "solana_models,tag:test_daily" --exclude tag:test_weekly tag:test_hourly "test_silver__transactions_missing_partitions" models/gold/core/core__fact_events_inner.sql models/silver/silver__events_inner.sql
+          dbt test -s "solana_models,./models" "solana_models,tag:test_daily" --exclude tag:test_weekly tag:test_hourly tag:exclude_test_daily "test_silver__transactions_missing_partitions"

--- a/models/silver/validator/silver__snapshot_stake_accounts.sql
+++ b/models/silver/validator/silver__snapshot_stake_accounts.sql
@@ -3,7 +3,7 @@
     unique_key = "CONCAT_WS('-', epoch_recorded, stake_pubkey)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['modified_timestamp::DATE'],
-    tags = ['validator']
+    tags = ['validator','exclude_test_daily']
 ) }}
 
 WITH base AS (


### PR DESCRIPTION
- add 'exclude_test_daily' tag for older version of snapshot_stake_accounts
- remove the events_inner tables from the exclusion