### PR TITLE
Deprecate legacy decode instructions pipeline

### DIFF
--- a/.github/workflows/dbt_run_decode_instructions.yml
+++ b/.github/workflows/dbt_run_decode_instructions.yml
@@ -41,5 +41,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s models/streamline/decode_instructions/streamline__decode_instructions_2_realtime.sql
           dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s models/streamline/decode_instructions/streamline__decode_instructions_3_realtime.sql

--- a/.github/workflows/dbt_run_decode_instructions_pyth.yml
+++ b/.github/workflows/dbt_run_decode_instructions_pyth.yml
@@ -41,5 +41,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s models/streamline/decode_instructions/streamline__decode_instructions_2_pyth_realtime.sql
           dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s models/streamline/decode_instructions/streamline__decode_instructions_3_pyth_realtime.sql

--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -311,7 +311,7 @@
     {% set table_names = results[1].values() %}
     {% for table_name in table_names %}
         {% set udf_call = if_data_call_function(
-        func = schema_names[0] ~ ".udf_bulk_instructions_decoder(object_construct('sql_source', '" ~ table_name ~ "', 'external_table', 'decoded_instructions_2', 'sql_limit', '" ~ sql_limit ~ "', 'producer_batch_size', '" ~ producer_batch_size ~ "', 'worker_batch_size', '" ~ worker_batch_size ~ "', 'batch_call_limit', '" ~ batch_call_limit ~ "', 'call_type', 'backfill'))",
+        func = schema_names[0] ~ ".udf_bulk_instructions_decoder_v2(object_construct('sql_source', '" ~ table_name ~ "', 'external_table', 'decoded_instructions_3', 'sql_limit', '" ~ sql_limit ~ "', 'producer_batch_size', '" ~ producer_batch_size ~ "', 'worker_batch_size', '" ~ worker_batch_size ~ "', 'batch_call_limit', '" ~ batch_call_limit ~ "', 'call_type', 'backfill'))",
         target = schema_names[0] ~ "." ~ table_name) %}
         
         {% do run_query(udf_call) %}

--- a/models/silver/parser/silver__decoded_instructions.sql
+++ b/models/silver/parser/silver__decoded_instructions.sql
@@ -1,20 +1,25 @@
 -- depends_on: {{ ref('bronze__streamline_decoded_instructions_2') }}
 -- depends_on: {{ ref('bronze__streamline_FR_decoded_instructions_2') }}
+-- depends_on: {{ ref('bronze__streamline_decoded_instructions_3') }}
+
 {{ config(
     materialized = 'incremental',
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     unique_key = "decoded_instructions_id",
-    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE','program_id'],
+    cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE', 'program_id'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_non_core'],
+    full_refresh = false,
 ) }}
+
+{% set legacy_cutoff_timestamp = '2024-12-04 00:00:00+00:00' %}
 
 /* run incremental timestamp value first then use it as a static value */
 {% if execute %}
     {% if is_incremental() %}
         {% set query %}
             SELECT
-                MAX(_inserted_timestamp) as _inserted_timestamp
+                max(_inserted_timestamp) AS _inserted_timestamp
             FROM
                 {{ this }}
         {% endset %}
@@ -29,41 +34,39 @@ SELECT
     A.tx_id,
     COALESCE(
         A.index,
-        VALUE :data :data [0] [0],
-        VALUE :data [0] [0]
-    ) :: INT AS INDEX,
+        VALUE:data:data[0][0],
+        VALUE:data[0][0]
+    )::INT AS index,
     A.inner_index,
     A.program_id,
     COALESCE(
-        A.value :data :data [0] [1],
-        A.value :data [1],
-        A.value :data
+        A.value:data:data[0][1],
+        A.value:data[1],
+        A.value:data
     ) AS decoded_instruction,
     A._inserted_timestamp,
-    {{ dbt_utils.generate_surrogate_key(
-        ['A.tx_id', 'A.index', 'A.inner_index']
-    ) }} AS decoded_instructions_id,
-    SYSDATE() AS inserted_timestamp,
-    SYSDATE() AS modified_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['A.tx_id', 'A.index', 'A.inner_index']) }} AS decoded_instructions_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
 FROM
