### PR TITLE
use verify_idl_v2 macro

### DIFF
--- a/models/silver/idls/silver__verified_user_idls.sql
+++ b/models/silver/idls/silver__verified_user_idls.sql
@@ -96,7 +96,7 @@ groupings AS (
 responses AS (
     SELECT
         program_id,
-        streamline.udf_verify_idl(requests) AS response
+        streamline.udf_verify_idl_v2(requests) AS response
     FROM
         groupings
 ),


### PR DESCRIPTION
- v2 version correctly validates IDL's such as `GovMaiHfpVPw8BAM1mbdzgmSZYDw2tdP32J2fapoQoYs`
![image](https://github.com/user-attachments/assets/0afeea09-e012-48fd-8300-21b13195146a)
