### PR TITLE
An 5223/jupiter limit orders

### DIFF
--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
@@ -79,6 +79,18 @@
     'JD25qVdtd65FoiXNmR89JjmoJdYk9sjYQeSTZAALFiMy'
 ] %}
 
+{% set jupiter_limit_singers = [
+    'j1oAbxxiDUWvoHxEDhWE7THLjEkDQW2cSHYn2vttxTF',
+    'Gw9QoW4y72hFDVt3RRzyqcD4qrV4pSqjhMMzwdGunz6H',
+    'LoAFmGjxUL84rWHk4X6k8jzrw12Hmb5yyReUXfkFRY6',
+    '71WDyyCsZwyEYDV91Qrb212rdg6woCHYQhFnmZUBxiJ6',
+    'EccxYg7rViwYfn9EMoNu7sUaV82QGyFt6ewiQaH1GYjv',
+    'j1oeQoPeuEDmjvyMwBmCWexzCQup77kbKKxV59CnYbd',
+    'JTJ9Cz7i43DBeps5PZdX1QVKbEkbWegBzKPxhWgkAf1',
+    'j1opmdubY84LUeidrPCsSGskTCYmeJVzds1UWm6nngb',
+    'AfQ1oaudsGjvznX4JNEw671hi57JfWo4CWqhtkdgoVHU'
+] %}
+
 WITH all_routes AS (
     SELECT 
         *
@@ -221,7 +233,7 @@ SELECT
         AND d.tx_id IS NOT NULL
     ) AS is_dca_swap,
     d.dca_requester,
-    case when e.limit_requester is not null then true else false end as is_limit_swap,
+    i.swapper IN ('{{ jupiter_limit_singers | join("','") }}') AS is_limit_swap,
     e.limit_requester,
     b._inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(['b.tx_id','b.index','b.inner_index']) }} AS swaps_intermediate_jupiterv6_id,

--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
@@ -79,7 +79,7 @@
     'JD25qVdtd65FoiXNmR89JjmoJdYk9sjYQeSTZAALFiMy'
 ] %}
 
