### PR TITLE
Deprecate/orca init pools

### DIFF
--- a/models/gold/defi/defi__fact_liquidity_pool_actions.yml
+++ b/models/gold/defi/defi__fact_liquidity_pool_actions.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: defi__fact_liquidity_pool_actions
-    description: Table containing liquidity pools actions on Orca, Raydium, Saber and Meteora. 
+    description: Table containing liquidity pools actions on Orca, Raydium, Saber and Meteora. NOTE - actions for Orca pools created after 11/22/2024 are not tracked in this table, and we are working on updating our Orca data pipeline to collect these.
     recent_date_filter: &recent_date_filter
       config:
         where: modified_timestamp >= current_date - 7

--- a/models/silver/liquidity_pool/silver__initialization_pools_orca.sql
+++ b/models/silver/liquidity_pool/silver__initialization_pools_orca.sql
@@ -3,7 +3,9 @@
     unique_key = ["block_id","tx_id"],
     incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp::date >= LEAST(current_date-7,(select min(block_timestamp)::date from ' ~ generate_tmp_view_name(this) ~ '))'],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    tags = ['scheduled_non_core'],
+    full_refresh = false,
+    enabled = false,
 ) }}
 
 WITH base_events AS(

--- a/models/silver/liquidity_pool/silver__initialization_pools_orca_view.sql
+++ b/models/silver/liquidity_pool/silver__initialization_pools_orca_view.sql
@@ -7,12 +7,12 @@ SELECT
     block_timestamp,
     block_id,
     tx_id,
-    instruction :accounts [4] :: STRING AS liquidity_pool,
-    'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc' AS owner,
-    liquidity_pool AS mint_authority,
-    instruction :accounts [5] :: STRING AS token_a_account,
-    instruction :accounts [6] :: STRING AS token_b_account,
-    NULL AS pool_token,
+    liquidity_pool,
+    owner,
+    mint_authority,
+    token_a_account,
+    token_b_account,
+    pool_token,
     _inserted_timestamp
 FROM
   {{ source(

--- a/models/silver/liquidity_pool/silver__initialization_pools_orca_view.sql
+++ b/models/silver/liquidity_pool/silver__initialization_pools_orca_view.sql
@@ -1,0 +1,21 @@
+
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    instruction :accounts [4] :: STRING AS liquidity_pool,
+    'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc' AS owner,
+    liquidity_pool AS mint_authority,
+    instruction :accounts [5] :: STRING AS token_a_account,
+    instruction :accounts [6] :: STRING AS token_b_account,
+    NULL AS pool_token,
+    _inserted_timestamp
+FROM
+  {{ source(
+    'solana_silver',
+    'initialization_pools_orca'
+  ) }}

--- a/models/silver/liquidity_pool/silver__liquidity_pool_events_orca.sql
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_events_orca.sql
@@ -170,7 +170,7 @@ lp_events_w_inner_program_ids AS (
                 C.*
             FROM
                 combined C
-                LEFT JOIN {{ ref('silver__initialization_pools_orca') }}
+                LEFT JOIN {{ ref('silver__initialization_pools_orca_view') }}
                 p1
                 ON (
                     event_instructions :accounts [6] :: STRING = p1.token_a_account
@@ -234,12 +234,12 @@ lp_events_w_inner_program_ids AS (
         END AS action
     FROM
         lp_events_with_swaps_removed A
-        LEFT JOIN {{ ref('silver__initialization_pools_orca') }}
+        LEFT JOIN {{ ref('silver__initialization_pools_orca_view') }}
         p1
         ON (
             A.event_instructions :accounts [3] :: STRING = p1.pool_token
         )
-        LEFT JOIN {{ ref('silver__initialization_pools_orca') }}
+        LEFT JOIN {{ ref('silver__initialization_pools_orca_view') }}
         p2
         ON (
             A.event_instructions :accounts [7] :: STRING = p2.pool_token

--- a/models/silver/liquidity_pool/silver__mints_orca_non_whirlpool.sql
+++ b/models/silver/liquidity_pool/silver__mints_orca_non_whirlpool.sql
@@ -92,7 +92,7 @@ pre_final_orca_mints AS(
         A._inserted_timestamp
     FROM
         orca_mint_actions A
-        INNER JOIN {{ ref('silver__initialization_pools_orca') }}
+        INNER JOIN {{ ref('silver__initialization_pools_orca_view') }}
         b
         ON A.mint = b.pool_token
 ),
@@ -114,7 +114,7 @@ mints_in_swaps AS(
         A._inserted_timestamp
     FROM
         base_mint_actions A
-        INNER JOIN {{ ref('silver__initialization_pools_orca') }}
+        INNER JOIN {{ ref('silver__initialization_pools_orca_view') }}
         b
         ON A.mint = b.pool_token
     WHERE

--- a/models/silver/liquidity_pool/silver__mints_orca_whirlpool.sql
+++ b/models/silver/liquidity_pool/silver__mints_orca_whirlpool.sql
@@ -75,7 +75,7 @@ SELECT
     A._inserted_timestamp
 FROM
     orca_mint_actions A
-    INNER JOIN {{ ref('silver__initialization_pools_orca') }}
+    INNER JOIN {{ ref('silver__initialization_pools_orca_view') }}
     b
     ON A.liquidity_pool_address = b.liquidity_pool
     qualify(row_number() over (partition by a.block_id, a.tx_id, a.index,a.inner_index order by a.index,a.inner_index)) = 1

--- a/models/silver/liquidity_pool/silver__pool_transfers_orca_non_whirlpool.sql
+++ b/models/silver/liquidity_pool/silver__pool_transfers_orca_non_whirlpool.sql
@@ -115,14 +115,14 @@ pre_final AS (
         ) AS liquidity_pool_address
     FROM
         non_whirlpool_txfers t
-        LEFT JOIN {{ ref('silver__initialization_pools_orca') }}
+        LEFT JOIN {{ ref('silver__initialization_pools_orca_view') }}
         p1
         ON (
             t.dest_token_account = p1.token_a_account
             OR t.dest_token_account = p1.token_b_account
         )
         AND t.action = 'deposit'
-        LEFT JOIN {{ ref('silver__initialization_pools_orca') }}
+        LEFT JOIN {{ ref('silver__initialization_pools_orca_view') }}
         p2
         ON (
             t.source_token_account = p2.token_a_account

--- a/models/silver/liquidity_pool/silver__pool_transfers_orca_whirlpool.sql
+++ b/models/silver/liquidity_pool/silver__pool_transfers_orca_whirlpool.sql
@@ -94,13 +94,13 @@ pre_final AS (
         END AS action_true
     FROM
         whirlpool_txfers t
-        LEFT JOIN {{ ref('silver__initialization_pools_orca') }}
+        LEFT JOIN {{ ref('silver__initialization_pools_orca_view') }}
         p1
         ON (
             t.dest_token_account = p1.token_a_account
             OR t.dest_token_account = p1.token_b_account
         )
-        LEFT JOIN {{ ref('silver__initialization_pools_orca') }}
+        LEFT JOIN {{ ref('silver__initialization_pools_orca_view') }}
         p2
         ON (
             t.source_token_account = p2.token_a_account

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -109,6 +109,7 @@ sources:
       - name: burns_orca_non_whirlpool
       - name: mints_orca_non_whirlpool
       - name: pool_transfers_orca_non_whirlpool
+      - name: initialization_pools_orca
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
deprecate initialization_pools_orca as logic needs a complete revamp and no new records are coming through
- use view table as reference for dependant tables (including already deprecated models which isn't completely necessary)


incremental runs (excluding deprecated models)

```
19:55:17  1 of 4 OK created sql view model silver.initialization_pools_orca_view ......... [SUCCESS 1 in 2.34s]
19:55:49  2 of 4 OK created sql incremental model silver.liquidity_pool_events_orca ...... [SUCCESS 15803 in 31.91s]
19:55:58  3 of 4 OK created sql incremental model silver.mints_orca_whirlpool ............ [SUCCESS 1 in 8.37s]
19:57:19  4 of 4 OK created sql incremental model silver.pool_transfers_orca_whirlpool ... [SUCCESS 15211 in 89.46s]
```

tests passed
```
20:05:02  Finished running 40 data tests, 7 project hooks in 0 hours 1 minutes and 16.84 seconds (76.84s).
20:05:02  
20:05:02  Completed successfully
20:05:02  
20:05:02  Done. PASS=40 WARN=0 ERROR=0 SKIP=0 TOTAL=40
```