### PR TITLE
partition by hour

### DIFF
--- a/models/bronze/streamline/bronze__streamline_FR_helius_cnft_metadata.sql
+++ b/models/bronze/streamline/bronze__streamline_FR_helius_cnft_metadata.sql
@@ -5,8 +5,8 @@
 {% set model = "helius_nft_metadata" %}
 {{ streamline_external_table_FR_query(
     model,
-    partition_function = "concat_ws('-',split_part(split_part(file_name,'/',3),'_',1),split_part(split_part(file_name,'/',3),'_',2),split_part(split_part(file_name,'/',3),'_',3))",
-    partition_name = "_partition_by_created_date",
+    partition_function = "to_timestamp(split_part(file_name, '/', -2), 'YYYY_MM_DD_HH24')",
+    partition_name = "_partition_by_created_hour",
     unique_key = "data:id::STRING AS mint",
     other_cols="HELIUS_NFT_METADATA_REQUESTS_ID, MAX_MINT_EVENT_INSERTED_TIMESTAMP"
 ) }}

--- a/models/bronze/streamline/bronze__streamline_helius_cnft_metadata.sql
+++ b/models/bronze/streamline/bronze__streamline_helius_cnft_metadata.sql
@@ -5,8 +5,8 @@
 {% set model = "helius_nft_metadata" %}
 {{ streamline_external_table_query(
     model,
-    partition_function = "concat_ws('-',split_part(split_part(file_name,'/',3),'_',1),split_part(split_part(file_name,'/',3),'_',2),split_part(split_part(file_name,'/',3),'_',3))",
-    partition_name = "_partition_by_created_date",
+    partition_function = "to_timestamp(split_part(file_name, '/', -2), 'YYYY_MM_DD_HH24')",
+    partition_name = "_partition_by_created_hour",
     unique_key = "data:id::STRING AS mint",
     other_cols="HELIUS_NFT_METADATA_REQUESTS_ID, MAX_MINT_EVENT_INSERTED_TIMESTAMP"
 ) }}

--- a/models/streamline/nft/metadata/complete/streamline__complete_helius_cnft_metadata_requests.sql
+++ b/models/streamline/nft/metadata/complete/streamline__complete_helius_cnft_metadata_requests.sql
@@ -13,7 +13,7 @@ SELECT
     mint,
     helius_nft_metadata_requests_id,
     max_mint_event_inserted_timestamp,
-    _partition_by_created_date,
+    _partition_by_created_hour,
     _inserted_timestamp
 FROM
     {% if is_incremental() %}

--- a/models/streamline/nft/metadata/requests/streamline__helius_cnft_metadata_requests.sql
+++ b/models/streamline/nft/metadata/requests/streamline__helius_cnft_metadata_requests.sql
@@ -74,7 +74,7 @@ SELECT
     group_num,
     concat_ws('_', current_timestamp, group_num) AS helius_nft_metadata_requests_id,
     max_mint_event_inserted_timestamp::string AS max_mint_event_inserted_timestamp,
-    replace(current_date::string, '-', '_') AS partition_key,
+    to_char(current_timestamp, 'YYYY_MM_DD_HH24') AS partition_key,
     {{ target.database }}.live.udf_api(
         'POST',
         '{service}/?api-key={Authentication}',


### PR DESCRIPTION
- Change the bronze partition to be by hour instead of by date. It is taking too long to scan bronze when trying to update the "complete" table when it has to scan by date. Making this a finer grain should improve performance