### PR TITLE
Orca v2 lp models

### DIFF
--- a/models/descriptions/token_a_account.md
+++ b/models/descriptions/token_a_account.md
@@ -1,0 +1,5 @@
+{% docs token_a_account %}
+
+Address of the account containing the first token in a liquidity pool pair
+
+{% enddocs %}

--- a/models/descriptions/token_a_mint.md
+++ b/models/descriptions/token_a_mint.md
@@ -1,0 +1,5 @@
+{% docs token_a_mint %}
+
+Address of the mint representing the first token in a liquidity pool pair
+
+{% enddocs %}

--- a/models/descriptions/token_b_account.md
+++ b/models/descriptions/token_b_account.md
@@ -1,0 +1,5 @@
+{% docs token_b_account %}
+
+Address of the account containing the second token in a liquidity pool pair
+
+{% enddocs %}

--- a/models/descriptions/token_b_mint.md
+++ b/models/descriptions/token_b_mint.md
@@ -1,0 +1,5 @@
+{% docs token_b_mint %}
+
+Address of the mint representing the second token in a liquidity pool pair
+
+{% enddocs %}

--- a/models/silver/liquidity_pool/orca/silver__initialization_pools_orcav2.sql
+++ b/models/silver/liquidity_pool/orca/silver__initialization_pools_orcav2.sql
@@ -1,0 +1,96 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = 'initialization_pools_orcav2_id',
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+        tags = ['scheduled_non_core'],
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.initialization_pools_orcav2__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = '9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP'
+        AND event_type = 'initialize'
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.initialization_pools_orcav2__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('swap', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('tokenA', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('tokenB', accounts) AS token_b_account
+    FROM
+        silver.initialization_pools_orcav2__intermediate_tmp
+),
+post_token_balances AS (
+    SELECT
+        block_timestamp,
+        tx_id,
+        account,
+        mint
+    FROM
+        {{ ref('silver___post_token_balances') }}
+    WHERE
+        {{ between_stmts }}
+)
+SELECT 
+    b.block_id,
+    b.block_timestamp,
+    b.tx_id,
+    b.index,
+    b.inner_index,
+    b.succeeded,
+    b.pool_address,
+    b.token_a_account,
+    ptb_a.mint AS token_a_mint,
+    b.token_b_account,
+    ptb_b.mint AS token_b_mint,
+    b.program_id,
+    b._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['b.block_id', 'b.tx_id', 'b.index', 'b.inner_index']) }} AS initialization_pools_orcav2_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    base AS b
+LEFT JOIN
+    post_token_balances AS ptb_a
+    ON b.block_timestamp::date = ptb_a.block_timestamp::date
+    AND b.tx_id = ptb_a.tx_id
+    AND b.token_a_account = ptb_a.account
+LEFT JOIN
+    post_token_balances AS ptb_b
+    ON b.block_timestamp::date = ptb_b.block_timestamp::date
+    AND b.tx_id = ptb_b.tx_id
+    AND b.token_b_account = ptb_b.account

--- a/models/silver/liquidity_pool/orca/silver__initialization_pools_orcav2.yml
+++ b/models/silver/liquidity_pool/orca/silver__initialization_pools_orcav2.yml
@@ -1,0 +1,77 @@
+version: 2
+models:
+  - name: silver__initialization_pools_orcav2
+    data_data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_ACCOUNT
+        description:  "{{ doc('token_a_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_ACCOUNT
+        description:  "{{ doc('token_b_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: INITIALIZATION_POOLS_ORCAV2_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null: 
+              name: test_silver__not_null_initialization_pools_orcav2_invocation_id


### PR DESCRIPTION
- Create Orca V2 pool initializations model
  - No new pools created since 2022 as this program is now deprecated, so we shouldn't expect new pools. Because of this I think we can run this just one time and leave it off the scheduler

`dbt run -s silver__initialization_pools_orcav2 -t dev --full-refresh`
```
16:38:21  1 of 1 OK created sql incremental model silver.initialization_pools_orcav2 ..... [SUCCESS 1 in 1272.96s]
```
 
Incremental logic in place and successful even though we shouldnt need it
`dbt run -s silver__initialization_pools_orcav2 -t dev  `
```
16:41:14  1 of 1 OK created sql incremental model silver.initialization_pools_orcav2 ..... [SUCCESS 0 in 6.10s]
```

Tests pass
`dbt test -s silver__initialization_pools_orcav2`
```
16:53:59  Finished running 16 data tests, 7 project hooks in 0 hours 0 minutes and 18.42 seconds (18.42s).
16:54:00  
16:54:00  Completed successfully
16:54:00  
16:54:00  Done. PASS=16 WARN=0 ERROR=0 SKIP=0 TOTAL=16
```

Data in DEV
```
select *
from solana_dev.silver.initialization_pools_orcav2;
```