### PR TITLE
Add backup block txs count pipeline

### DIFF
--- a/.github/workflows/dbt_run_streamline_solscan_blocks.yml
+++ b/.github/workflows/dbt_run_streamline_solscan_blocks.yml
@@ -40,6 +40,8 @@ jobs:
           pip install -r requirements.txt
           dbt deps
       - name: Run DBT Jobs
+        # TODO: Replace w/ solscan blocks once we have credits again
+        # dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__solscan_blocks
         run: |
           dbt run -s silver___blocks_tx_count
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__solscan_blocks
+          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__helius_blocks

--- a/models/bronze/streamline/bronze__streamline_FR_helius_blocks.sql
+++ b/models/bronze/streamline/bronze__streamline_FR_helius_blocks.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "helius_blocks" %}
+{{ streamline_external_table_FR_query_v2(
+    model,
+    partition_function = "split_part(file_name, '/', 3)",
+    partition_name = "_partition_by_created_date",
+    unique_key = "block_id",
+    other_cols="array_size(data:result:signatures::array) AS transaction_count"
+) }}

--- a/models/bronze/streamline/bronze__streamline_helius_blocks.sql
+++ b/models/bronze/streamline/bronze__streamline_helius_blocks.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "helius_blocks" %}
+{{ streamline_external_table_query_v2(
+    model,
+    partition_function = "split_part(file_name, '/', 3)",
+    partition_name = "_partition_by_created_date",
+    unique_key = "block_id",
+    other_cols="array_size(data:result:signatures::array) AS transaction_count"
+) }}

--- a/models/silver/non_core/silver___blocks_tx_count.sql
+++ b/models/silver/non_core/silver___blocks_tx_count.sql
@@ -3,20 +3,48 @@
     unique_key = ['block_id'],
 ) }}
 
+WITH solscan_blocks AS (
+    SELECT
+        block_id,
+        coalesce(data:data:transactions_count,data:result:transactionCount) AS solscan_transaction_count,
+        _inserted_timestamp
+    FROM
+        {{ ref('bronze__streamline_solscan_blocks_2') }}
+    {% if is_incremental() %}
+    WHERE
+        _inserted_timestamp >= (
+            SELECT
+                max(_inserted_timestamp) - INTERVAL '15 MINUTE'
+            FROM
+                {{ this }}
+        )
+    {% endif %}
+),
+helius_blocks AS (
+    SELECT
+        block_id,
+        transaction_count AS helius_transaction_count,
+        _inserted_timestamp
+    FROM
+        {{ ref('bronze__streamline_helius_blocks') }}
+    {% if is_incremental() %}
+    WHERE
+        _inserted_timestamp >= (
+            SELECT
+                max(_inserted_timestamp) - INTERVAL '15 MINUTE'
+            FROM
+                {{ this }}
+        )
+    {% endif %}
+)
 SELECT
     block_id,
-    coalesce(data:data:transactions_count,data:result:transactionCount) as transaction_count,
-    _inserted_timestamp
+    coalesce(s.solscan_transaction_count,helius_transaction_count) AS transaction_count,
+    least_ignore_nulls(s._inserted_timestamp,h._inserted_timestamp) AS _inserted_timestamp
 FROM
-    {{ ref('bronze__streamline_solscan_blocks_2') }}
-{% if is_incremental() %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            max(_inserted_timestamp)
-        FROM
-            {{ this }}
-    )
-{% endif %}
+    solscan_blocks AS s
+FULL OUTER JOIN
+    helius_blocks AS h
+    USING (block_id)
 QUALIFY 
-    row_number() over (partition by block_id order by _inserted_timestamp desc, transaction_count desc) = 1
+    row_number() over (partition by block_id order by least_ignore_nulls(s._inserted_timestamp,h._inserted_timestamp) desc, transaction_count desc) = 1

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -68,6 +68,7 @@ sources:
       - name: decoded_instructions_3
       - name: decoded_logs_2
       - name: block_txs_2
