### PR TITLE
Migrate validator list to streamline 2.0

### DIFF
--- a/.github/workflows/dbt_run_streamline_validator_vote_program_accounts_snapshot.yml
+++ b/.github/workflows/dbt_run_streamline_validator_vote_program_accounts_snapshot.yml
@@ -1,5 +1,5 @@
-name: dbt_run_streamline_validator_vote_program_accounts
-run-name: dbt_run_streamline_validator_vote_program_accounts
+name: dbt_run_streamline_validator_vote_program_accounts_snapshot
+run-name: dbt_run_streamline_validator_vote_program_accounts_snapshot
 
 on:
   workflow_dispatch:

--- a/.github/workflows/dbt_run_streamline_validators_list_snapshot.yml
+++ b/.github/workflows/dbt_run_streamline_validators_list_snapshot.yml
@@ -1,0 +1,46 @@
+name: dbt_run_streamline_validators_list_snapshot
+run-name: dbt_run_streamline_validators_list_snapshot
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs 01:22 daily (see https://crontab.guru)
+    - cron: '22 1 * * *'
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -s "solana_models,streamline__validators_list_2" --vars '{"STREAMLINE_INVOKE_STREAMS": True}'
+

--- a/.github/workflows/dbt_run_streamline_validators_list_snapshot.yml
+++ b/.github/workflows/dbt_run_streamline_validators_list_snapshot.yml
@@ -4,8 +4,8 @@ run-name: dbt_run_streamline_validators_list_snapshot
 on:
   workflow_dispatch:
   schedule:
-    # Runs 01:22 daily (see https://crontab.guru)
-    - cron: '22 1 * * *'
+    # Runs 01:23 daily (see https://crontab.guru)
+    - cron: '23 1 * * *'
     
 env:
   DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"

--- a/models/bronze/streamline/bronze__streamline_FR_validators_list_2.sql
+++ b/models/bronze/streamline/bronze__streamline_FR_validators_list_2.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "validators_list_2" %}
+{{ streamline_external_table_FR_query(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "",
+    other_cols = ""
+) }}

--- a/models/bronze/streamline/bronze__streamline_validators_list_2.sql
+++ b/models/bronze/streamline/bronze__streamline_validators_list_2.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "validators_list_2" %}
+{{ streamline_external_table_query(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "",
+    other_cols = ""
+) }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -62,6 +62,7 @@ sources:
       - name: validator_vote_accounts_2
       - name: validator_vote_program_accounts_2
       - name: validator_metadata_2
+      - name: validators_list_2
   - name: bronze_api
     schema: bronze_api
     tables:

--- a/models/streamline/core/snapshot/streamline__validators_list_2.sql
+++ b/models/streamline/core/snapshot/streamline__validators_list_2.sql
@@ -1,0 +1,30 @@
+{{ config (
+    materialized = "view",
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ 
+            "external_table" :"validators_list_2",
+            "sql_limit" :"1",
+            "producer_batch_size" :"1",
+            "worker_batch_size" :"1",
+            "sql_source" :"{{this.identifier}}",
+        }
+    )
+) }}
+
+SELECT
+    replace(current_date::string,'-','_') AS partition_key, -- Issue with streamline handling `-` in partition key so changing to `_`
+    '{{ invocation_id }}' AS invocation_id,
+    {{ target.database }}.live.udf_api(
+        'GET',
+        '{Service}/validators/mainnet.json',
+        OBJECT_CONSTRUCT(
+            'Content-Type',
+            'application/json',
+            'Token',
+            '{Authentication}'
+        ),
+        {},
+        'Vault/prod/solana/validators_app/api'
+    ) AS request


### PR DESCRIPTION
- Migrate validator list requests to streamline 2.0
  - Data is unflattened. Streamline 2.0 doesnt seem to be able to flatten when the response is an array w/ no property name. Data is small though, shouldnt be any issues flattening in SF
- Fix workflow naming for streamline validator vote program accounts

`dbt run --vars '{STREAMLINE_INVOKE_STREAMS: True}' -s streamline__validators_list_2`
```
16:54:38  Running macro `if_data_call_function`: Calling udf streamline.udf_bulk_rest_api_v2 with params: 
{
  "external_table": "validators_list_2",
  "producer_batch_size": "1",
  "sql_limit": "1",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "1"
}
 on {{this.schema}}.{{this.identifier}}
16:54:46  1 of 1 OK created sql view model streamline.validators_list_2 .................. [SUCCESS 1 in 8.48s]
```

Data in DEV
```
select *
from solana_dev.bronze.streamline_validators_list_2;
```