### PR TITLE
Orcav1 initialization pools

### DIFF
--- a/models/silver/liquidity_pool/orca/v1/silver__initialization_pools_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__initialization_pools_orcav1.sql
@@ -1,0 +1,164 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = 'initialization_pools_orcav1_id',
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.initialization_pools_orcav1__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = 'DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1'
+        AND event_type = 'initialize'
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.initialization_pools_orcav1__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('swap', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('pool', accounts) AS pool_token_mint,
+        silver.udf_get_account_pubkey_by_name('tokenA', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('tokenB', accounts) AS token_b_account
+    FROM
+        silver.initialization_pools_orcav1__intermediate_tmp
+),
+-- post_token_balances AS (
+--     SELECT
+--         block_timestamp,
+--         tx_id,
+--         account,
+--         mint
+--     FROM
+--         {{ ref('silver___post_token_balances') }}
+--     WHERE
+--         {{ between_stmts }}
+-- )
+token_account_mints AS (
+    SELECT
+        tx_id,
+        index,
+        inner_index,
+        token_a_account,
+        {{ target.database }}.live.udf_api(
+            'POST',
+            '{service}/{Authentication}',
+            OBJECT_CONSTRUCT(
+                'Content-Type',
+                'application/json'
+            ),
+            OBJECT_CONSTRUCT(
+                'id',
+                1,
+                'jsonrpc',
+                '2.0',
+                'method',
+                'getAccountInfo',
+                'params',
+                ARRAY_CONSTRUCT(
+                    token_a_account,
+                    OBJECT_CONSTRUCT(
+                        'encoding',
+                        'jsonParsed'
+                    )
+                )
+            ),
+            'Vault/prod/solana/quicknode/mainnet'
+        ) AS token_a_response,
+        token_b_account,
+        {{ target.database }}.live.udf_api(
+            'POST',
+            '{service}/{Authentication}',
+            OBJECT_CONSTRUCT(
+                'Content-Type',
+                'application/json'
+            ),
+            OBJECT_CONSTRUCT(
+                'id',
+                2,
+                'jsonrpc',
+                '2.0',
+                'method',
+                'getAccountInfo',
+                'params',
+                ARRAY_CONSTRUCT(
+                    token_b_account,
+                    OBJECT_CONSTRUCT(
+                        'encoding',
+                        'jsonParsed'
+                    )
+                )
+            ),
+            'Vault/prod/solana/quicknode/mainnet'
+        ) AS token_b_response
+    FROM
+        base
+)
+SELECT 
+    b.block_id,
+    b.block_timestamp,
+    b.tx_id,
+    b.index,
+    b.inner_index,
+    b.succeeded,
+    b.pool_address,
+    b.pool_token_mint,
+    b.token_a_account,
+    token_a_response:data:result:value:data:parsed:info:mint::string AS token_a_mint,
+    -- ptb_a.mint AS token_a_mint,
+    b.token_b_account,
+    -- ptb_b.mint AS token_b_mint,
+    token_b_response:data:result:value:data:parsed:info:mint::string AS token_b_mint,
+    b.program_id,
+    b._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['b.block_id', 'b.tx_id', 'b.index', 'b.inner_index']) }} AS initialization_pools_orcav1_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    base AS b
+JOIN
+    token_account_mints AS t
+    ON b.tx_id = t.tx_id
+    AND b.index = t.index
+    AND coalesce(b.inner_index, -1) = coalesce(t.inner_index, -1)
+-- LEFT JOIN
+--     post_token_balances AS ptb_a
+--     ON b.block_timestamp::date = ptb_a.block_timestamp::date
+--     AND b.tx_id = ptb_a.tx_id
+--     AND b.token_a_account = ptb_a.account
+-- LEFT JOIN
+--     post_token_balances AS ptb_b
+--     ON b.block_timestamp::date = ptb_b.block_timestamp::date
+--     AND b.tx_id = ptb_b.tx_id
+--     AND b.token_b_account = ptb_b.account

--- a/models/silver/liquidity_pool/orca/v1/silver__initialization_pools_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__initialization_pools_orcav1.sql
@@ -53,17 +53,6 @@ WITH base AS (
     FROM
         silver.initialization_pools_orcav1__intermediate_tmp
 ),
--- post_token_balances AS (
---     SELECT
---         block_timestamp,
---         tx_id,
---         account,
---         mint
---     FROM
---         {{ ref('silver___post_token_balances') }}
---     WHERE
---         {{ between_stmts }}
--- )
 token_account_mints AS (
     SELECT
         tx_id,
@@ -135,9 +124,7 @@ SELECT
     b.pool_token_mint,
     b.token_a_account,
     token_a_response:data:result:value:data:parsed:info:mint::string AS token_a_mint,
-    -- ptb_a.mint AS token_a_mint,
     b.token_b_account,
-    -- ptb_b.mint AS token_b_mint,
     token_b_response:data:result:value:data:parsed:info:mint::string AS token_b_mint,
     b.program_id,
     b._inserted_timestamp,
@@ -152,13 +139,3 @@ JOIN
     ON b.tx_id = t.tx_id
     AND b.index = t.index
     AND coalesce(b.inner_index, -1) = coalesce(t.inner_index, -1)
--- LEFT JOIN
---     post_token_balances AS ptb_a
---     ON b.block_timestamp::date = ptb_a.block_timestamp::date
---     AND b.tx_id = ptb_a.tx_id
---     AND b.token_a_account = ptb_a.account
--- LEFT JOIN
---     post_token_balances AS ptb_b
---     ON b.block_timestamp::date = ptb_b.block_timestamp::date
---     AND b.tx_id = ptb_b.tx_id
---     AND b.token_b_account = ptb_b.account

--- a/models/silver/liquidity_pool/orca/v1/silver__initialization_pools_orcav1.yml
+++ b/models/silver/liquidity_pool/orca/v1/silver__initialization_pools_orcav1.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver__initialization_pools_orcav1
+    data_data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null
+      - name: POOL_TOKEN_MINT
+        description: "{{ doc('liquidity_pool_token_mint') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_ACCOUNT
+        description:  "{{ doc('token_a_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_ACCOUNT
+        description:  "{{ doc('token_b_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: INITIALIZATION_POOLS_ORCAV1_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null: 
+              name: test_silver__not_null_initialization_pools_orcav1_invocation_id


### PR DESCRIPTION
- Create Orca V1 pool initializations model
  - No new pools created since 2021 as this program is now deprecated, so we shouldn't expect new pools. Because of this I think we can run this just one time and leave it off the scheduler
  - Slightly diff than V2 model as the mint data is not available in `post_token_balances`. Instead use LQ to get the account mints directly from Quicknode. There are only `27` pools and we only have to do this once.

`dbt build -s silver__initialization_pools_orcav1 -t dev --full-refresh`
```
15:33:57  Finished running 1 incremental model, 17 data tests, 7 project hooks in 0 hours 0 minutes and 33.89 seconds (33.89s).
15:33:58  
15:33:58  Completed successfully
15:33:58  
15:33:58  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```
 
Incremental logic in place and successful even though we shouldnt need it
`dbt run -s silver__initialization_pools_orcav1 -t dev`
```
15:34:43  1 of 1 OK created sql incremental model silver.initialization_pools_orcav1 ..... [SUCCESS 0 in 6.88s]
```

Data in DEV
```
select *
from solana_dev.silver.initialization_pools_orcav1;
```