### PR TITLE
update tests

### DIFF
--- a/models/silver/core/silver___post_token_balances.yml
+++ b/models/silver/core/silver___post_token_balances.yml
@@ -1,62 +1,65 @@
 version: 2
 models:
   - name: silver___post_token_balances
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_ID
             - TX_ID
             - INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: Location of the post token balance entry within the array for a transaction
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: ACCOUNT_INDEX
         description: Location corresponding to the index in the account_keys array 
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: OWNER
         description: Address of the owner of the token account
         tests: 
           - not_null:
-              where: block_id > 111492264 # before this we don't have owner from figment
+              where: block_id > 111492264 and _inserted_timestamp >= current_date - 7 # before this we don't have owner from figment
       - name: DECIMAL 
         description: Number of decimals in the token value, need to divide amount by 10^decimal
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: UIAMOUNT
         description: Amount of the token in the transaction 
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: UIAMOUNTSTRING
         description: Amount of the token in the transaction in string format
         tests: 
-          - not_null  
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/core/silver___pre_token_balances.yml
+++ b/models/silver/core/silver___pre_token_balances.yml
@@ -1,62 +1,65 @@
 version: 2
 models:
   - name: silver___pre_token_balances
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_ID
             - TX_ID
             - INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: Location of the pre token balance entry within the array for a transaction
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: ACCOUNT_INDEX
         description: Location corresponding to the index in the accounts array 
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: OWNER
         description: Address of the owner of the token account
         tests: 
           - not_null:
-              where: block_id > 111492264 # before this we don't have owner from figment
+              where: block_id > 111492264 and _inserted_timestamp >= current_date - 7 # before this we don't have owner from figment
       - name: DECIMAL 
         description: Number of decimals in the token value, need to divide amount by 10^decimal
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: UIAMOUNT
         description: Amount of the token in the transaction 
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: UIAMOUNTSTRING
         description: Amount of the token in the transaction in string format
         tests: 
-          - not_null  
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/non_core/silver__burn_actions.yml
+++ b/models/silver/non_core/silver__burn_actions.yml
@@ -2,6 +2,9 @@ version: 2
 models:
   - name: silver__burn_actions
     description: table holding token burn events
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -10,6 +13,7 @@ models:
             - INNER_INDEX
             - EVENT_TYPE
             - MINT
+          where: block_timestamp::date > current_date - 7
       - compare_model_subset:
           name: silver__burn_actions_logic_test
           compare_model: ref('testing__burn_actions')
@@ -29,46 +33,46 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null:
-              where: block_id > 39824213 and _inserted_timestamp::date < current_date
+              where: block_id > 39824213 and _inserted_timestamp >= current_date - 7
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 3
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: "{{ doc('event_index') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: INNER_INDEX
         description: Location of the inner instruction within an instruction
       - name: EVENT_TYPE 
         description: "{{ doc('event_type') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TOKEN_ACCOUNT
         description: The account address where tokens are burned from
       - name: BURN_AMOUNT
         description: Number of tokens burned
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: BURN_AUTHORITY
         description: Account address authorizing burn
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SIGNERS
         description: Account address authorizing burn
       - name: _INSERTED_TIMESTAMP

--- a/models/silver/non_core/silver__mint_actions.yml
+++ b/models/silver/non_core/silver__mint_actions.yml
@@ -2,6 +2,9 @@ version: 2
 models:
   - name: silver__mint_actions
     description: table holding mint initialization or token minting events
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -10,54 +13,54 @@ models:
             - INNER_INDEX
             - EVENT_TYPE
             - MINT
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null:
-              where: block_id > 39824213 and _inserted_timestamp::date < current_date
+              where: block_id > 39824213 and _inserted_timestamp >= current_date - 7
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 3
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: "{{ doc('event_index') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: INNER_INDEX
         description: Location of the inner instruction within an instruction
       - name: EVENT_TYPE 
         description: "{{ doc('event_type') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TOKEN_ACCOUNT
         description: The token's account - this can be used to join to the token account owners table. 
       - name: DECIMAL
         description: "{{ doc('decimal') }}"
         tests: 
           - not_null:
-              where: event_type in ('initializeMint','initializeMint2')
+              where: event_type in ('initializeMint','initializeMint2') and _inserted_timestamp >= current_date - 7
       - name: MINT_AMOUNT
         description: "{{ doc('mint_amount') }}"
         tests: 
           - not_null:
-              where: event_type in ('mintTo','mintToChecked')
+              where: event_type in ('mintTo','mintToChecked') and _inserted_timestamp >= current_date - 7
       - name: MINT_AUTHORITY
         description: "Account address authorizing mint"
       - name: SIGNERS

--- a/models/silver/non_core/silver__signers.yml
+++ b/models/silver/non_core/silver__signers.yml
@@ -1,6 +1,9 @@
 version: 2
 models:
   - name: silver__signers
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -9,11 +12,11 @@ models:
       - name: SIGNER
         description: The address of the user that initiated the transaction
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: FIRST_TX_DATE
         description: The first date that the wallet performed a transaction on.
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: FIRST_PROGRAM_ID
         description: The ID of the first program this signer interacted with, excluding chain admin programs.
         tests: 
@@ -22,7 +25,7 @@ models:
       - name: LAST_TX_DATE
         description: The date of the most recent transaction the signer has performed.
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: LAST_PROGRAM_ID
         description: The ID of the last program this signer interacted with, excluding chain admin programs.
         tests: 
@@ -31,7 +34,7 @@ models:
       - name: NUM_DAYS_ACTIVE
         description: A count of the total number of unique days that this signer has performed a transaction.
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: NUM_TXS
         description: The total number of distinct transactions initiated by this signer. 
         tests: 
@@ -44,5 +47,27 @@ models:
       - name: PROGRAMS_USED
         description: An array containing all program IDs a user interacted with on a given day.
         tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests: 
           - not_null
+      - name: SIGNERS_ID
+        description: '{{ doc("pk") }}'
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_signers_invocation_id
+              <<: *recent_date_filter
           


### PR DESCRIPTION
Update long-running tests
- decrease unique test range to scan last 7 days
- add recent date filter

running test:
```
17:35:10  Finished running 65 data tests, 7 project hooks in 0 hours 18 minutes and 43.17 seconds (1123.17s).
17:35:11  
17:35:11  Completed successfully
17:35:11  
17:35:11  Done. PASS=65 WARN=0 ERROR=0 SKIP=0 TOTAL=65
```

Example of prev run times:
- `10:25:39  670 of 2311 PASS dbt_utils_unique_combination_of_columns_silver___post_token_balances_BLOCK_ID__TX_ID__INDEX  [PASS in 3944.70s]
`