### PR TITLE
add new dca signer addresses

### DIFF
--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
@@ -73,7 +73,10 @@
     'DCAKuApAuZtVNYLk3KTAVW9GLWVvPbnb5CxxRRmVgcTr',
     'DCAKxn5PFNN1mBREPWGdk1RXg5aVH9rPErLfBFEi2Emb',
     'DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw',
-    'BFQ2te7ERN319HA87mn6NJ9oxMUvNxyifqEhUWHFTie9'
+    'BFQ2te7ERN319HA87mn6NJ9oxMUvNxyifqEhUWHFTie9',
+    'JD1dHSqYkrXvqUVL8s6gzL1yB7kpYymsHfwsGxgwp55h',
+    'JD38n7ynKYcgPpF7k1BhXEeREu1KqptU93fVGy3S624k',
+    'JD25qVdtd65FoiXNmR89JjmoJdYk9sjYQeSTZAALFiMy'
 ] %}
 
 WITH all_routes AS (

--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
@@ -106,7 +106,7 @@ models:
               expression: "= True"
               config:
                 where: >
-                  swapper IN ('DCAKuApAuZtVNYLk3KTAVW9GLWVvPbnb5CxxRRmVgcTr','DCAKxn5PFNN1mBREPWGdk1RXg5aVH9rPErLfBFEi2Emb','DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw','BFQ2te7ERN319HA87mn6NJ9oxMUvNxyifqEhUWHFTie9')
+                  swapper IN ('DCAKuApAuZtVNYLk3KTAVW9GLWVvPbnb5CxxRRmVgcTr','DCAKxn5PFNN1mBREPWGdk1RXg5aVH9rPErLfBFEi2Emb','DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw','BFQ2te7ERN319HA87mn6NJ9oxMUvNxyifqEhUWHFTie9','JD1dHSqYkrXvqUVL8s6gzL1yB7kpYymsHfwsGxgwp55h','JD38n7ynKYcgPpF7k1BhXEeREu1KqptU93fVGy3S624k','JD25qVdtd65FoiXNmR89JjmoJdYk9sjYQeSTZAALFiMy')
                   AND _inserted_timestamp >= current_date - 7
                   AND block_timestamp >= '2024-05-12' /* last recorded date where some txs used the Beta DCA program (Betam4GuxvAes2uQ5vX8SackcxL5pxRuHowM5m2Ykmcq) */
       - name: DCA_REQUESTER

--- a/tests/test_silver__decoded_logs_jupiter_dca_signers.sql
+++ b/tests/test_silver__decoded_logs_jupiter_dca_signers.sql
@@ -10,4 +10,7 @@ WHERE
         'DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw',
         'DCAKuApAuZtVNYLk3KTAVW9GLWVvPbnb5CxxRRmVgcTr',
         'BFQ2te7ERN319HA87mn6NJ9oxMUvNxyifqEhUWHFTie9' /* this was used early on for a few dca txs */
+        'JD1dHSqYkrXvqUVL8s6gzL1yB7kpYymsHfwsGxgwp55h',
+        'JD38n7ynKYcgPpF7k1BhXEeREu1KqptU93fVGy3S624k',
+        'JD25qVdtd65FoiXNmR89JjmoJdYk9sjYQeSTZAALFiMy'
     )


### PR DESCRIPTION
- Add additional addresses to dca signer whitelist
- Update PROD -- the incorrect records all have a `dca_requester` value and `FALSE` for `is_dca_swap`
```
UPDATE solana.silver.swaps_intermediate_jupiterv6_2
SET is_dca_swap = TRUE
WHERE dca_requester is not null
and _inserted_timestamp::date >='2024-09-14';
```