### PR TITLE
Orca v1 lp actions

### DIFF
--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -50,7 +50,8 @@
         -- AND _inserted_timestamp > '{{ max_timestamp }}'
         -- AND block_timestamp::date BETWEEN '2022-06-01' AND '2023-01-01'
         -- AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
-        AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
+        -- AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
+        AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-06-01'
         {% else %}
         /* 
         there are data issues from 2021-02-14 to 2021-03-17 with transfers 

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -1,0 +1,218 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::date','liquidity_pool_actions_orcav1_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::date','modified_timestamp::date'],
+        post_hook = enable_search_optimization(
+            '{{this.schema}}',
+            '{{this.identifier}}',
+            'ON EQUALITY(tx_id, provider_address, token_a_mint, token_b_mint, liquidity_pool_actions_orcav1_id)'
+        ),
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.liquidity_pool_actions_orcav1__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = 'DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1'
+        AND event_type IN (
+            'depositAllTokenTypes', 
+            'depositSingleTokenTypeExactAmountIn', 
+            'withdrawAllTokenTypes', 
+            'withdrawSingleTokenTypeExactAmountOut'
+        )
+        {% if is_incremental() %}
+        -- AND _inserted_timestamp > '{{ max_timestamp }}'
+        AND block_timestamp::date between '2022-06-01' and '2023-01-01'
+        {% else %}
+        AND block_timestamp::date between '2021-02-10' and '2022-06-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.liquidity_pool_actions_orcav1__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+with base as (
+    select 
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('swap', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('userTransferAuthority', accounts) AS provider_address,
+        silver.udf_get_account_pubkey_by_name('swapTokenA', accounts) AS pool_token_a_account,
+        silver.udf_get_account_pubkey_by_name('swapTokenB', accounts) AS pool_token_b_account,
+        case 
+            when event_type = 'depositAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('depositTokenA', accounts)
+            when event_type = 'depositSingleTokenTypeExactAmountIn' then
+                silver.udf_get_account_pubkey_by_name('sourceToken', accounts)
+            when event_type = 'withdrawAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('destinationTokenA', accounts)
+            when event_type = 'withdrawSingleTokenTypeExactAmountOut' then
+                silver.udf_get_account_pubkey_by_name('destination', accounts)
+            else
+                NULL
+        end AS token_a_account,
+        case 
+            when event_type = 'depositAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('depositTokenB', accounts)
+            when event_type = 'withdrawAllTokenTypes' then
+                silver.udf_get_account_pubkey_by_name('destinationTokenB', accounts)
+            else
+                NULL
+        end AS token_b_account,
+        coalesce(lead(inner_index) over (partition by tx_id, index order by inner_index),9999) AS next_lp_action_inner_index
+    from 
+        silver.liquidity_pool_actions_orcav1__intermediate_tmp
+),
+transfers as (
+    select * exclude(index),
+        split_part(index,'.',1)::int AS index,
+        nullif(split_part(index,'.',2),'')::int AS inner_index
+    from
+        {{ ref('silver__transfers') }}
+    WHERE
+        {{ between_stmts }}
+),
+deposit_transfers AS (
+    select 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount,
+    from base AS b
+    left join
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND (
+                (t.source_token_account = b.token_a_account
+                AND t.dest_token_account = b.pool_token_a_account)
+            OR
+                (t.source_token_account = b.token_a_account
+                AND t.dest_token_account = b.pool_token_b_account
+                AND b.event_type = 'depositSingleTokenTypeExactAmountIn') /* we always represent single token deposit as a deposit of "token A" */
+            )
+    left join
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.source_token_account = b.token_b_account
+        AND t2.dest_token_account = b.pool_token_b_account
+    where
+        b.event_type IN (
+            'depositAllTokenTypes', 
+            'depositSingleTokenTypeExactAmountIn'
+        )
+),
+withdraw_transfers AS (
+    select 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount,
+    from base AS b
+    left join
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND (
+                (t.dest_token_account = b.token_a_account
+                AND t.source_token_account = b.pool_token_a_account)
+            OR
+                (t.dest_token_account = b.token_a_account
+                AND t.source_token_account = b.pool_token_b_account
+                AND b.event_type = 'withdrawSingleTokenTypeExactAmountOut') /* we always represent single token withdraw as a withdraw of "token A" */
+            )
+    left join
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.dest_token_account = b.token_b_account
+        AND t2.source_token_account = b.pool_token_b_account
+    where
+        b.event_type IN (
+            'withdrawAllTokenTypes', 
+            'withdrawSingleTokenTypeExactAmountOut'
+        )
+)
+select
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    event_type,
+    pool_address,
+    provider_address,
+    token_a_mint,
+    token_a_amount,
+    token_b_mint,
+    token_b_amount,
+    program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav1_id,
+    sysdate() as inserted_timestamp,
+    sysdate() as modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+from deposit_transfers
+union all
+select 
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    event_type,
+    pool_address,
+    provider_address,
+    token_a_mint,
+    token_a_amount,
+    token_b_mint,
+    token_b_amount,
+    program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav1_id,
+    sysdate() as inserted_timestamp,
+    sysdate() as modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+from withdraw_transfers

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -48,7 +48,8 @@
         )
         {% if is_incremental() %}
         -- AND _inserted_timestamp > '{{ max_timestamp }}'
