### PR TITLE
Migrate validator vote program accounts

### DIFF
--- a/.github/workflows/dbt_run_streamline_validator_vote_program_accounts.yml
+++ b/.github/workflows/dbt_run_streamline_validator_vote_program_accounts.yml
@@ -1,0 +1,46 @@
+name: dbt_run_streamline_validator_vote_program_accounts
+run-name: dbt_run_streamline_validator_vote_program_accounts
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs 01:22 daily (see https://crontab.guru)
+    - cron: '22 1 * * *'
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -s "solana_models,streamline__validator_vote_program_accounts_2" --vars '{"STREAMLINE_INVOKE_STREAMS": True}'
+

--- a/models/bronze/streamline/bronze__streamline_FR_validator_vote_program_accounts_2.sql
+++ b/models/bronze/streamline/bronze__streamline_FR_validator_vote_program_accounts_2.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "validator_vote_program_accounts_2" %}
+{{ streamline_external_table_FR_query(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "",
+    other_cols = ""
+) }}

--- a/models/bronze/streamline/bronze__streamline_validator_vote_program_accounts_2.sql
+++ b/models/bronze/streamline/bronze__streamline_validator_vote_program_accounts_2.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "validator_vote_program_accounts_2" %}
+{{ streamline_external_table_query(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "",
+    other_cols = ""
+) }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -60,6 +60,7 @@ sources:
       - name: helius_nft_metadata
       - name: blocks_2
       - name: validator_vote_accounts_2
+      - name: validator_vote_program_accounts_2
   - name: bronze_api
     schema: bronze_api
     tables:

--- a/models/streamline/core/snapshot/streamline__validator_vote_program_accounts_2.sql
+++ b/models/streamline/core/snapshot/streamline__validator_vote_program_accounts_2.sql
@@ -1,0 +1,48 @@
+{{ config (
+    materialized = "view",
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params = { 
+            "external_table": "validator_vote_program_accounts_2",
+            "sql_limit": "1",
+            "producer_batch_size": "1",
+            "worker_batch_size": "1",
+            "sql_source": "{{this.identifier}}",
+            "exploded_key": tojson(["result.value"]),
+        }
+    )
+) }}
+
+SELECT
+    replace(current_date::string, '-', '_') AS partition_key, -- Issue with streamline handling `-` in partition key so changing to `_`
+    '{{ invocation_id }}' AS invocation_id,
+    {{ target.database }}.live.udf_api(
+        'POST',
+        '{service}/{Authentication}',
+        object_construct(
+            'Content-Type',
+            'application/json'
+        ),
+        object_construct(
+            'id',
+            1,
+            'jsonrpc',
+            '2.0',
+            'method',
+            'getProgramAccounts',
+            'params',
+            array_construct(
+                'Vote111111111111111111111111111111111111111',
+                object_construct(
+                    'commitment',
+                    'confirmed',
+                    'encoding',
+                    'jsonParsed',
+                    'withContext',
+                    True
+                )
+            )
+        ),
+        'Vault/prod/solana/quicknode/mainnet'
+    ) AS request


### PR DESCRIPTION
- Add streamline 2.0 pipeline for validator vote program accounts data
  - This is a snapshot and will run once per day

Requests on M
```
15:21:08  Running macro `if_data_call_function`: Calling udf streamline.udf_bulk_rest_api_v2 with params: 
{
  "exploded_key": "[\"result.value\"]",
  "external_table": "validator_vote_program_accounts_2",
  "producer_batch_size": "1",
  "sql_limit": "1",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "1"
}
 on {{this.schema}}.{{this.identifier}}
15:21:16  1 of 1 OK created sql view model streamline.validator_vote_program_accounts_2 .. [SUCCESS 1 in 8.37s]
```

Data in dev
```
select *
from solana_dev.bronze.streamline_FR_validator_vote_program_accounts_2;
```