### PR TITLE
Migrate compressed mint calls to streamline 2.0

### DIFF
--- a/macros/helpers/nft_compressed_mints_backfill_helpers.sql
+++ b/macros/helpers/nft_compressed_mints_backfill_helpers.sql
@@ -82,7 +82,7 @@
             )
             SELECT
                 ARRAY_AGG(request) AS batch_request,
-                streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
+                streamline.udf_decode_compressed_mint_change_logs_v2(batch_request) AS responses,
                 MIN(event_inserted_timestamp) AS start_inserted_timestamp,
                 MAX(event_inserted_timestamp) AS end_inserted_timestamp,
                 concat_ws(

--- a/macros/streamline/streamline_udfs.sql
+++ b/macros/streamline/streamline_udfs.sql
@@ -82,6 +82,7 @@
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_decode_compressed_mint_change_logs_v2("JSON" ARRAY) 
     returns VARIANT 
+    max_batch_rows = 1
     api_integration = 
     {% if target.database == 'SOLANA' -%}
         AWS_SOLANA_API_PROD_V2

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_mints.sql
@@ -96,7 +96,7 @@ base AS (
 )
 SELECT
     ARRAY_AGG(request) AS batch_request,
-    streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
+    streamline.udf_decode_compressed_mint_change_logs_v2(batch_request) AS responses,
     MIN(event_inserted_timestamp) AS start_inserted_timestamp,
     MAX(event_inserted_timestamp) AS end_inserted_timestamp,
     concat_ws(

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_sales_magic_eden.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_sales_magic_eden.sql
@@ -81,7 +81,7 @@ base AS (
 )
 SELECT
     ARRAY_AGG(request) AS batch_request,
-    streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
+    streamline.udf_decode_compressed_mint_change_logs_v2(batch_request) AS responses,
     MIN(decoded_inserted_timestamp) AS start_inserted_timestamp,
     MAX(decoded_inserted_timestamp) AS end_inserted_timestamp,
     SYSDATE() AS _inserted_timestamp,

--- a/models/bronze/bronze_api/bronze_api__parse_compressed_nft_sales_solsniper.sql
+++ b/models/bronze/bronze_api/bronze_api__parse_compressed_nft_sales_solsniper.sql
@@ -81,7 +81,7 @@ base AS (
 )
 SELECT
     ARRAY_AGG(request) AS batch_request,
-    streamline.udf_decode_compressed_mint_change_logs(batch_request) AS responses,
+    streamline.udf_decode_compressed_mint_change_logs_v2(batch_request) AS responses,
     MIN(decoded_inserted_timestamp) AS start_inserted_timestamp,
     MAX(decoded_inserted_timestamp) AS end_inserted_timestamp,
     SYSDATE() AS _inserted_timestamp,


### PR DESCRIPTION
- Set `max_batch_rows` to be same as v1 call
- Update usages to use `v2`

Results for all 3 models in DEV
<img width="1617" alt="Screenshot 2024-12-13 at 5 13 39 PM" src="https://github.com/user-attachments/assets/3548ed23-8eaa-4509-a8d4-e88098a7c539" />
<img width="1624" alt="Screenshot 2024-12-13 at 5 14 15 PM" src="https://github.com/user-attachments/assets/2ac6b1ac-c95c-46da-8ff3-1a93592ce308" />
<img width="1616" alt="Screenshot 2024-12-13 at 5 14 33 PM" src="https://github.com/user-attachments/assets/704672ca-01d4-4b83-81c3-2d434258feea" />