-        AND block_timestamp::date BETWEEN '2022-06-01'  AND '2023-01-01'
+        -- AND block_timestamp::date BETWEEN '2022-06-01' AND '2023-01-01'
+        AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
         {% else %}
         /* 
         there are data issues from 2021-02-14 to 2021-03-17 with transfers 

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -47,80 +47,78 @@
             'withdrawSingleTokenTypeExactAmountOut'
         )
         {% if is_incremental() %}
-        -- AND _inserted_timestamp > '{{ max_timestamp }}'
-        AND block_timestamp::date between '2022-06-01' and '2023-01-01'
+        AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}
-        AND block_timestamp::date between '2021-02-10' and '2022-06-01'
+        AND block_timestamp::date BETWEEN '2021-02-14' AND '2022-06-01'
         {% endif %}
     {% endset %}
     {% do run_query(base_query) %}
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.liquidity_pool_actions_orcav1__intermediate_tmp","block_timestamp::date") %}
 {% endif %}
 
-with base as (
-    select 
+WITH base AS (
+    SELECT 
         * exclude(accounts),
         silver.udf_get_account_pubkey_by_name('swap', accounts) AS pool_address,
         silver.udf_get_account_pubkey_by_name('userTransferAuthority', accounts) AS provider_address,
         silver.udf_get_account_pubkey_by_name('swapTokenA', accounts) AS pool_token_a_account,
         silver.udf_get_account_pubkey_by_name('swapTokenB', accounts) AS pool_token_b_account,
-        case 
-            when event_type = 'depositAllTokenTypes' then
+        CASE 
+            WHEN event_type = 'depositAllTokenTypes' THEN
                 silver.udf_get_account_pubkey_by_name('depositTokenA', accounts)
-            when event_type = 'depositSingleTokenTypeExactAmountIn' then
+            WHEN event_type = 'depositSingleTokenTypeExactAmountIn' THEN
                 silver.udf_get_account_pubkey_by_name('sourceToken', accounts)
-            when event_type = 'withdrawAllTokenTypes' then
+            WHEN event_type = 'withdrawAllTokenTypes' THEN
                 silver.udf_get_account_pubkey_by_name('destinationTokenA', accounts)
-            when event_type = 'withdrawSingleTokenTypeExactAmountOut' then
+            WHEN event_type = 'withdrawSingleTokenTypeExactAmountOut' THEN
                 silver.udf_get_account_pubkey_by_name('destination', accounts)
-            else
-                NULL
-        end AS token_a_account,
-        case 
-            when event_type = 'depositAllTokenTypes' then
+            ELSE NULL
+        END AS token_a_account,
+        CASE 
+            WHEN event_type = 'depositAllTokenTypes' THEN
                 silver.udf_get_account_pubkey_by_name('depositTokenB', accounts)
-            when event_type = 'withdrawAllTokenTypes' then
+            WHEN event_type = 'withdrawAllTokenTypes' THEN
                 silver.udf_get_account_pubkey_by_name('destinationTokenB', accounts)
-            else
-                NULL
-        end AS token_b_account,
-        coalesce(lead(inner_index) over (partition by tx_id, index order by inner_index),9999) AS next_lp_action_inner_index
-    from 
+            ELSE NULL
+        END AS token_b_account,
+        coalesce(lead(inner_index) OVER (
+            PARTITION BY tx_id, index 
+            ORDER BY inner_index
+        ), 9999) AS next_lp_action_inner_index
+    FROM 
         silver.liquidity_pool_actions_orcav1__intermediate_tmp
 ),
-transfers as (
-    select * exclude(index),
+
+transfers AS (
+    SELECT 
+        * exclude(index),
         split_part(index,'.',1)::int AS index,
         nullif(split_part(index,'.',2),'')::int AS inner_index
-    from
+    FROM
         {{ ref('silver__transfers') }}
     WHERE
         {{ between_stmts }}
 ),
+
 deposit_transfers AS (
-    select 
+    SELECT 
         b.*,
         t.mint AS token_a_mint,
         t.amount AS token_a_amount,
         t2.mint AS token_b_mint,
-        t2.amount AS token_b_amount,
-    from base AS b
-    left join
+        t2.amount AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
         transfers AS t
         ON t.block_timestamp::date = b.block_timestamp::date
         AND t.tx_id = b.tx_id
         AND t.index = b.index
         AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
         AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
-        AND (
-                (t.source_token_account = b.token_a_account
-                AND t.dest_token_account = b.pool_token_a_account)
-            OR
-                (t.source_token_account = b.token_a_account
-                AND t.dest_token_account = b.pool_token_b_account
-                AND b.event_type = 'depositSingleTokenTypeExactAmountIn') /* we always represent single token deposit as a deposit of "token A" */
-            )
-    left join
+        AND t.source_token_account = b.token_a_account
+        AND t.dest_token_account = b.pool_token_a_account
+    LEFT JOIN
         transfers AS t2
         ON t2.block_timestamp::date = b.block_timestamp::date
         AND t2.tx_id = b.tx_id
