### PR TITLE
deprecate and source as view

### DIFF
--- a/models/gold/nft/nft__dim_nft_metadata.sql
+++ b/models/gold/nft/nft__dim_nft_metadata.sql
@@ -20,7 +20,7 @@ SELECT
 FROM
   {{ ref('silver__helius_nft_metadata') }} A
 LEFT JOIN 
-  {{ ref('silver__nft_collection') }} b
+  {{ ref('silver__nft_collection_view') }} b
   ON A.nft_collection_id = b.nft_collection_id
 UNION ALL
 SELECT

--- a/models/silver/metadata/silver__nft_collection.sql
+++ b/models/silver/metadata/silver__nft_collection.sql
@@ -4,9 +4,17 @@
     incremental_strategy = 'merge',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(collection_id,nft_collection_name)'),
-    tags = ['nft_api']
+    tags = ['nft_api'],
+    enabled = false
 ) }}
 
+/*
+DEPRECATED - keeping so that we know this table still exists in snowflake
+
+DEPENDS ON SOLSCAN v1.0 WHICH IS DEPRECATED. v2.0 API HAS NO REPLACEMENT.
+*/
+
+/*
 with collections as (
 SELECT
     items.value ['grouping'] AS GROUPING,
@@ -105,3 +113,4 @@ SELECT
     '{{ invocation_id }}' AS invocation_id
 FROM
     response
+*/

--- a/models/silver/metadata/silver__nft_collection_view.sql
+++ b/models/silver/metadata/silver__nft_collection_view.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized = 'view',
+    )
+}}
+
+SELECT *
+FROM
+    {{ source('solana_silver', 'nft_collection') }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -99,6 +99,7 @@ sources:
       - name: nft_sales_amm_sell
       - name: nft_sales_hyperspace
       - name: stake_pool_actions_lido
+      - name: nft_collection
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
- Deprecate the nft collections table as this is no longer supported in the v2.0 solscan API. You cannot find a token's collection_id based using a token address 🤯 

New/Updated models run in DEV
`dbt run -s models/silver/metadata/silver__nft_collection_view.sql -t dev`
```
00:46:36  1 of 1 OK created sql view model silver.nft_collection_view .................... [SUCCESS 1 in 2.47s]
```

`dbt build -s models/gold/nft/nft__dim_nft_metadata.sql`
```
00:48:42  1 of 13 OK created sql view model nft.dim_nft_metadata ......................... [SUCCESS 1 in 3.32s]
00:48:49  Finished running 1 view model, 12 data tests, 5 project hooks in 0 hours 0 minutes and 24.52 seconds (24.52s).
00:48:50  
00:48:50  
00:48:50  Done. PASS=13 WARN=0 ERROR=1 SKIP=0 TOTAL=14
```