### PR TITLE
Raydium v4 initialize pools

### DIFF
--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
@@ -101,9 +101,9 @@ WHERE
     I spot checked a few of these and they seem to be invalid as the pool_address they are trying to initialize has already been created
     */
     (
-        b.block_timestamp > '2022-11-10 20:16:52.000'
+        b.block_timestamp >= '2022-11-11'
         OR (
-            b.block_timestamp < '2022-11-10 20:16:52.000'
+            b.block_timestamp < '2022-11-11'
             AND token_a_mint IS NOT NULL
             AND token_b_mint IS NOT NULL
             AND token_a_account IS NOT NULL

--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
@@ -3,7 +3,7 @@
     config(
         materialized = 'incremental',
         incremental_strategy = 'merge',
-        unique_key = 'initialization_pools_raydiumv4_id',
+        unique_key = ['block_timestamp::DATE','initialization_pools_raydiumv4_id'],
         incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
         merge_exclude_columns = ["inserted_timestamp"],
         cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],

--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
@@ -1,0 +1,111 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = 'initialization_pools_raydiumv4_id',
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.initialization_pools_raydiumv4__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = '675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8'
+        AND event_type IN ('initialize', 'initialize2')
+        {% if is_incremental() %}
+        -- AND _inserted_timestamp > '{{ max_timestamp }}'
+        AND block_timestamp::date BETWEEN '2021-03-21' AND '2023-01-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.initialization_pools_raydiumv4__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('amm', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('lpMintAddress', accounts) AS pool_token_mint,
+        silver.udf_get_account_pubkey_by_name('coinMintAddress', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('pcMintAddress', accounts) AS token_b_account
+    FROM
+        silver.initialization_pools_raydiumv4__intermediate_tmp
+    WHERE
+        event_type = 'initialize'
+    UNION ALL
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('amm', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('lpMint', accounts) AS pool_token_mint,
+        silver.udf_get_account_pubkey_by_name('coinMint', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('pcMint', accounts) AS token_b_account
+    FROM
+        silver.initialization_pools_raydiumv4__intermediate_tmp
+    WHERE
+        event_type = 'initialize2'
+),
+post_token_balances AS (
+    SELECT
+        block_timestamp,
+        tx_id,
+        account,
+        mint
+    FROM
+        {{ ref('silver___post_token_balances') }}
+    WHERE
+        {{ between_stmts }}
+)
+SELECT 
+    b.block_id,
+    b.block_timestamp,
+    b.tx_id,
+    b.index,
+    b.inner_index,
+    b.succeeded,
+    b.pool_address,
+    b.pool_token_mint,
+    b.token_a_account,
+    ptb_a.mint AS token_a_mint,
+    b.token_b_account,
+    ptb_b.mint AS token_b_mint,
+    b.program_id,
+    b._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['b.block_id', 'b.tx_id', 'b.index', 'b.inner_index']) }} AS initialization_pools_raydiumv4_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    base AS b
+LEFT JOIN
+    post_token_balances AS ptb_a
+    ON b.block_timestamp::date = ptb_a.block_timestamp::date
+    AND b.tx_id = ptb_a.tx_id
+    AND b.token_a_account = ptb_a.account
+LEFT JOIN
+    post_token_balances AS ptb_b
+    ON b.block_timestamp::date = ptb_b.block_timestamp::date
+    AND b.tx_id = ptb_b.tx_id
+    AND b.token_b_account = ptb_b.account

--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
@@ -37,6 +37,7 @@
     WHERE
         program_id = '675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8'
         AND event_type IN ('initialize', 'initialize2')
+        AND succeeded
         {% if is_incremental() %}
         AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}

--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
@@ -94,3 +94,18 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM 
     base AS b
+WHERE
+    /* 
+    found 157 cases where the instructions seems to be "bad", where it gives incomplete account information.
+    I spot checked a few of these and they seem to be invalid as the pool_address they are trying to initialize has already been created
+    */
+    (
+        b.block_timestamp > '2022-11-10 20:16:52.000'
+        OR (
+            b.block_timestamp < '2022-11-10 20:16:52.000'
+            AND token_a_mint IS NOT NULL
+            AND token_b_mint IS NOT NULL
+            AND token_a_account IS NOT NULL
+            AND token_b_account IS NOT NULL
+        )
+    )

--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.sql
@@ -7,6 +7,7 @@
         incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
         merge_exclude_columns = ["inserted_timestamp"],
         cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+        tags = ['scheduled_non_core'],
     )
 }}
 

--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.yml
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.yml
@@ -1,63 +1,68 @@
 version: 2
 models:
   - name: silver__initialization_pools_raydiumv4
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp > current_date - 7
     data_data_tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - TX_ID
             - INDEX
             - INNER_INDEX
+          <<: *recent_date_filter
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         data_tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         data_tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         data_tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: "{{ doc('event_index') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INNER_INDEX
         description: "{{ doc('inner_index') }}"
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: POOL_ADDRESS
         description: "{{ doc('liquidity_pool_address') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: POOL_TOKEN_MINT
         description: "{{ doc('liquidity_pool_token_mint') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TOKEN_A_ACCOUNT
         description:  "{{ doc('token_a_account') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TOKEN_A_MINT
         description:  "{{ doc('token_a_mint') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TOKEN_B_ACCOUNT
         description:  "{{ doc('token_b_account') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TOKEN_B_MINT
         description:  "{{ doc('token_b_mint') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         data_tests: 
@@ -65,17 +70,18 @@ models:
       - name: INITIALIZATION_POOLS_RAYDIUMV4_ID
         description: '{{ doc("pk") }}'   
         data_tests: 
-          - unique
+          - unique: *recent_date_filter
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MODIFIED_TIMESTAMP
         description: '{{ doc("modified_timestamp") }}' 
         data_tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: _INVOCATION_ID
         description: '{{ doc("_invocation_id") }}' 
         data_tests: 
           - not_null: 
               name: test_silver__not_null_initialization_pools_raydiumv4_invocation_id
+              <<: *recent_date_filter

--- a/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.yml
+++ b/models/silver/liquidity_pool/raydium/v4/silver__initialization_pools_raydiumv4.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver__initialization_pools_raydiumv4
+    data_data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null
+      - name: POOL_TOKEN_MINT
+        description: "{{ doc('liquidity_pool_token_mint') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_ACCOUNT
+        description:  "{{ doc('token_a_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_ACCOUNT
+        description:  "{{ doc('token_b_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: INITIALIZATION_POOLS_RAYDIUMV4_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null: 
+              name: test_silver__not_null_initialization_pools_raydiumv4_invocation_id


### PR DESCRIPTION
- Create `silver__initialization_pools_raydiumv4` to capture lp pools being created
  - `~157` decoded records seem to have "bad" data (issue w/ the actual instruction) but hasnt happened since late 2022. I have removed these from the model

`dbt build -s silver__initialization_pools_raydiumv4 -t dev --full-refresh`
```
15:23:21  Finished running 1 incremental model, 17 data tests, 7 project hooks in 0 hours 1 minutes and 46.54 seconds (106.54s).
15:23:21  
15:23:21  Completed successfully
15:23:21  
15:23:21  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```

`dbt build -s silver__initialization_pools_raydiumv4 -t dev`
```
15:24:36  Finished running 1 incremental model, 17 data tests, 7 project hooks in 0 hours 0 minutes and 46.32 seconds (46.32s).
15:24:36  
15:24:36  Completed successfully
15:24:36  
15:24:36  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```

Data in dev
```
select *
from solana_dev.silver.initialization_pools_raydiumv4
limit 100;
```