### PR TITLE
don't put null data into silver table

### DIFF
--- a/models/silver/silver__blocks.sql
+++ b/models/silver/silver__blocks.sql
@@ -111,6 +111,7 @@ WITH pre_final AS (
     AND block_id IS NOT NULL
     AND error IS NULL
     AND data:error::STRING IS NULL
+    AND data IS NOT NULL
     {% if is_incremental() %}
     AND _inserted_date = '{{ load_date }}'
     AND _inserted_timestamp >= '{{ load_timestamp }}'


### PR DESCRIPTION
Do not select block data from bronze when the data is `NULL`. A valid block should never have `NULL` data so it should either have data populated after the request is retried or it will result in an error indicating that the slot was skipped

Example w/ existing problem record, now returns nothing
```
select *
from solana.bronze.streamline_blocks_2
where block_id = 302193434
and _inserted_timestamp >= current_date - 1
and block_id IS NOT NULL
and error IS NULL
and data:error::STRING IS NULL
and data IS NOT NULL;
```