-
-{% if is_incremental() %}
-{{ ref('bronze__streamline_decoded_instructions_2') }} A
-{% else %}
+    {% if is_incremental() and max_inserted_timestamp < modules.datetime.datetime.strptime(legacy_cutoff_timestamp, '%Y-%m-%d %H:%M:%S%z') %}
+    {{ ref('bronze__streamline_decoded_instructions_2') }} A
+    {% elif is_incremental() %}
+    {{ ref('bronze__streamline_decoded_instructions_3') }} A
+    {% else %}
     {{ ref('bronze__streamline_FR_decoded_instructions_2') }} A
-{% endif %}
-JOIN {{ ref('silver__blocks') }}
-b
-ON A.block_id = b.block_id
-
+    {% endif %}
+JOIN 
+    {{ ref('silver__blocks') }} b
+    ON A.block_id = b.block_id
 {% if is_incremental() %}
 WHERE
     A._inserted_timestamp >= dateadd('minute', -5, '{{ max_inserted_timestamp }}')
-AND 
-    A._partition_by_created_date_hour >= dateadd('hour', -2, date_trunc('hour','{{ max_inserted_timestamp }}'::timestamp_ntz))
+    AND A._partition_by_created_date_hour >= dateadd('hour', -2, date_trunc('hour', '{{ max_inserted_timestamp }}'::timestamp_ntz))
 {% endif %}
-
-qualify(ROW_NUMBER() over (PARTITION BY tx_id, INDEX, coalesce(inner_index,-1)
-ORDER BY
-    A._inserted_timestamp DESC)) = 1
+QUALIFY
+    row_number() OVER (
+        PARTITION BY tx_id, index, coalesce(inner_index, -1)
+        ORDER BY A._inserted_timestamp DESC
+    ) = 1

--- a/models/silver/parser/silver__decoded_instructions.sql
+++ b/models/silver/parser/silver__decoded_instructions.sql
@@ -54,9 +54,14 @@ FROM
     {{ ref('bronze__streamline_decoded_instructions_2') }} A
     {% elif is_incremental() %}
     {{ ref('bronze__streamline_decoded_instructions_3') }} A
+    {% endif %}
+    /*
+    No longer allow full refresh of this model. 
+    If we need to full refresh, manual intervention is required as we need to union both sets of raw data
     {% else %}
     {{ ref('bronze__streamline_FR_decoded_instructions_2') }} A
     {% endif %}
+    */
 JOIN 
     {{ ref('silver__blocks') }} b
     ON A.block_id = b.block_id

--- a/models/silver/parser/silver__decoded_instructions.sql
+++ b/models/silver/parser/silver__decoded_instructions.sql
@@ -12,7 +12,7 @@
     full_refresh = false,
 ) }}
 
-{% set legacy_cutoff_timestamp = '2024-12-04 00:00:00+00:00' %}
+{% set legacy_cutoff_timestamp = '2024-12-09 00:00:00+00:00' %}
 
 /* run incremental timestamp value first then use it as a static value */
 {% if execute %}
@@ -67,7 +67,7 @@ JOIN
     ON A.block_id = b.block_id
 {% if is_incremental() %}
 WHERE
-    A._inserted_timestamp >= dateadd('minute', -5, '{{ max_inserted_timestamp }}')
+    A._inserted_timestamp >= dateadd('hour', -2, '{{ max_inserted_timestamp }}')
     AND A._partition_by_created_date_hour >= dateadd('hour', -2, date_trunc('hour', '{{ max_inserted_timestamp }}'::timestamp_ntz))
 {% endif %}
 QUALIFY

--- a/models/streamline/decode_instructions/streamline__decode_instructions_3_pyth_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_3_pyth_realtime.sql
@@ -7,12 +7,83 @@
     tags = ['streamline_decoder']
 ) }}
 
