### PR TITLE
only check amount when the tx is successful

### DIFF
--- a/models/gold/defi/defi__fact_stake_pool_actions.yml
+++ b/models/gold/defi/defi__fact_stake_pool_actions.yml
@@ -63,7 +63,11 @@ models:
         description: "Amount in Lamports"
         tests:
           - dbt_expectations.expect_column_to_exist
-          - not_null: *recent_date_filter 
+          - not_null:
+              config:
+                where: >
+                  modified_timestamp >= current_date - 7
+                  AND succeeded
       - name: TOKEN
         description: "Token utilized in the stake pool action"
         tests:


### PR DESCRIPTION
We should only verify amounts as non-null when the transaction is successful. This is already done in the upstream silver models but was missed in the gold version.

This will fix alerting for all these
```
select *
from solana.defi.fact_stake_pool_actions
where amount is null
and succeeded = FALSE;
```