### PR TITLE
refactor using quicknode and latest liverquery function

### DIFF
--- a/.github/workflows/dbt_run_macro_get_block_production.yml
+++ b/.github/workflows/dbt_run_macro_get_block_production.yml
@@ -2,6 +2,7 @@ name: dbt_run_macro_get_block_production
 run-name: dbt_run_macro_get_block_production
 
 on:
+  workflow_dispatch:
   schedule:
     # Runs "every 4 hours" (see https://crontab.guru)
     - cron: '0 */4 * * *'

--- a/macros/bronze_api/get_block_production.sql
+++ b/macros/bronze_api/get_block_production.sql
@@ -10,64 +10,121 @@
     {% do run_query(create_table) %}
     {% set create_block_prod_call_query %}
     CREATE temporary TABLE bronze_api.block_production_call AS
-SELECT
-    utils.udf_json_rpc_call(
-          'getBlockProduction',
-          [{ 'commitment': 'confirmed', 'range': { 'firstSlot': previous_epoch_start, 'lastSlot': previous_epoch_end } }],
-          previous_epoch
-   ) calls
-FROM
-    (
-        WITH current_epoch_data AS (
-            SELECT
-                live.udf_api(
-                    'POST',
-                    'https://api.mainnet-beta.solana.com',
-                    {},
-                    utils.udf_json_rpc_call(
-                        'getEpochInfo',
-                        []
-                    )
-                ) DATA
-        ),
-        temp AS (
-            SELECT
-                DATA :data :result :epoch :: INT AS current_epoch,
-                current_epoch - 1 AS previous_epoch,
-                DATA :data :result :absoluteSlot - DATA :data :result :slotIndex AS current_epoch_start,
-                (
-                    current_epoch_start - 432000
-                ) :: INT AS previous_epoch_start,
-                (
-                    current_epoch_start - 1
-                ) :: INT AS previous_epoch_end
-            FROM
-                current_epoch_data
-        )
+    WITH current_epoch_data AS (
         SELECT
-            *
-        FROM
-            temp
-    ) {% endset %}
-    {% do run_query(create_block_prod_call_query) %}
-    {% set results_query %}
-INSERT INTO
-    bronze_api.block_production (json_data,epoch,calls,_inserted_timestamp) WITH results AS (
+            live.udf_api(
+                'POST',
+                '{service}/{Authentication}',
+                OBJECT_CONSTRUCT(
+                    'Content-Type',
+                    'application/json'
+                ),
+                OBJECT_CONSTRUCT(
+                    'id',
+                    current_timestamp,
+                    'jsonrpc',
+                    '2.0',
+                    'method',
+                    'getEpochInfo',
+                    'params',
+                    []
+                ),
+                'Vault/prod/solana/quicknode/mainnet'
+            ) AS data
+    ),
+    previous_epoch_start_end AS (
         SELECT
-            live.udf_api('POST',
-                'https://api.mainnet-beta.solana.com',{},
-                calls
-            ),
-            calls :id,
-            calls :: string,
-            TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP) AS _inserted_timestamp
+            DATA :data :result :epoch :: INT AS current_epoch,
+            current_epoch - 1 AS previous_epoch,
+            DATA :data :result :absoluteSlot - DATA :data :result :slotIndex AS current_epoch_start,
+            (
+                current_epoch_start - 432000
+            ) :: INT AS previous_epoch_start,
+            (
+                current_epoch_start - 1
+            ) :: INT AS previous_epoch_end
         FROM
-            bronze_api.block_production_call
+            current_epoch_data
+    ),
+    blocks_grouped AS (
+        SELECT 
+            (SELECT max(previous_epoch) FROM previous_epoch_start_end) AS epoch,
+            _id,
+            floor(_id/5000) AS group_num
+        FROM 
+            {{ source('crosschain_silver', 'number_sequence') }}
+        WHERE _id BETWEEN (SELECT max(previous_epoch_start) FROM previous_epoch_start_end) AND (SELECT max(previous_epoch_end) FROM previous_epoch_start_end)
+    ),
+    blocks_min_max_per_group AS (
+        SELECT 
+            epoch,
+            group_num,
+            min(_id) AS min_block,
+            max(_id) AS max_block
+        FROM 
+            blocks_grouped
+        GROUP BY 1,2
     )
-SELECT
-    *
-FROM
-    results;
-{% endset %}
+    SELECT
+        live.udf_api(
+            'POST',
+            '{service}/{Authentication}',
+            OBJECT_CONSTRUCT(
+                'Content-Type',
+                'application/json'
+            ),
+            OBJECT_CONSTRUCT(
+                'id',
+                concat_ws('-',current_timestamp,group_num),
+                'jsonrpc',
+                '2.0',
+                'method',
+                'getBlockProduction',
+                'params',
+                [{ 
+                    'commitment': 
+                    'confirmed', 
+                    'range': { 
+                        'firstSlot': min_block, 
+                        'lastSlot': max_block 
+                    } 
+                }]
+            ),
+            'Vault/prod/solana/quicknode/mainnet'
+        ) AS json_data,
+        epoch,
+        OBJECT_CONSTRUCT(
+            'id',
+            concat_ws('-',current_timestamp,group_num),
+            'jsonrpc',
+            '2.0',
+            'method',
+            'getBlockProduction',
+            'params',
+            [{ 
+                'commitment': 
+                'confirmed', 
+                'range': { 
+                    'firstSlot': min_block, 
+                    'lastSlot': max_block 
+                } 
+            }]
+        )::STRING AS calls,
+        TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP) AS _inserted_timestamp
+    FROM
+        blocks_min_max_per_group;
+    {% endset %}
+    {% do run_query(create_block_prod_call_query) %}
+
+    {% set results_query %}
+    INSERT INTO bronze_api.block_production (json_data,epoch,calls,_inserted_timestamp)
+    SELECT
+        json_data,
+        epoch,
+        calls,
+        _inserted_timestamp
+    FROM
+        bronze_api.block_production_call
+    {% endset %}
     {% do run_query(results_query) %}
 {% endmacro %}


### PR DESCRIPTION
- This is a short term fix to get block production data flowing again. Long term we probably want to move this to a streamline pipeline or into regular model code
  -  Quicknode only allows retrieving 5000 blocks at once, so code was refactored to get data in blocks of 5000 based on the start/end blocks of the epoch
 
Call to get the data in DEV
`dbt run-operation get_block_production -t dev`
```
17:02:59  Running with dbt=1.8.5
17:03:00  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
17:03:00  Registered adapter: snowflake=1.8.3
17:03:01  Found 398 models, 2476 data tests, 57 seeds, 7 operations, 5 analyses, 85 sources, 1106 macros
```

Data in DEV
```
select *
from solana_dev.bronze_api.block_production
where _inserted_timestamp >= '2024-11-08 16:50:00';
```

Data loaded to silver DEV
```
select *
from solana_dev.silver.snapshot_block_production
where epoch = 693;
```