### PR TITLE
set sane defaults when unable to retrieve dates in pre-model query

### DIFF
--- a/models/silver/core/silver__blocks.sql
+++ b/models/silver/core/silver__blocks.sql
@@ -57,8 +57,8 @@
   {% endset %}
 
   {% set get_dates_to_load_columns = run_query(get_dates_to_load_query).columns %}
-  {% set load_timestamp = get_dates_to_load_columns[0].values()[0] %}
-  {% set load_date = get_dates_to_load_columns[1].values()[0] %}
+  {% set load_timestamp = get_dates_to_load_columns[0].values()[0] if get_dates_to_load_columns[0].values()[0] is not none else max_inserted_timestamp %}
+  {% set load_date = get_dates_to_load_columns[1].values()[0] if get_dates_to_load_columns[1].values()[0] is not none else max_inserted_timestamp.date() %}
   {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Use default values for situations where the pre-model query is unable to retrieve one or both date values

I forced it to run the default values part of the code by hardcoding the last predicate in `get_dates_to_load_query` as there is no streamline data between these times
```
WHERE
    _inserted_timestamp > '2024-12-19 12:16:44'
    AND _inserted_timestamp < '2024-12-19 13:03:00'
```

I then ran compile to see that valid timestamp/date values were inserted into the query
`dbt compile -s silver__blocks -t prod`
```
/*
This CTE (pre_final) combines data from two sources:
1. Legacy data from 'bronze__blocks2' for blocks before the cutover_block_id
2. New data using streamline 2.0 raw data from 'bronze__streamline_blocks_2' for blocks after and including the cutover_block_id
*/
WITH pre_final AS (
  SELECT
    value:block_id::INTEGER AS block_id,
    to_timestamp_ntz(data:blockTime) AS block_timestamp,
    'mainnet' AS network,
    'solana' AS chain_id,
    data:blockHeight AS block_height,
    data:blockhash::STRING AS block_hash,
    data:parentSlot AS previous_block_id,
    data:previousBlockhash::STRING AS previous_block_hash,
    _inserted_date,
    _inserted_timestamp
  FROM
    SOLANA.bronze.blocks2
  WHERE
    block_id < 295976124
    AND block_id IS NOT NULL
    AND error IS NULL
    
    AND _inserted_date = '2024-12-19'
    AND _inserted_timestamp >= '2024-12-19 14:56:52'
    
  UNION ALL
  SELECT
    block_id,
    to_timestamp_ntz(data:result:blockTime) AS block_timestamp,
    'mainnet' AS network,
    'solana' AS chain_id,
    data:result:blockHeight AS block_height,
    data:result:blockhash::STRING AS block_hash,
    data:result:parentSlot AS previous_block_id,
    data:result:previousBlockhash::STRING AS previous_block_hash,
    to_date(_partition_by_created_date, 'YYYY_MM_DD') AS _inserted_date,
    _inserted_timestamp
  FROM
    SOLANA.bronze.streamline_blocks_2
  WHERE
    block_id >= 295976124
    AND block_id IS NOT NULL
    AND error IS NULL
    AND data:error::STRING IS NULL
    AND data IS NOT NULL
    
    AND _inserted_date = '2024-12-19'
    AND _inserted_timestamp >= '2024-12-19 14:56:52'
    
)
SELECT
  block_id,
  CASE
    WHEN block_timestamp IS NULL THEN 
      DATEADD('millisecond', 500, LAST_VALUE(block_timestamp) IGNORE NULLS OVER (ORDER BY block_id ROWS UNBOUNDED PRECEDING))
    ELSE 
      block_timestamp
  END AS block_timestamp,
  network,
  chain_id,
  block_height,
  block_hash,
  previous_block_id,
  previous_block_hash,
  _inserted_date,
  _inserted_timestamp,
  
    
md5(cast(coalesce(cast(block_id as TEXT), '_dbt_utils_surrogate_key_null_') as TEXT)) AS blocks_id,
  sysdate() AS inserted_timestamp,
  sysdate() AS modified_timestamp,
  '049096ef-b0b7-4ac2-b13e-be926c88a27b' AS _invocation_id
FROM
  pre_final
QUALIFY
  row_number() OVER (PARTITION BY block_id ORDER BY _inserted_timestamp DESC) = 1
```

Ran the above in snowflake UI to confirm it is a valid query
<img width="1513" alt="Screenshot 2024-12-19 at 7 23 45 AM" src="https://github.com/user-attachments/assets/e4f36357-86fd-4a89-b8fa-23c7712b0987" />