@@ -129,36 +127,51 @@ deposit_transfers AS (
         AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
         AND t2.source_token_account = b.token_b_account
         AND t2.dest_token_account = b.pool_token_b_account
-    where
-        b.event_type IN (
-            'depositAllTokenTypes', 
-            'depositSingleTokenTypeExactAmountIn'
-        )
+    WHERE
+        b.event_type = 'depositAllTokenTypes'
 ),
-withdraw_transfers AS (
-    select 
+
+single_deposit_transfers AS (
+    SELECT 
         b.*,
         t.mint AS token_a_mint,
         t.amount AS token_a_amount,
-        t2.mint AS token_b_mint,
-        t2.amount AS token_b_amount,
-    from base AS b
-    left join
+        NULL AS token_b_mint,
+        NULL AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
         transfers AS t
         ON t.block_timestamp::date = b.block_timestamp::date
         AND t.tx_id = b.tx_id
         AND t.index = b.index
         AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
         AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
-        AND (
-                (t.dest_token_account = b.token_a_account
-                AND t.source_token_account = b.pool_token_a_account)
-            OR
-                (t.dest_token_account = b.token_a_account
-                AND t.source_token_account = b.pool_token_b_account
-                AND b.event_type = 'withdrawSingleTokenTypeExactAmountOut') /* we always represent single token withdraw as a withdraw of "token A" */
-            )
-    left join
+        AND t.source_token_account = b.token_a_account
+        AND t.dest_token_account IN (b.pool_token_a_account, b.pool_token_b_account)
+    WHERE
+        b.event_type = 'depositSingleTokenTypeExactAmountIn'
+),
+
+withdraw_transfers AS (
+    SELECT 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t.dest_token_account = b.token_a_account
+        AND t.source_token_account = b.pool_token_a_account
+    LEFT JOIN
         transfers AS t2
         ON t2.block_timestamp::date = b.block_timestamp::date
         AND t2.tx_id = b.tx_id
@@ -167,13 +180,33 @@ withdraw_transfers AS (
         AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
         AND t2.dest_token_account = b.token_b_account
         AND t2.source_token_account = b.pool_token_b_account
-    where
-        b.event_type IN (
-            'withdrawAllTokenTypes', 
-            'withdrawSingleTokenTypeExactAmountOut'
-        )
+    WHERE
+        b.event_type = 'withdrawAllTokenTypes'
+),
+
+single_withdraw_transfers AS (
+    SELECT 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        NULL AS token_b_mint,
+        NULL AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t.dest_token_account = b.token_a_account
+        AND t.source_token_account IN (b.pool_token_a_account, b.pool_token_b_account)
+    WHERE
+        b.event_type = 'withdrawSingleTokenTypeExactAmountOut'
 )
-select
+
+SELECT
     block_id,
     block_timestamp,
     tx_id,
@@ -190,12 +223,15 @@ select
     program_id,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav1_id,
-    sysdate() as inserted_timestamp,
-    sysdate() as modified_timestamp,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
-from deposit_transfers
-union all
-select 
+FROM 
+    deposit_transfers
+
+UNION ALL
+
+SELECT 
     block_id,
     block_timestamp,
     tx_id,
@@ -212,7 +248,58 @@ select
     program_id,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav1_id,
-    sysdate() as inserted_timestamp,
-    sysdate() as modified_timestamp,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
-from withdraw_transfers
+FROM 
+    withdraw_transfers
+
+UNION ALL
+
+SELECT 
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    event_type,
+    pool_address,
+    provider_address,
+    token_a_mint,
+    token_a_amount,
+    token_b_mint,
+    token_b_amount,
+    program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav1_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    single_deposit_transfers
+
+UNION ALL
+
+SELECT 
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    event_type,
+    pool_address,
+    provider_address,
+    token_a_mint,
+    token_a_amount,
+    token_b_mint,
+    token_b_amount,
+    program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orcav1_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    single_withdraw_transfers

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -12,6 +12,7 @@
             '{{this.identifier}}',
             'ON EQUALITY(tx_id, provider_address, token_a_mint, token_b_mint, liquidity_pool_actions_orcav1_id)'
         ),
+        tags = ['scheduled_non_core']
     )
 }}
 
