### PR TITLE
Orca v2 lp actions

### DIFF
--- a/models/descriptions/token_a_amount.md
+++ b/models/descriptions/token_a_amount.md
@@ -1,0 +1,5 @@
+{% docs token_a_amount %}
+
+Amount of the first token in a liquidity pool pair transferred during a liquidity pool action
+
+{% enddocs %}

--- a/models/descriptions/token_b_amount.md
+++ b/models/descriptions/token_b_amount.md
@@ -1,0 +1,5 @@
+{% docs token_b_amount %}
+
+Amount of the second token in a liquidity pool pair transferred during a liquidity pool action
+
+{% enddocs %}

--- a/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.sql
+++ b/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.sql
@@ -3,10 +3,10 @@
     config(
         materialized = 'incremental',
         incremental_strategy = 'merge',
-        unique_key = 'liquidity_pool_actions_orcav2_id',
+        unique_key = ['block_timestamp::date','liquidity_pool_actions_orcav2_id'],
         incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
         merge_exclude_columns = ["inserted_timestamp"],
-        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+        cluster_by = ['block_timestamp::date','modified_timestamp::date'],
         post_hook = enable_search_optimization(
             '{{this.schema}}',
             '{{this.identifier}}',

--- a/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.sql
+++ b/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.sql
@@ -1,0 +1,217 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = 'liquidity_pool_actions_orcav2_id',
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+        post_hook = enable_search_optimization(
+            '{{this.schema}}',
+            '{{this.identifier}}',
+            'ON EQUALITY(tx_id, provider_address, token_a_mint, token_b_mint, liquidity_pool_actions_orcav2_id)'
+        ),
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.liquidity_pool_actions_orcav2__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = '9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP'
+        AND event_type IN (
+            'depositAllTokenTypes', 
+            'depositSingleTokenTypeExactAmountIn', 
+            'withdrawAllTokenTypes', 
+            'withdrawSingleTokenTypeExactAmountOut'
+        )
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        {% else %}
+        AND block_timestamp::date between '2021-06-10' and '2023-01-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.liquidity_pool_actions_orcav2__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+with base as (
+    select 
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('swap', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('userTransferAuthority', accounts) AS provider_address,
+        silver.udf_get_account_pubkey_by_name('swapTokenA', accounts) AS pool_token_a_account,
+        silver.udf_get_account_pubkey_by_name('swapTokenB', accounts) AS pool_token_b_account,
+        case 
+            when event_type = 'depositAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('depositTokenA', accounts)
+            when event_type = 'depositSingleTokenTypeExactAmountIn' then
+                silver.udf_get_account_pubkey_by_name('sourceToken', accounts)
+            when event_type = 'withdrawAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('destinationTokenA', accounts)
+            when event_type = 'withdrawSingleTokenTypeExactAmountOut' then
+                silver.udf_get_account_pubkey_by_name('destination', accounts)
+            else
+                NULL
+        end AS token_a_account,
+        case 
+            when event_type = 'depositAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('depositTokenB', accounts)
+            when event_type = 'withdrawAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('destinationTokenB', accounts)
+            else
+                NULL
+        end AS token_b_account,
+        coalesce(lead(inner_index) over (partition by tx_id, index order by inner_index),9999) AS next_lp_action_inner_index
+    from 
+        silver.liquidity_pool_actions_orcav2__intermediate_tmp
+),
+transfers as (
+    select * exclude(index),
+        split_part(index,'.',1)::int AS index,
+        nullif(split_part(index,'.',2),'')::int AS inner_index
+    from
+        {{ ref('silver__transfers') }}
+    WHERE
+        {{ between_stmts }}
+),
+deposit_transfers AS (
+    select 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount,
+    from base AS b
+    left join
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND (
+                (t.source_token_account = b.token_a_account
+                AND t.dest_token_account = b.pool_token_a_account)
+            OR
+                (t.source_token_account = b.token_a_account
+                AND t.dest_token_account = b.pool_token_b_account
+                AND b.event_type = 'depositSingleTokenTypeExactAmountIn') /* we always represent single token deposit as a deposit of "token A" */
+            )
+    left join
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.source_token_account = b.token_b_account
+        AND t2.dest_token_account = b.pool_token_b_account
+    where
+        b.event_type IN (
+            'depositAllTokenTypes', 
+            'depositSingleTokenTypeExactAmountIn'
+        )
+),
+withdraw_transfers AS (
+    select 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount,
+    from base AS b
+    left join
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND (
+                (t.dest_token_account = b.token_a_account
+                AND t.source_token_account = b.pool_token_a_account)
+            OR
+                (t.dest_token_account = b.token_a_account
+                AND t.source_token_account = b.pool_token_b_account
+                AND b.event_type = 'withdrawSingleTokenTypeExactAmountOut') /* we always represent single token withdraw as a withdraw of "token A" */
+            )
+    left join
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.dest_token_account = b.token_b_account
+        AND t2.source_token_account = b.pool_token_b_account
+    where
+        b.event_type IN (
+            'withdrawAllTokenTypes', 
+            'withdrawSingleTokenTypeExactAmountOut'
+        )
+)
+select
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    event_type,
+    pool_address,
+    provider_address,
+    token_a_mint,
+    token_a_amount,
+    token_b_mint,
+    token_b_amount,
+    program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav2_id,
+    sysdate() as inserted_timestamp,
+    sysdate() as modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+from deposit_transfers
+union all
+select 
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    event_type,
+    pool_address,
+    provider_address,
+    token_a_mint,
+    token_a_amount,
+    token_b_mint,
+    token_b_amount,
+    program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav2_id,
+    sysdate() as inserted_timestamp,
+    sysdate() as modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+from withdraw_transfers

--- a/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.sql
+++ b/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.sql
@@ -12,6 +12,7 @@
             '{{this.identifier}}',
             'ON EQUALITY(tx_id, provider_address, token_a_mint, token_b_mint, liquidity_pool_actions_orcav2_id)'
         ),
+        tags = ['scheduled_non_core']
     )
 }}
 