-{% set jupiter_limit_singers = [
+{% set jupiter_limit_signers = [
     'j1oAbxxiDUWvoHxEDhWE7THLjEkDQW2cSHYn2vttxTF',
     'Gw9QoW4y72hFDVt3RRzyqcD4qrV4pSqjhMMzwdGunz6H',
     'LoAFmGjxUL84rWHk4X6k8jzrw12Hmb5yyReUXfkFRY6',
@@ -233,7 +233,10 @@ SELECT
         AND d.tx_id IS NOT NULL
     ) AS is_dca_swap,
     d.dca_requester,
-    i.swapper IN ('{{ jupiter_limit_singers | join("','") }}') AS is_limit_swap,
+    (
+        i.swapper IN ('{{ jupiter_limit_signers | join("','") }}')
+        AND e.tx_id IS NOT NULL
+    ) AS is_limit_swap,
     e.limit_requester,
     b._inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(['b.tx_id','b.index','b.inner_index']) }} AS swaps_intermediate_jupiterv6_id,

--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
@@ -118,6 +118,24 @@ models:
                   is_dca_swap
                   AND _inserted_timestamp >= current_date - 7
                   AND block_timestamp >= '2024-05-12' /* last recorded date where some txs used the Beta DCA program (Betam4GuxvAes2uQ5vX8SackcxL5pxRuHowM5m2Ykmcq)  */
+      - name: IS_LIMIT_SWAP
+        description: "Whether the swap was initiated by a Jupiter limit order. If value is NULL then it is NOT a limit order swap"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "= True"
+              config:
+                where: >
+                  _inserted_timestamp >= current_date - 7
+                  AND block_timestamp >= '2023-10-01' 
+      - name: LIMIT_REQUESTER
+        description: "Original address that requested the limit order swap"
+        tests:
+          - not_null:
+              config:
+                where: >
+                  is_limit_swap
+                  AND _inserted_timestamp >= current_date - 7
+                  AND block_timestamp >= '2023-10-01' 
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.yml
@@ -125,7 +125,8 @@ models:
               expression: "= True"
               config:
                 where: >
-                  _inserted_timestamp >= current_date - 7
+                  swapper IN ('j1oAbxxiDUWvoHxEDhWE7THLjEkDQW2cSHYn2vttxTF','Gw9QoW4y72hFDVt3RRzyqcD4qrV4pSqjhMMzwdGunz6H','LoAFmGjxUL84rWHk4X6k8jzrw12Hmb5yyReUXfkFRY6','71WDyyCsZwyEYDV91Qrb212rdg6woCHYQhFnmZUBxiJ6','EccxYg7rViwYfn9EMoNu7sUaV82QGyFt6ewiQaH1GYjv','j1oeQoPeuEDmjvyMwBmCWexzCQup77kbKKxV59CnYbd','JTJ9Cz7i43DBeps5PZdX1QVKbEkbWegBzKPxhWgkAf1','j1opmdubY84LUeidrPCsSGskTCYmeJVzds1UWm6nngb','AfQ1oaudsGjvznX4JNEw671hi57JfWo4CWqhtkdgoVHU')
+                  AND _inserted_timestamp >= current_date - 7
                   AND block_timestamp >= '2023-10-01' 
       - name: LIMIT_REQUESTER
         description: "Original address that requested the limit order swap"

--- a/tests/test_silver__decoded_instructions_jupiter_limit_signers.sql
+++ b/tests/test_silver__decoded_instructions_jupiter_limit_signers.sql
@@ -1,0 +1,18 @@
+SELECT DISTINCT 
+    signers[0]::string AS signer
+FROM
+    {{ ref('silver__decoded_instructions_combined') }} 
+WHERE 
+    program_id in ('j1o2qRpjcyUwEvwtcfhEQefh773ZgjxcVRry7LDqg5X','jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu')
+    AND event_type = 'flashFillOrder'
+    AND _inserted_timestamp >= current_date - 7
+    AND signer NOT IN ('j1oAbxxiDUWvoHxEDhWE7THLjEkDQW2cSHYn2vttxTF',
+        'Gw9QoW4y72hFDVt3RRzyqcD4qrV4pSqjhMMzwdGunz6H',
+        'LoAFmGjxUL84rWHk4X6k8jzrw12Hmb5yyReUXfkFRY6',
+        '71WDyyCsZwyEYDV91Qrb212rdg6woCHYQhFnmZUBxiJ6',
+        'EccxYg7rViwYfn9EMoNu7sUaV82QGyFt6ewiQaH1GYjv',
+        'j1oeQoPeuEDmjvyMwBmCWexzCQup77kbKKxV59CnYbd',
+        'JTJ9Cz7i43DBeps5PZdX1QVKbEkbWegBzKPxhWgkAf1',
+        'j1opmdubY84LUeidrPCsSGskTCYmeJVzds1UWm6nngb',
+        'AfQ1oaudsGjvznX4JNEw671hi57JfWo4CWqhtkdgoVHU'
+    )


### PR DESCRIPTION
- Add limit order related cols
   - Flag to indicate whether a swap was initiated by Jupiter limit order
   - List the source wallet that requested the limit order if the above is true
   - Add tests for new columns + checks for the specific addresses that Jupiter limit orders use
- Will use FR'ed dev table to update prod
```
UPDATE solana.silver.swaps_intermediate_jupiterv6_2 AS p
SET 
    is_limit_swap = d.is_limit_swap,
    limit_requester = d.limit_requester,
    modified_timestamp = sysdate()

FROM solana_dev.silver.swaps_intermediate_jupiterv6_2 AS d
WHERE 
    p.swaps_intermediate_jupiterv6_id = d.swaps_intermediate_jupiterv6_id
    and p.block_timestamp::date >= '2023-10-01'
    and p.is_limit_swap is null;
```

Incremental on Medium
`18:33:15  1 of 1 OK created sql incremental model silver.swaps_intermediate_jupiterv6_2 .. [SUCCESS 215711 in 116.93s]
`
Tests (after running FR on dev)
```
18:24:05  Finished running 25 data tests, 11 project hooks in 0 hours 1 minutes and 6.79 seconds (66.79s).
18:24:05  
18:24:05  Completed successfully
18:24:05  
18:24:05  Done. PASS=25 WARN=0 ERROR=0 SKIP=0 TOTAL=25
```

