### PR TITLE
Migrate validator rank metadata

### DIFF
--- a/.github/workflows/dbt_run_streamline_validator_metadata_snapshot.yml
+++ b/.github/workflows/dbt_run_streamline_validator_metadata_snapshot.yml
@@ -1,0 +1,46 @@
+name: dbt_run_streamline_validator_metadata_snapshot
+run-name: dbt_run_streamline_validator_metadata_snapshot
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs 01:22 daily (see https://crontab.guru)
+    - cron: '22 1 * * *'
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -s "solana_models,streamline__validator_metadata_2" --vars '{"STREAMLINE_INVOKE_STREAMS": True}'
+

--- a/models/bronze/streamline/bronze__streamline_FR_validator_metadata_2.sql
+++ b/models/bronze/streamline/bronze__streamline_FR_validator_metadata_2.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "validator_metadata_2" %}
+{{ streamline_external_table_FR_query(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "",
+    other_cols = ""
+) }}

--- a/models/bronze/streamline/bronze__streamline_validator_metadata_2.sql
+++ b/models/bronze/streamline/bronze__streamline_validator_metadata_2.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "validator_metadata_2" %}
+{{ streamline_external_table_query(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "",
+    other_cols = ""
+) }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -61,6 +61,7 @@ sources:
       - name: blocks_2
       - name: validator_vote_accounts_2
       - name: validator_vote_program_accounts_2
+      - name: validator_metadata_2
   - name: bronze_api
     schema: bronze_api
     tables:

--- a/models/streamline/core/snapshot/streamline__validator_metadata_2.sql
+++ b/models/streamline/core/snapshot/streamline__validator_metadata_2.sql
@@ -1,0 +1,29 @@
+{{ config (
+    materialized = "view",
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ 
+            "external_table" :"validator_metadata_2",
+            "sql_limit" :"1",
+            "producer_batch_size" :"1",
+            "worker_batch_size" :"1",
+            "sql_source" :"{{this.identifier}}",
+        }
+    )
+) }}
+
+SELECT
+    replace(current_date::string,'-','_') AS partition_key, -- Issue with streamline handling `-` in partition key so changing to `_`
+    '{{ invocation_id }}' AS invocation_id,
+    {{ target.database }}.live.udf_api(
+        'GET',
+        '{Service}/validators',
+        OBJECT_CONSTRUCT(
+            'Content-Type',
+            'application/json'
+        ),
+        {},
+        'Vault/prod/solana/topvalidators_app'
+    ) AS request
+


### PR DESCRIPTION
- Add streamline 2.0 pipeline for validator metadata
  - Old pipeline was through solscan, but that API is dead (it has been for a bit) with no replacement as far as I can tell
  - New api is through https://topvalidators.app/ and the only thing "missing" in the data is the `validator_rank`. I found that the ranking is just by the # of active stake in descending order. We can do that downstream to get the ranking value that matches solscan's old API response. You can see the solscan ranking [here](https://solscan.io/validator?page=1)

`dbt run -s streamline__validator_metadata_2 --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -t dev`
```
16:24:24  Running macro `if_data_call_function`: Calling udf streamline.udf_bulk_rest_api_v2 with params: 
{
  "external_table": "validator_metadata_2",
  "producer_batch_size": "1",
  "sql_limit": "1",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "1"
}
 on {{this.schema}}.{{this.identifier}}
16:24:27  1 of 1 OK created sql view model streamline.validator_metadata_2 ............... [SUCCESS 1 in 3.45s]
```

Data in DEV
```
select
    r.value :identity :: STRING AS node_pubkey,
    r.value :commission :: INTEGER AS commission,
    r.value :vote_identity :: STRING AS vote_pubkey,
    r.value :activated_stake :: FLOAT AS stake,
    row_number() over (order by stake desc) AS validator_rank
from solana_dev.bronze.streamline_validator_metadata_2 AS v,
table(flatten(data::array)) AS r
```