### PR TITLE
use streamline 2.0 raw data

### DIFF
--- a/models/silver/silver__blocks.sql
+++ b/models/silver/silver__blocks.sql
@@ -2,15 +2,17 @@
   materialized = 'incremental',
   unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp::DATE','_inserted_timestamp::date'],
+  cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::date'],
   tags = ['scheduled_core'],
   full_refresh = false
 ) }}
 
+{% set cutover_block_id = 295976124 %}
+
 {% if execute %}
   {% set max_inserted_query %}
   SELECT
-      MAX(_inserted_timestamp) AS _inserted_timestamp
+      max(_inserted_timestamp) AS _inserted_timestamp
   FROM
     {{ this }}
   {% endset %}
@@ -18,21 +20,40 @@
 
   {% if is_incremental() %}
   {% set get_dates_to_load_query %}
-    WITH base_blocks AS (
-      SELECT
-        *
-      FROM
-        {{ ref('bronze__blocks2') }}
-      WHERE
-        _inserted_date >= '{{max_inserted_timestamp}}'::date - INTERVAL '1 DAY'
-    )
+  WITH base_blocks AS (
     SELECT
-      MIN(_inserted_timestamp) AS load_timestamp,
-      MIN(_inserted_date) AS load_date
+      block_id,
+      value,
+      data,
+      error,
+      _inserted_date,
+      _inserted_timestamp
     FROM
-      base_blocks
+      {{ ref('bronze__blocks2') }}
     WHERE
-      _inserted_timestamp > '{{max_inserted_timestamp}}'
+      _inserted_date >= '{{max_inserted_timestamp}}'::DATE - INTERVAL '1 DAY'
+      AND block_id < {{cutover_block_id}}
+    UNION ALL
+    SELECT
+      block_id,
+      value,
+      data,
+      error,
+      to_date(_partition_by_created_date, 'YYYY_MM_DD') AS _inserted_date,
+      _inserted_timestamp
+    FROM
+      {{ ref('bronze__streamline_blocks_2')}}
+    WHERE
+      _inserted_date >= '{{max_inserted_timestamp}}'::DATE - INTERVAL '1 DAY'
+      AND block_id >= {{cutover_block_id}}
+  )
+  SELECT
+    min(_inserted_timestamp) AS load_timestamp,
+    min(_inserted_date) AS load_date
+  FROM
+    base_blocks
+  WHERE
+    _inserted_timestamp > '{{max_inserted_timestamp}}'
   {% endset %}
 
   {% set get_dates_to_load_columns = run_query(get_dates_to_load_query).columns %}
@@ -42,40 +63,68 @@
 {% endif %}
 
 
+/*
+This CTE (pre_final) combines data from two sources:
+1. Legacy data from 'bronze__blocks2' for blocks before the cutover_block_id
+2. New data using streamline 2.0 raw data from 'bronze__streamline_blocks_2' for blocks after and including the cutover_block_id
+*/
 WITH pre_final AS (
   SELECT
-    VALUE :block_id :: INTEGER AS block_id,
-    TO_TIMESTAMP_NTZ(
-      DATA :blockTime
-    ) AS block_timestamp,
+    value:block_id::INTEGER AS block_id,
+    to_timestamp_ntz(data:blockTime) AS block_timestamp,
     'mainnet' AS network,
     'solana' AS chain_id,
-    DATA :blockHeight AS block_height,
-    DATA :blockhash :: STRING AS block_hash,
-    DATA :parentSlot AS previous_block_id,
-    DATA :previousBlockhash :: STRING AS previous_block_hash,
+    data:blockHeight AS block_height,
+    data:blockhash::STRING AS block_hash,
+    data:parentSlot AS previous_block_id,
+    data:previousBlockhash::STRING AS previous_block_hash,
     _inserted_date,
     _inserted_timestamp
   FROM
     {{ ref('bronze__blocks2') }}
   WHERE
-    block_id IS NOT NULL
+    block_id < {{cutover_block_id}}
+    AND block_id IS NOT NULL
     AND error IS NULL
     {% if is_incremental() %}
-    AND _inserted_date = '{{load_date}}'
-    AND _inserted_timestamp >= '{{load_timestamp}}'
+    AND _inserted_date = '{{ load_date }}'
+    AND _inserted_timestamp >= '{{ load_timestamp }}'
     {% else %}
-    AND _inserted_date = '2022-08-12'
+    AND _inserted_date = '2024-08-12'
     {% endif %}
-  qualify(ROW_NUMBER() over(PARTITION BY block_id ORDER BY _inserted_date DESC)) = 1
+  UNION ALL
+  SELECT
+    block_id,
+    to_timestamp_ntz(data:result:blockTime) AS block_timestamp,
+    'mainnet' AS network,
+    'solana' AS chain_id,
+    data:result:blockHeight AS block_height,
+    data:result:blockhash::STRING AS block_hash,
+    data:result:parentSlot AS previous_block_id,
+    data:result:previousBlockhash::STRING AS previous_block_hash,
+    to_date(_partition_by_created_date, 'YYYY_MM_DD') AS _inserted_date,
+    _inserted_timestamp
+  FROM
+    {{ ref('bronze__streamline_blocks_2')}}
+  WHERE
+    block_id >= {{cutover_block_id}}
+    AND block_id IS NOT NULL
+    AND error IS NULL
+    AND data:error::STRING IS NULL
+    {% if is_incremental() %}
+    AND _inserted_date = '{{ load_date }}'
+    AND _inserted_timestamp >= '{{ load_timestamp }}'
+    {% else %}
+    AND _inserted_date = '2024-08-12'
+    {% endif %}
 )
 SELECT
   block_id,
   CASE
