### PR TITLE
add pubkey col

### DIFF
--- a/models/gold/gov/gov__fact_rewards_fee.sql
+++ b/models/gold/gov/gov__fact_rewards_fee.sql
@@ -9,7 +9,8 @@
 SELECT
   block_timestamp,
   block_id,
-  vote_pubkey,
+  vote_pubkey, --todo: remove by 2024-12-03
+  vote_pubkey as pubkey,
   epoch_earned,
   reward_amount_sol,
   post_balance_sol,
@@ -25,7 +26,8 @@ UNION ALL
 SELECT
   block_timestamp,
   block_id,
-  vote_pubkey,
+  vote_pubkey, --todo: remove by 2024-12-03
+  vote_pubkey as pubkey,
   epoch_earned,
   reward_amount_sol,
   post_balance_sol,

--- a/models/gold/gov/gov__fact_rewards_fee.yml
+++ b/models/gold/gov/gov__fact_rewards_fee.yml
@@ -20,7 +20,11 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: VOTE_PUBKEY
-        description: "{{ doc('vote_pubkey') }}"
+        description: "DEPRECATING SOON: Column will be removed by 2024-12-03. Please use PUBKEY, as this new naming more accurately defines all addresses receiving rewards."
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: PUBKEY
+        description: "The address receiving the fee rewards"
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: EPOCH_EARNED


### PR DESCRIPTION
Add `pubkey` column which will replace `vote_pubkey`, since the existing name assumes the rewards are always sent to the vote account which is not always true.
- Remove`vote_pubkey` by 2024-12-03