### PR TITLE
check for dca program call for is_dca_swap

### DIFF
--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
@@ -69,7 +69,7 @@
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.swaps_intermediate_jupiterv6__intermediate_tmp","block_timestamp::date") %}
 {% endif %}
 
-{% set jupiter_dca_singers = [
+{% set jupiter_dca_signers = [
     'DCAKuApAuZtVNYLk3KTAVW9GLWVvPbnb5CxxRRmVgcTr',
     'DCAKxn5PFNN1mBREPWGdk1RXg5aVH9rPErLfBFEi2Emb',
     'DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw',
@@ -205,7 +205,10 @@ SELECT
     i.amount AS from_amount,
     o.mint AS to_mint,
     o.amount AS to_amount,
-    i.swapper IN ('{{ jupiter_dca_singers | join("','") }}') AS is_dca_swap,
+    (
+        i.swapper IN ('{{ jupiter_dca_signers | join("','") }}')
+        AND d.tx_id IS NOT NULL
+    ) AS is_dca_swap,
     d.dca_requester,
     b._inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(['b.tx_id','b.index','b.inner_index']) }} AS swaps_intermediate_jupiterv6_id,


### PR DESCRIPTION
- Fix a few swaps where it is listed a `is_dca_swap=TRUE` when it should be `FALSE`
  - Need to check to make sure DCA program is called in the request as there are some swaps done by the DCA signers that don't appear to be DCA swaps

`dbt run -s silver__swaps_intermediate_jupiterv6_2 -t dev`
```
17:38:49  1 of 1 OK created sql incremental model silver.swaps_intermediate_jupiterv6_2 .. [SUCCESS 273561 in 130.18s]
```

Tests are failing but that is due to model test failures that are currently in production unrelated to this.

DML to update the existing non-dca swaps marked as `is_dca_swap=TRUE`
```
UPDATE solana.silver.swaps_intermediate_jupiterv6_2 AS t
SET
    is_dca_swap = FALSE,
    modified_timestamp = sysdate()
FROM
(
    WITH has_dca_logs AS (
        SELECT
            tx_id,
            decoded_log:args:userKey::string AS dca_requester,
        FROM 
            solana.silver.decoded_logs
        WHERE 
            program_id = 'DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M'
            AND event_type = 'Filled'
    ),
    listed_as_dca AS (
        SELECT *
        FROM 
            solana.silver.swaps_intermediate_jupiterv6_2
        where 
            is_dca_swap
    )
    SELECT 
        d.tx_id
    FROM
        listed_as_dca AS d
    LEFT OUTER JOIN
        has_dca_logs AS l
        USING(tx_id)
    WHERE
        l.tx_id is null
) AS s
WHERE
    t.tx_id = s.tx_id
    AND t.is_dca_swap
    AND t.dca_requester IS NULL;
```
Ran DML on DEV
<img width="1259" alt="Screenshot 2024-11-04 at 9 49 33 AM" src="https://github.com/user-attachments/assets/2fbd7595-a8ea-48e2-8e8b-600f6f77b2a4">
