### PR TITLE
remove unique_key to insert only

### DIFF
--- a/models/silver/backfill/silver__backfill_transactions_units_consumed.sql
+++ b/models/silver/backfill/silver__backfill_transactions_units_consumed.sql
@@ -1,7 +1,6 @@
 {{
     config(
         materialized="incremental",
-        unique_key=['tx_id'],
         tags=['units_consumed_backfill']
     )
 }}


### PR DESCRIPTION
- Update backfill model to only insert records
- insert takes a few seconds vs minutes for the merge https://app.snowflake.com/zsniary/exa10207/#/compute/history/queries/01b88c3e-0612-4260-3d4f-8302a9350d07/detail

Same counts returned
```
select count(*) ct, 'dev' as source from solana_dev.silver.backfill_transactions_units_consumed
where _partition_id between 48924 and 48929
union 
select count(*) ct, 'prod' as source from solana.silver.backfill_transactions_units_consumed
where _partition_id between 48924 and 48929;
```