### PR TITLE
if block level data is null, don't mark it as complete

### DIFF
--- a/models/streamline/core/complete/streamline__complete_blocks_2.sql
+++ b/models/streamline/core/complete/streamline__complete_blocks_2.sql
@@ -15,15 +15,18 @@ SELECT
 FROM
     {% if is_incremental() %}
     {{ ref('bronze__streamline_blocks_2') }}
-    WHERE
-        _inserted_timestamp >= (
-            SELECT
-                coalesce(max(_inserted_timestamp), '1970-01-01'::DATE) max_inserted_timestamp
-            FROM
-                {{ this }}
-        )
     {% else %}
     {{ ref('bronze__streamline_FR_blocks_2') }}
+    {% endif %}
+WHERE
+    data IS NOT NULL
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= (
+        SELECT
+            coalesce(max(_inserted_timestamp), '1970-01-01'::DATE) max_inserted_timestamp
+        FROM
+            {{ this }}
+    )
     {% endif %}
 QUALIFY
     row_number() OVER (


### PR DESCRIPTION
Fix issue where block level data retrieved from QN comes back as `NULL` but is still being added to the complete table. This change will no longer put these into the complete table and thus the streamline view will automatically retry getting these blocks.

`dbt run -s streamline__complete_blocks_2 -t dev`
```
15:56:50  1 of 1 OK created sql incremental model streamline.complete_blocks_2 ........... [SUCCESS 81574 in 7.38s]
```

Manually checking one of the issue blocks would no longer be added to the complete table
```
SELECT
    block_id,
    error,
    _partition_by_created_date,
    _inserted_timestamp,
FROM
    SOLANA.bronze.streamline_blocks_2
WHERE
    data IS NOT NULL
    AND _inserted_timestamp >= '2024-11-12 17:16:56.000 +0000'
    AND block_id = 300991654
QUALIFY
    row_number() OVER (
        PARTITION BY block_id
        ORDER BY _inserted_timestamp DESC
    ) = 1
```