### PR TITLE
switch to ankr as provider for tx counts

### DIFF
--- a/models/streamline/core/realtime/streamline__helius_blocks.sql
+++ b/models/streamline/core/realtime/streamline__helius_blocks.sql
@@ -41,7 +41,7 @@ SELECT
     replace(current_date::string,'-','_') AS partition_key, -- Issue with streamline handling `-` in partition key so changing to `_`
     {{ target.database }}.live.udf_api(
         'POST',
-        '{service}/?api-key={Authentication}',
+        '{Service}?apikey={Authentication}',
         OBJECT_CONSTRUCT(
             'Content-Type',
             'application/json'
@@ -68,7 +68,7 @@ SELECT
                 )
             )
         ),
-        'Vault/prod/solana/helius/mainnet'
+        'Vault/prod/solana/ankr/mainnet'
     ) AS request
 FROM
     block_ids


### PR DESCRIPTION
Switch the endpoint to get block tx counts from `helius` to `ankr`

`dbt run --vars '{STREAMLINE_INVOKE_STREAMS: True}' -s streamline__helius_blocks -t dev`
```
{
  "external_table": "helius_blocks",
  "producer_batch_size": "1000",
  "sql_limit": "10000",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "1000"
}
 on {{this.schema}}.{{this.identifier}}
00:24:34  1 of 1 OK created sql view model streamline.helius_blocks ...................... [SUCCESS 1 in 11.42s]
```

Data in Dev
```
select *
from solana_dev.bronze.streamline_helius_blocks
where _partition_by_created_date = '2024_12_12'
limit 10;
```
<img width="1521" alt="Screenshot 2024-12-11 at 4 32 03 PM" src="https://github.com/user-attachments/assets/d2ce034f-5fa4-4802-abf4-67bafa7929ab" />