--- a/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.yml
+++ b/models/silver/liquidity_pool/orca/silver__liquidity_pool_actions_orcav2.yml
@@ -1,0 +1,98 @@
+version: 2
+models:
+  - name: silver__liquidity_pool_actions_orcav2
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp < current_date - 7
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: EVENT_TYPE
+        description: "{{ doc('event_type') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROVIDER_ADDRESS
+        description:  "{{ doc('liquidity_provider') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_AMOUNT
+        description:  "{{ doc('token_a_amount') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp < current_date - 7
+                  AND event_type IN ('withdrawAllTokenTypes','depositAllTokenTypes')
+      - name: TOKEN_B_AMOUNT
+        description:  "{{ doc('token_b_amount') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp < current_date - 7
+                  AND event_type IN ('withdrawAllTokenTypes','depositAllTokenTypes')
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: LIQUIDITY_POOL_ACTIONS_ORCAV2_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_liquidity_pool_actions_orcav2_invocation_id
+              <<: *recent_date_filter


### PR DESCRIPTION
- Create `silver__liquidity_pool_actions_orcav2` to capture deposits and withdraws for v2 pools
  - Uses decoded instructions and transfers as upstreams
 
> [!NOTE]
> We will need to backfill this table in batches before merging which will take a few hours total on 2xl


`dbt build -s silver__liquidity_pool_actions_orcav2 -t dev-2xl --full-refresh`
```
05:41:25  Finished running 1 incremental model, 19 data tests, 7 project hooks in 0 hours 31 minutes and 25.78 seconds (1885.78s).
05:41:25  
05:41:25  Completed successfully
05:41:25  
05:41:25  Done. PASS=20 WARN=0 ERROR=0 SKIP=0 TOTAL=20
```

Incremental on next 6 months of data
```
15:14:22  1 of 20 OK created sql incremental model silver.liquidity_pool_actions_orcav2 .. [SUCCESS 11399 in 1125.66s]
15:14:34  Finished running 1 incremental model, 19 data tests, 7 project hooks in 0 hours 19 minutes and 16.90 seconds (1156.90s).
15:14:35  
15:14:35  Completed successfully
15:14:35  
15:14:35  Done. PASS=20 WARN=0 ERROR=0 SKIP=0 TOTAL=20
```

Data in DEV (I have only loaded data up to 2023-06-01 so far)
```
-- 3wxhEKEptkTp8ipV2bmiuPg68EihPuL4Jsqnf2rpzymijwep2N6RUv8xEDrooyuYegPugDnzUdUFQKrJSKDit8Jo
-- 2zgmSDuys4DiEkmXqRgHsicT7zqbZRhUXczqG1YPda3pybzFkZTUy2QYZxYS1r4cjuVrjD1esQKbDPR3GcpMzLaQ
-- 4RaF2mQrrTry2J8qWSnXpDKoc71T7Rc8dnCyNeD7W43mNCV9PsecPGcUS3A7H77HzoxaE4esWV1xQmZJ14YZyasx
-- 2j4BMnzbn3rHuJoSPGeG2N5hFyEhVo1EiPiaGnq9U6RKPAeg8pwoMd54VFkBbP4brYdbHi6g6W2CmYFJFe7erkgq
-- 5Be4WNg14fSdxNxpum2RFWe6H3bcWg3z2ieYaCK1Q3rJMUkjQZ1tjYh5VTG1ZQ9GoTroL7cDLYrL78u15hxRzmYH
select *
from solana_dev.silver.liquidity_pool_actions_orcav2
where tx_id = '3wxhEKEptkTp8ipV2bmiuPg68EihPuL4Jsqnf2rpzymijwep2N6RUv8xEDrooyuYegPugDnzUdUFQKrJSKDit8Jo';
```
