### PR TITLE
Raydium Stable Initialize Pools

### DIFF
--- a/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
+++ b/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
@@ -81,4 +81,4 @@ FROM
     base AS b
 WHERE
     /* the USDT/USDC pool was created twice according to instructions, ignoring the first one */
-    b.block_timestamp > '2022-01-18 07:37:50.000'
+    b.block_timestamp >= '2022-01-18 07:37:50.000'

--- a/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
+++ b/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
@@ -35,6 +35,7 @@
     WHERE
         program_id = '5quBtoiQqxF9Jv6KYKctB59NT3gtJD2Y65kdnB1Uev3h'
         AND event_type = 'initialize'
+        AND succeeded
         {% if is_incremental() %}
         AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}

--- a/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
+++ b/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
@@ -38,7 +38,7 @@
         {% if is_incremental() %}
         AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}
-        AND _inserted_timestamp BETWEEN '2024-05-24' AND '2025-05-28'
+        AND _inserted_timestamp BETWEEN '2024-05-24' AND '2024-05-28'
         {% endif %}
     {% endset %}
     {% do run_query(base_query) %}

--- a/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
+++ b/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
@@ -1,0 +1,83 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::DATE','initialization_pools_raydiumstable_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.initialization_pools_raydiumstable__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = '5quBtoiQqxF9Jv6KYKctB59NT3gtJD2Y65kdnB1Uev3h'
+        AND event_type = 'initialize'
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        {% else %}
+        AND _inserted_timestamp BETWEEN '2024-05-24' AND '2025-05-28'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.initialization_pools_raydiumstable__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('ammOpenOrders', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('pcMint', accounts) AS pool_token_mint,
+        silver.udf_get_account_pubkey_by_name('withdrawQueue', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('tokenDestLp', accounts) AS token_b_account,
+        silver.udf_get_account_pubkey_by_name('poolTokenCoin', accounts) AS token_a_mint,
+        silver.udf_get_account_pubkey_by_name('poolTokenPc', accounts) AS token_b_mint
+    FROM
+        silver.initialization_pools_raydiumstable__intermediate_tmp
+)
+SELECT 
+    b.block_id,
+    b.block_timestamp,
+    b.tx_id,
+    b.index,
+    b.inner_index,
+    b.succeeded,
+    b.pool_address,
+    b.pool_token_mint,
+    b.token_a_account,
+    b.token_a_mint,
+    b.token_b_account,
+    b.token_b_mint,
+    b.program_id,
+    b._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['b.block_id', 'b.tx_id', 'b.index', 'b.inner_index']) }} AS initialization_pools_raydiumstable_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    base AS b
+WHERE
+    /* the USDT/USDC pool was created twice according to instructions, ignoring the first one */
+    b.block_timestamp > '2022-01-18 07:37:50.000'

--- a/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
+++ b/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.sql
@@ -39,7 +39,7 @@
         {% if is_incremental() %}
         AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}
-        AND _inserted_timestamp BETWEEN '2024-05-24' AND '2024-05-28'
+        AND _inserted_timestamp BETWEEN '2024-05-24' AND '2024-05-29'
         {% endif %}
     {% endset %}
     {% do run_query(base_query) %}

--- a/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.yml
+++ b/models/silver/liquidity_pool/raydium/stable/silver__initialization_pools_raydiumstable.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver__initialization_pools_raydiumstable
+    data_data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null
+      - name: POOL_TOKEN_MINT
+        description: "{{ doc('liquidity_pool_token_mint') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_ACCOUNT
+        description:  "{{ doc('token_a_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_ACCOUNT
+        description:  "{{ doc('token_b_account') }}"
+        data_tests: 
+          - not_null
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: INITIALIZATION_POOLS_RAYDIUMSTABLE_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_initialization_pools_raydiumstable_invocation_id


### PR DESCRIPTION
- Create `silver__initialization_pools_raydiumstable` to capture lp pools being created
  - Only 3 total pools
  - Will only be run once so no scheduler

`dbt build -s silver__initialization_pools_raydiumstable -t dev --full-refresh`
```
16:21:20  Finished running 1 incremental model, 17 data tests, 7 project hooks in 0 hours 0 minutes and 31.23 seconds (31.23s).
16:21:21  
16:21:21  Completed successfully
16:21:21  
16:21:21  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```

Data in dev
```
select *
from solana_dev.silver.initialization_pools_raydiumstable
limit 100;
```