### PR TITLE
An 5328/update compute units logic

### DIFF
--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -32,7 +32,7 @@ WITH pre_final AS (
         t.data :meta :innerInstructions :: ARRAY AS inner_instructions,
         t.data :meta :logMessages :: ARRAY AS log_messages,
         t.data:transaction:message:addressTableLookups::array as address_table_lookups,
-        t.data :meta :computeUnitsConsumed as compute_units_consumed,
+        t.data :meta :computeUnitsConsumed :: NUMBER as compute_units_consumed,
         t.data :version :: STRING as version,
         t._partition_id,
         t._inserted_timestamp

--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -162,8 +162,7 @@ SELECT
     log_messages,
     address_table_lookups,
     CASE 
-        WHEN _partition_id > 24238 
-            THEN compute_units_consumed 
+        WHEN _partition_id > 24238 THEN compute_units_consumed 
         ELSE silver.udf_get_compute_units_consumed(log_messages, instructions) 
     END AS units_consumed,
     silver.udf_get_compute_units_total(log_messages, instructions) as units_limit,

--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -32,6 +32,7 @@ WITH pre_final AS (
         t.data :meta :innerInstructions :: ARRAY AS inner_instructions,
         t.data :meta :logMessages :: ARRAY AS log_messages,
         t.data:transaction:message:addressTableLookups::array as address_table_lookups,
+        t.data :meta :computeUnitsConsumed as compute_units_consumed,
         t.data :version :: STRING as version,
         t._partition_id,
         t._inserted_timestamp
@@ -160,7 +161,11 @@ SELECT
     inner_instructions,
     log_messages,
     address_table_lookups,
-    silver.udf_get_compute_units_consumed(log_messages, instructions) as units_consumed,
+    CASE 
+        WHEN _partition_id > 24238 
+            THEN compute_units_consumed 
+        ELSE silver.udf_get_compute_units_consumed(log_messages, instructions) 
+    END AS units_consumed,
     silver.udf_get_compute_units_total(log_messages, instructions) as units_limit,
     silver.udf_get_tx_size(account_keys,instructions,version,address_table_lookups,signers) as tx_size,
     version,

--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -162,7 +162,7 @@ SELECT
     log_messages,
     address_table_lookups,
     CASE 
-        WHEN _partition_id > 24238 THEN compute_units_consumed 
+        WHEN block_id > 204777016 THEN compute_units_consumed 
         ELSE silver.udf_get_compute_units_consumed(log_messages, instructions) 
     END AS units_consumed,
     silver.udf_get_compute_units_total(log_messages, instructions) as units_limit,


### PR DESCRIPTION
Get `units_consumed` value from raw transaction data, which is included in the node response after block `204777016`

to-do:
- Backfill will be another PR for separate workflow to create new table with updated `units_consumed` value, and used to update silver table
- For testing, add a null test to column and include 7 day filter -- will add after backfill update is complete since it will raise errors until then

inc run on medium
`17:52:40  1 of 1 OK created sql incremental model silver.transactions .................... [SUCCESS 1226726 in 121.31s]`

no null values returned for run
```
select * from solana_dev.silver.transactions
where _partition_id > 120818 and units_consumed is null;
```