### PR TITLE
temporary job to check if all null mints are wsol

### DIFF
--- a/.github/workflows/dbt_run_backfill_transfers_mints.yml
+++ b/.github/workflows/dbt_run_backfill_transfers_mints.yml
@@ -1,0 +1,46 @@
+name: dbt_run_backfill_transfers_mints
+run-name: dbt_run_backfill_transfers_mints
+
+on:
+  workflow_dispatch:
+    branches:
+      - "tmp-backfill-transfers-missing-mints"
+  schedule:
+    - cron: "*/3 * * * *"
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -s silver__transfers_null_mints_fix -t dev

--- a/models/silver/backfill/silver__transfers_null_mints_fix.sql
+++ b/models/silver/backfill/silver__transfers_null_mints_fix.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized = 'incremental',
+        full_refresh = false
+    )
+}}
+
+{% if execute and is_incremental() %}
+    {% set next_block_date_to_process_query %}
+        select min(block_timestamp::date)-1 from {{ this }}
+    {% endset %}
+    {% set next_block_date_to_process = run_query(next_block_date_to_process_query)[0][0] %}
+{% endif %}
+
+select 
+    t.block_timestamp,
+    tr.*,
+    (
+        silver.udf_get_account_balances_index(dest_token_account, t.account_keys) IS NOT NULL
+        OR silver.udf_get_account_balances_index(source_token_account, t.account_keys) IS NOT NULL
+    ) AS is_wsol
+from solana_dev.silver.transfers_null_mints AS tr
+join solana.silver.transactions AS t 
+    using(tx_id)
+where
+    {% if is_incremental() %}
+        t.block_timestamp::date = '{{ next_block_date_to_process }}'
+    {% else %}
+        t.block_timestamp::date = '2024-12-04'
+    {% endif %}


### PR DESCRIPTION
Run this backfill backwards to ensure all the missing mints are `WSOL` so that we can run a simple update statement. Scheduled workflows have to be in main branch so we are forced to merge this into main even though this table will only live in dev