### PR TITLE
add missing meteora events without transfers

### DIFF
--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_dlmm.sql
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_dlmm.sql
@@ -64,17 +64,29 @@ WITH base AS (
 ),
 base_transfers AS (
     SELECT
-        block_timestamp,
-        tx_id,
-        INDEX,
-        mint,
-        amount,
-        dest_token_account,
-        source_token_account
+        a.block_timestamp,
+        a.tx_id,
+        a.INDEX,
+        a.mint,
+        a.amount,
+        a.dest_token_account,
+        a.source_token_account
     FROM
-        {{ ref('silver__transfers') }}
+        {{ ref('silver__transfers') }} a
+    INNER JOIN
+        (
+            SELECT DISTINCT
+                tx_id,
+                block_timestamp::DATE AS block_date
+            FROM
+                base
+        ) b
+    ON
+        b.block_date = a.block_timestamp::DATE
+        AND b.tx_id = a.tx_id
     WHERE
         {{ between_stmts }}
+        AND succeeded
 ),
 decoded AS (
     SELECT
@@ -108,6 +120,10 @@ decoded AS (
             'reserveY',
             decoded_instruction :accounts
         ) AS liquidity_b_token_vault,
+        silver.udf_get_account_pubkey_by_name(
+            'tokenXMint',
+            decoded_instruction :accounts
+        ) AS token_x_mint,
         _inserted_timestamp,
     FROM
         base
@@ -168,31 +184,28 @@ withdraws AS (
         ) :: INT AS inner_index,
         d.program_id,
         d.action,
-        t.mint,
-        t.amount,
+        -- Handle edge case where removeAllLiquidity actions do not transfer anything
+        CASE
+            WHEN d.action = 'removeAllLiquidity' AND t.mint IS NULL THEN d.token_x_mint
+            ELSE t.mint
+        END AS mint,
+        CASE
+            WHEN d.action = 'removeAllLiquidity' AND t.amount IS NULL THEN 0
+            ELSE t.amount
+        END AS amount,
         d.liquidity_provider,
         d.liquidity_pool_address,
         d._inserted_timestamp
     FROM
-        base_transfers t
-        INNER JOIN decoded d
+        decoded d
+    LEFT JOIN base_transfers t
         ON t.block_timestamp :: DATE = d.block_timestamp :: DATE
         AND t.tx_id = d.tx_id
-        AND SPLIT_PART(
-            t.index,
-            '.',
-            1
-        ) = d.index
+        AND SPLIT_PART(t.index, '.', 1) = d.index
+        AND source_token_account IN (liquidity_a_token_vault, liquidity_b_token_vault)
     WHERE
-        d.action IN (
-            'removeLiquidityByRange',
-            'removeLiquidity',
-            'removeAllLiquidity'
-        )
-        AND source_token_account IN (
-            liquidity_a_token_vault,
-            liquidity_b_token_vault
-        )
+        d.action IN ('removeLiquidityByRange', 'removeLiquidity', 'removeAllLiquidity')
+
 ),
 pre_final AS (
     SELECT

--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_dlmm.yml
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_dlmm.yml
@@ -60,7 +60,8 @@ models:
       - name: INNER_INDEX
         description: "Position of event within inner instructions"
         tests:
-          - not_null: *recent_date_filter
+          - not_null:
+              where: action <> 'removeAllLiquidity' AND _inserted_timestamp >= current_date - 7
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 


### PR DESCRIPTION
- Meteora `removeAllLiquidity` actions occasionally have no transfer of tokens so previous logic didn't include these in the table. This update adds these events which will have `0` amounts and defaults to the first 'mint' that appears in the decoded instruction
  - 33 txs affected

```
with prod_issues as (
    select *
    from solana.silver.decoded_instructions_combined
    where program_id = 'LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo'
    and event_type IN ('removeLiquidityByRange','removeLiquidity','removeAllLiquidity','addLiquidityByStrategyOneSide','addLiquidityOneSide','addLiquidity','addLiquidityByWeight','addLiquidityByStrategy')
    and tx_id not in (
        select tx_id from solana.silver.liquidity_pool_actions_meteora_dlmm
        where block_timestamp::date between '2024-10-01' and '2024-11-06' 
        )
    and block_timestamp::date between '2024-10-01' and '2024-11-06'  
)

select b.tx_id, b.mint, b.amount, a.*
from prod_issues a
left join solana_dev.silver.liquidity_pool_actions_meteora_dlmm b
    on a.block_timestamp = b.block_timestamp
    and a.tx_id = b.tx_id
    and a.index = b.index
    and a.program_id = b.program_id;
```

To update: run affected range in dev, and will immediately insert the missing into prod so that modified dates are picked up in gold

```
INSERT INTO solana.silver.liquidity_pool_actions_meteora_dlmm
SELECT *
FROM solana_dev.silver.liquidity_pool_actions_meteora_dlmm
WHERE tx_id NOT IN (
    SELECT tx_id
    FROM solana.silver.liquidity_pool_actions_meteora_dlmm
    WHERE block_timestamp::date BETWEEN '2024-10-01' AND '2024-11-06'
)
AND block_timestamp::date BETWEEN '2024-10-01' AND '2024-11-06';

```

- tests pass:
```
22:11:32  Finished running 22 data tests, 7 project hooks in 0 hours 0 minutes and 55.81 seconds (55.81s).
22:11:32  
22:11:32  Completed successfully
22:11:32  
22:11:32  Done. PASS=22 WARN=0 ERROR=0 SKIP=0 TOTAL=22
```