@@ -52,7 +53,7 @@
         -- AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
         -- AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
         -- AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-06-01'
-        AND block_timestamp::date BETWEEN '2024-06-01' AND '2025-01-05'
+        -- AND block_timestamp::date BETWEEN '2024-06-01' AND '2025-01-05'
         {% else %}
         /* 
         there are data issues from 2021-02-14 to 2021-03-17 with transfers 

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -47,7 +47,8 @@
             'withdrawSingleTokenTypeExactAmountOut'
         )
         {% if is_incremental() %}
-        AND _inserted_timestamp > '{{ max_timestamp }}'
+        -- AND _inserted_timestamp > '{{ max_timestamp }}'
+        AND block_timestamp::date BETWEEN '2022-06-01'  AND '2023-01-01'
         {% else %}
         /* 
         there are data issues from 2021-02-14 to 2021-03-17 with transfers 

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -49,10 +49,15 @@
         {% if is_incremental() %}
         AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}
-        /* there are data issues from 2021-02-14 to 2021-03-17 with transfers 
+        /* 
+        there are data issues from 2021-02-14 to 2021-03-17 with transfers 
         and some deposits that don't seem to have transfers at all.
         It would take significant time and complexity for solve for these edge cases 
-        so we are electing to exclude this data for now */
+        so we are electing to exclude this data for now 
+        examples:
+            -- 7Jdcs7rwoC3n8vSX6B3CdB98Ms8zzU7AwtAPrNYPuma2tZCdJTWGiEmC5w63RPpWNpfxZFvHrq72baExvU1FGEc
+            -- 34x5eT8bpjKFr2hZzRQLQ77jyLy4KMH98WWeNgJiFmS4q8pECVXkg3iKSd9e5mnehj5kQa37F1XRGWKh795DAH1f
+        */
         AND block_timestamp::date BETWEEN '2021-03-17' AND '2022-06-01' 
         {% endif %}
     {% endset %}

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -51,7 +51,8 @@
         -- AND block_timestamp::date BETWEEN '2022-06-01' AND '2023-01-01'
         -- AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
         -- AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
-        AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-06-01'
+        -- AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-06-01'
+        AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-01-05'
         {% else %}
         /* 
         there are data issues from 2021-02-14 to 2021-03-17 with transfers 

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -49,7 +49,11 @@
         {% if is_incremental() %}
         AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}
-        AND block_timestamp::date BETWEEN '2021-02-14' AND '2022-06-01'
+        /* there are data issues from 2021-02-14 to 2021-03-17 with transfers 
+        and some deposits that don't seem to have transfers at all.
+        It would take significant time and complexity for solve for these edge cases 
+        so we are electing to exclude this data for now */
+        AND block_timestamp::date BETWEEN '2021-03-17' AND '2022-06-01' 
         {% endif %}
     {% endset %}
     {% do run_query(base_query) %}

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -49,7 +49,8 @@
         {% if is_incremental() %}
         -- AND _inserted_timestamp > '{{ max_timestamp }}'
         -- AND block_timestamp::date BETWEEN '2022-06-01' AND '2023-01-01'