-    WHEN block_timestamp IS NULL THEN DATEADD('millisecond', 500, LAST_VALUE(block_timestamp) ignore nulls over (
-    ORDER BY
-      block_id rows unbounded preceding))
-      ELSE block_timestamp
+    WHEN block_timestamp IS NULL THEN 
+      DATEADD('millisecond', 500, LAST_VALUE(block_timestamp) IGNORE NULLS OVER (ORDER BY block_id ROWS UNBOUNDED PRECEDING))
+    ELSE 
+      block_timestamp
   END AS block_timestamp,
   network,
   chain_id,
@@ -85,11 +134,11 @@ SELECT
   previous_block_hash,
   _inserted_date,
   _inserted_timestamp,
-  {{ dbt_utils.generate_surrogate_key(
-        ['block_id']
-    ) }} AS blocks_id,
-  SYSDATE() AS inserted_timestamp,
-  SYSDATE() AS modified_timestamp,
+  {{ dbt_utils.generate_surrogate_key(['block_id']) }} AS blocks_id,
+  sysdate() AS inserted_timestamp,
+  sysdate() AS modified_timestamp,
   '{{ invocation_id }}' AS _invocation_id
 FROM
   pre_final
+QUALIFY
+  row_number() OVER (PARTITION BY block_id ORDER BY _inserted_timestamp DESC) = 1

--- a/models/silver/silver__blocks.sql
+++ b/models/silver/silver__blocks.sql
@@ -90,7 +90,7 @@ WITH pre_final AS (
     AND _inserted_date = '{{ load_date }}'
     AND _inserted_timestamp >= '{{ load_timestamp }}'
     {% else %}
-    AND _inserted_date = '2024-08-12'
+    AND _inserted_date = '2022-08-12'
     {% endif %}
   UNION ALL
   SELECT
@@ -115,7 +115,7 @@ WITH pre_final AS (
     AND _inserted_date = '{{ load_date }}'
     AND _inserted_timestamp >= '{{ load_timestamp }}'
     {% else %}
-    AND _inserted_date = '2024-08-12'
+    AND _inserted_date = '2022-08-12'
     {% endif %}
 )
 SELECT


### PR DESCRIPTION
- Add streamline 2.0 raw data upstream to `silver__blocks`
  - All data in the model after and including the `295976124` cutoff block will come from the new upstream

Dev is currently setup to run off of prod streamline data. This query should return no results after an incremental run in dev
```
select block_id
from solana.silver.blocks
where block_id >= 295976124
except
select block_id
from solana_dev.silver.blocks
where block_id >= 295976124;
```

Incremental on M
`dbt run -s silver__blocks`
```
16:12:57  1 of 1 OK created sql incremental model silver.blocks .......................... [SUCCESS 1173 in 15.79s]
```

Tests pass
`dbt test -s silver__blocks -t dev --exclude test_silver__token_account_owners_recency`
```
16:12:08  Finished running 10 data tests, 11 project hooks in 0 hours 0 minutes and 34.74 seconds (34.74s).
16:12:09  
16:12:09  Completed successfully
16:12:09  
16:12:09  Done. PASS=10 WARN=0 ERROR=0 SKIP=0 TOTAL=10
```