### PR TITLE
Fix table not found error for streamline block txs

### DIFF
--- a/.github/workflows/dbt_test_hourly.yml
+++ b/.github/workflows/dbt_test_hourly.yml
@@ -40,6 +40,12 @@ jobs:
         run: |
           pip install -r requirements.txt
           dbt deps
+
+      # Run the streamline__transactions_and_votes_missing_7_days model to update after the tests
+      # This is necessary as the table is referenced in streamline views but DBT drops test output tables when they run
+      # so at time this will cause the streamline views to fail because the table it is trying to reference has been dropped.
+      # This should prevent that from happening by always referencing the model instead of the test output
       - name: Run DBT Jobs
         run: |
           dbt test -s "solana_models,tag:test_hourly"
+          dbt run -s streamline__transactions_and_votes_missing_7_days

--- a/models/streamline/core/streamline__transactions_and_votes_missing_7_days.sql
+++ b/models/streamline/core/streamline__transactions_and_votes_missing_7_days.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized = 'table',
+    )
+}}
+
+SELECT
+    *
+FROM
+    {{ source('solana_test_silver','transactions_and_votes_missing_7_days') }}

--- a/models/streamline/streamline__all_unknown_block_txs_real_time.sql
+++ b/models/streamline/streamline__all_unknown_block_txs_real_time.sql
@@ -88,12 +88,9 @@ solscan_discrepancy_retries AS (
     SELECT
         m.block_id
     FROM
-        {{ source(
-            'solana_test_silver',
-            'transactions_and_votes_missing_7_days'
-        ) }}
-        m
-        LEFT JOIN {{ ref('streamline__complete_block_txs') }} C
+        {{ ref('streamline__transactions_and_votes_missing_7_days') }} m
+    LEFT JOIN 
+        {{ ref('streamline__complete_block_txs') }} C
         ON C.block_id = m.block_id
     WHERE
         C._partition_id <= m._partition_id


### PR DESCRIPTION
Tables created from running tests get dropped when the test runs before they are recreated. This is causing some runs of the streamline block txs requests to fail when it happens to run at the same time the test is running because the view is trying to reference the test output table to figure out retries. The test takes 8-15mins to complete and runs hourly so this is causing failed requests 1-3x per hour.

- Fix is to create a model that selects from the test output table immediately after the test command is completed
  - DBT full refresh models do not have an accompanying DROP statement. This will ensure that the resource is always available for the streamline request view
- Change the view to query the model instead of the test output table

<img width="1599" alt="Screenshot 2024-11-13 at 9 28 02 AM" src="https://github.com/user-attachments/assets/10822eb1-4291-4c9e-a4c3-768140aeca7d">

`dbt run -s streamline__transactions_and_votes_missing_7_days -t dev`
```
17:15:45  1 of 1 OK created sql table model streamline.transactions_and_votes_missing_7_days  [SUCCESS 1 in 2.12s]
```

`dbt run -s streamline__all_unknown_block_txs_real_time -t dev`
```
17:20:39  1 of 1 OK created sql view model streamline.all_unknown_block_txs_real_time .... [SUCCESS 1 in 3.44s]
```