+      - name: helius_blocks
   - name: bronze_api
     schema: bronze_api
     tables:

--- a/models/streamline/core/realtime/streamline__helius_blocks.sql
+++ b/models/streamline/core/realtime/streamline__helius_blocks.sql
@@ -1,0 +1,74 @@
+{{ config(
+    materialized = 'view',
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"helius_blocks",
+            "sql_limit" :"10000",
+            "producer_batch_size" :"1000",
+            "worker_batch_size" :"1000",
+            "sql_source" :"{{this.identifier}}", 
+        }
+    )
+) }}
+
+{% set producer_limit_size = 10000 %}
+
+WITH base AS (
+    SELECT 
+        b.block_id
+    FROM 
+        {{ ref('silver__blocks') }} b
+    LEFT OUTER JOIN 
+        {{ source('solana_silver','_blocks_tx_count') }} b2
+        ON b.block_id = b2.block_id
+    WHERE 
+        b.block_id >= 226000000
+        AND (b2.block_id IS NULL 
+            OR b2.transaction_count IS NULL)
+        AND b.block_timestamp::DATE <= current_date
+),
+block_ids AS (
+    SELECT 
+        block_id 
+    FROM 
+        base b
+    QUALIFY 
+        row_number() OVER (ORDER BY b.block_id DESC) <= {{ producer_limit_size }}
+)
+SELECT
+    block_id,
+    replace(current_date::string,'-','_') AS partition_key, -- Issue with streamline handling `-` in partition key so changing to `_`
+    {{ target.database }}.live.udf_api(
+        'POST',
+        '{service}/?api-key={Authentication}',
+        OBJECT_CONSTRUCT(
+            'Content-Type',
+            'application/json'
+        ),
+        OBJECT_CONSTRUCT(
+            'id',
+            block_id,
+            'jsonrpc',
+            '2.0',
+            'method',
+            'getBlock',
+            'params',
+            ARRAY_CONSTRUCT(
+                block_id,
+                OBJECT_CONSTRUCT(
+                    'encoding',
+                    'jsonParsed',
+                    'rewards',
+                    False,
+                    'transactionDetails',
+                    'signatures',
+                    'maxSupportedTransactionVersion',
+                    0
+                )
+            )
+        ),
+        'Vault/prod/solana/helius/mainnet'
+    ) AS request
+FROM
+    block_ids


### PR DESCRIPTION
Temporarily get tx counts from helius (although we also have limited credits there and it won't support a full month) until we are back up w/ Solscan. Last resort we can switch the helius endpoint to quicknode but I would rather not verify data using the same source as `block_txs`.

I think this pipeline is important enough to warrant usage of the helius credits as we are really dependent on this to self-heal txs which we do often.

Incremental
`dbt run -s silver___blocks_tx_count -t dev`
```
17:06:38  1 of 1 OK created sql incremental model silver._blocks_tx_count ................ [SUCCESS 900 in 8.39s]
```

New tx counts in dev thats not in prod
```
select block_id
from solana_dev.silver._blocks_tx_count
where block_id >= 305000000
and transaction_count is not null
except 
select block_id
from solana.silver._blocks_tx_count;
```

Streamline call
`dbt run -s streamline__helius_blocks --vars '{STREAMLINE_INVOKE_STREAMS: True}'`
```
16:07:27  Running macro `if_data_call_function`: Calling udf streamline.udf_bulk_rest_api_v2 with params: 
{
  "external_table": "helius_blocks",
  "include_top_level_json": "[\"len(result.signatures)\"]",
  "producer_batch_size": "1000",
  "sql_limit": "10000",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "1000"
}
 on {{this.schema}}.{{this.identifier}}
16:07:39  1 of 1 OK created sql view model streamline.helius_blocks ...................... [SUCCESS 1 in 11.74s]
```