-        AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
+        -- AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
+        AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
         {% else %}
         /* 
         there are data issues from 2021-02-14 to 2021-03-17 with transfers 

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -52,7 +52,7 @@
         -- AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
         -- AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
         -- AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-06-01'
-        AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-01-05'
+        AND block_timestamp::date BETWEEN '2024-06-01' AND '2025-01-05'
         {% else %}
         /* 
         there are data issues from 2021-02-14 to 2021-03-17 with transfers 

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.yml
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.yml
@@ -1,0 +1,98 @@
+version: 2
+models:
+  - name: silver__liquidity_pool_actions_orcav1
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp < current_date - 7
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: EVENT_TYPE
+        description: "{{ doc('event_type') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROVIDER_ADDRESS
+        description:  "{{ doc('liquidity_provider') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_AMOUNT
+        description:  "{{ doc('token_a_amount') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp < current_date - 7
+                  AND event_type IN ('withdrawAllTokenTypes','depositAllTokenTypes')
+      - name: TOKEN_B_AMOUNT
+        description:  "{{ doc('token_b_amount') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp < current_date - 7
+                  AND event_type IN ('withdrawAllTokenTypes','depositAllTokenTypes')
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: LIQUIDITY_POOL_ACTIONS_ORCAV1_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_liquidity_pool_actions_orcav1_invocation_id
+              <<: *recent_date_filter


### PR DESCRIPTION
- Create `silver__liquidity_pool_actions_orcav1` to capture deposits and withdraws for v1 pools
  - Uses decoded instructions and transfers as upstreams
  - There are issues with data before `2021-03-17`. These records have been omitted from the model
 
> [!NOTE]
> We will need to backfill this table in batches before merging which will take a ~1 hour total on 2xl


`dbt build -s silver__liquidity_pool_actions_orcav1 -t dev-2xl --full-refresh`
```
17:47:59  1 of 20 OK created sql incremental model silver.liquidity_pool_actions_orcav1 .. [SUCCESS 1 in 457.93s]
17:48:08  Finished running 1 incremental model, 19 data tests, 7 project hooks in 0 hours 8 minutes and 1.40 seconds (481.40s).
17:48:08  
17:48:08  Completed successfully
17:48:08  
17:48:08  Done. PASS=20 WARN=0 ERROR=0 SKIP=0 TOTAL=20
```

Incremental on next 6 months of data
```
17:49:51  1 of 20 OK created sql incremental model silver.liquidity_pool_actions_orcav1 .. [SUCCESS 82 in 37.26s]
17:49:59  Finished running 1 incremental model, 19 data tests, 7 project hooks in 0 hours 0 minutes and 58.79 seconds (58.79s).
17:49:59  
17:49:59  Completed successfully
17:49:59  
17:49:59  Done. PASS=20 WARN=0 ERROR=0 SKIP=0 TOTAL=20
```

Data in DEV (I have only loaded data up to 2023-01-01 so far)
```
-- 4678RmhHsgM6i2DMRwzaiKWsg3AXsyd6vyiBienyHheS2KaCjat6HoqkhFTSViieaSCbDHhoVYW7gKSUDivM4Q8U
-- kjKjSRWwQBqin1JiknPt4HJgvABFM3BC4E2STqryDzJVptSUNNGhUevPrirECZBR16QamWtXyWadqRKH4cqRG7k
-- 2SrPZdNLgt7E3yTM4U2KCuGriD1un3G9PM18XgtcaXuGxTx9WqXDVHseaB8rqe1zt7athPhisCvCTrUx9cmCoueq
select *
from solana_dev.silver.liquidity_pool_actions_orcav1
where tx_id = '2SrPZdNLgt7E3yTM4U2KCuGriD1un3G9PM18XgtcaXuGxTx9WqXDVHseaB8rqe1zt7athPhisCvCTrUx9cmCoueq';
```