-/* 
-while we are running in parallel, can just select from the existing table 
-once we are done, we can move the existing code into this table 
-and it should be mostly the same except for the completed table references
-*/
+{% if execute %}
+    {% set max_block_id_query %}
+        select max(block_id)
+        from {{ ref('silver__events') }}
+    {% endset %}
+    {% set max_block_id = run_query(max_block_id_query).columns[0].values()[0] %}
+    {% set min_block_id = max_block_id - 150000 %}
+{% endif %}
+
+WITH event_subset AS (
+    SELECT
+        e.program_id,
+        e.tx_id,
+        e.index,
+        NULL as inner_index,
+        e.instruction,
+        e.block_id,
+        e.block_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','e.program_id']) }} as id
+    FROM
+        {{ ref('silver__events') }}
+        e
+    WHERE
+        e.program_id = 'FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH'
+    AND 
+        e.block_timestamp >= CURRENT_DATE - 1
+    AND 
+        e.block_id between {{ min_block_id }} and {{ max_block_id}}
+    AND 
+        e.succeeded
+    UNION ALL
+    SELECT
+        i.value :programId :: STRING AS inner_program_id,
+        e.tx_id,
+        e.index,
+        i.index AS inner_index,
+        i.value AS instruction,
+        e.block_id,
+        e.block_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','inner_program_id']) }} as id
+    FROM
+        {{ ref('silver__events') }}
+        e
+        JOIN table(flatten(e.inner_instruction:instructions)) i 
+    WHERE
+        ARRAY_CONTAINS('FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH'::variant, e.inner_instruction_program_ids) 
+    AND
+        e.block_timestamp >= CURRENT_DATE - 1
+    AND 
+        e.block_id between {{ min_block_id }} and {{ max_block_id}}
+    AND 
+        e.succeeded
+    AND 
+        inner_program_id = 'FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH'
+    
+),
+completed_subset AS (
+    SELECT
+        block_id,
+        complete_decoded_instructions_2_id as id
+    FROM
+        {{ ref('streamline__complete_decoded_instructions_3') }}
+    WHERE
+        block_id >= {{ min_block_id }}
+)
 SELECT
-    *
+    e.program_id,
+    e.tx_id,
+    e.index,
+    e.inner_index,
+    e.instruction,
+    e.block_id,
+    e.block_timestamp
 FROM
-    {{ ref('streamline__decode_instructions_2_pyth_realtime') }}
+    event_subset e
+    LEFT OUTER JOIN completed_subset C
+    ON C.block_id = e.block_id
+    AND e.id = C.id
+WHERE
+    C.block_id IS NULL

