### PR TITLE
add qualify

### DIFF
--- a/models/silver/nfts/silver__nft_sales_tensorswap.sql
+++ b/models/silver/nfts/silver__nft_sales_tensorswap.sql
@@ -285,3 +285,5 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM 
     pre_final
+QUALIFY
+    row_number() OVER (PARTITION BY nft_sales_tensorswap_id ORDER BY _inserted_timestamp DESC) = 1


### PR DESCRIPTION
- causing alert on `non-core` job -- failing due to `100090 (42P18): Duplicate row detected during DML action`
- ran in prod and succeeded
`20:20:10  1 of 1 OK created sql incremental model silver.nft_sales_tensorswap ............ [SUCCESS 461 in 17.18s]`