--- a/models/streamline/decode_instructions/streamline__decode_instructions_3_pyth_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_3_pyth_realtime.sql
@@ -66,7 +66,7 @@ WITH event_subset AS (
 completed_subset AS (
     SELECT
         block_id,
-        complete_decoded_instructions_2_id as id
+        complete_decoded_instructions_3_id as id
     FROM
         {{ ref('streamline__complete_decoded_instructions_3') }}
     WHERE

--- a/models/streamline/decode_instructions/streamline__decode_instructions_3_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_3_realtime.sql
@@ -78,7 +78,7 @@ event_subset AS (
 completed_subset AS (
     SELECT
         block_id,
-        complete_decoded_instructions_2_id as id
+        complete_decoded_instructions_3_id as id
     FROM
         {{ ref('streamline__complete_decoded_instructions_3') }}
     WHERE

--- a/models/streamline/decode_instructions/streamline__decode_instructions_3_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_3_realtime.sql
@@ -7,12 +7,101 @@
     tags = ['streamline_decoder']
 ) }}
 
-/* 
-while we are running in parallel, can just select from the existing table 
-once we are done, we can move the existing code into this table 
-and it should be mostly the same except for the completed table references
-*/
+{% if execute %}
+    {% set min_event_block_id_query %}
+        select min(block_id)
+        from {{ ref('silver__events') }}
+        where 
+            block_timestamp >= CURRENT_DATE - 2
+    {% endset %}
+    {% set min_event_block_id = run_query(min_event_block_id_query).columns[0].values()[0] %}
+{% endif %}
+
+WITH idl_in_play AS (
+
+    SELECT
+        program_id
+    FROM
+        {{ ref('silver__verified_idls') }}
+    WHERE   
+        program_id <> 'FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH'
+),
+event_subset AS (
+    SELECT
+        e.program_id,
+        e.tx_id,
+        e.index,
+        NULL as inner_index,
+        e.instruction,
+        e.block_id,
+        e.block_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','e.program_id']) }} as id
+    FROM
+        {{ ref('silver__events') }}
+        e
+        JOIN idl_in_play b
+        ON e.program_id = b.program_id
+    WHERE
+        e.block_timestamp >= CURRENT_DATE - 2
+    AND 
+        e.succeeded
+    UNION ALL
+    SELECT
+        i.value :programId :: STRING AS inner_program_id,
+        e.tx_id,
+        e.index,
+        i.index AS inner_index,
+        i.value AS instruction,
+        e.block_id,
+        e.block_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','inner_program_id']) }} as id
+    FROM
+        {{ ref('silver__events') }}
+        e
+        JOIN idl_in_play b
+        ON ARRAY_CONTAINS(b.program_id::variant, e.inner_instruction_program_ids) 
+        JOIN table(flatten(e.inner_instruction:instructions)) i 
+    WHERE
+        e.block_timestamp >= CURRENT_DATE - 2
+    AND 
+        e.succeeded
+    AND 
+        i.value :programId :: STRING = b.program_id
+    AND (
+            (
+                inner_program_id in ('FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn','SNPRohhBurQwrpwAptw1QYtpFdfEKitr4WSJ125cN1g','GovaE4iu227srtG2s3tZzB4RmWBzw8sTwrCLZz7kN7rY','JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
+                AND array_size(i.value:accounts) > 1
+            )
+            OR inner_program_id not in ('FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn','SNPRohhBurQwrpwAptw1QYtpFdfEKitr4WSJ125cN1g','GovaE4iu227srtG2s3tZzB4RmWBzw8sTwrCLZz7kN7rY','JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
+        )
+),
+completed_subset AS (
+    SELECT
+        block_id,
+        complete_decoded_instructions_2_id as id
+    FROM
+        {{ ref('streamline__complete_decoded_instructions_3') }}
+    WHERE
+        block_id >= {{ min_event_block_id }} --ensure we at least prune to last 2 days worth of blocks since the dynamic below will scan everything
+    AND block_id >= (
+            SELECT
+                MIN(block_id)
+            FROM
+                event_subset
+        )
+)
 SELECT
-    *
+    e.program_id,
+    e.tx_id,
+    e.index,
+    e.inner_index,
+    e.instruction,
+    e.block_id,
+    e.block_timestamp
 FROM
-    {{ ref('streamline__decode_instructions_2_realtime') }}
+    event_subset e
+    LEFT OUTER JOIN completed_subset C
+    ON C.block_id = e.block_id
+    AND e.id = C.id
+WHERE
+    C.block_id IS NULL


### PR DESCRIPTION
> [!IMPORTANT]  
> This will not be merged until **Monday 12/9 630am PT**



- Remove calls to legacy pipeline
- Modify realtime queries to match existing but using `streamline.complete_decoded_instructions_3`
- Modify `silver.decoded_instructions` to use streamline 2.0 upstream data after cutoff data `2024-12-09`
  - Temporarily extend lookback window
- Modify backfill macro to call streamline 2.0 endpoint


Streamline models run on DEV
`dbt run -s streamline__decode_instructions_3_realtime -t dev`
```
17:30:44  1 of 1 OK created sql table model streamline.decode_instructions_3_realtime .... [SUCCESS 1 in 528.25s]
```

`dbt run -s streamline__decode_instructions_3_pyth_realtime -t dev`
```
17:32:40  1 of 1 OK created sql view model streamline.decode_instructions_3_pyth_realtime  [SUCCESS 1 in 3.57s]
```

Silver model on DEV
`dbt run -s silver__decoded_instructions -t dev-2xl`
```
16:56:07  1 of 1 OK created sql incremental model silver.decoded_instructions ............ [SUCCESS 26068385 in 111.25s]
```