### PR TITLE
Raydium CPMM Initialize Pools

### DIFF
--- a/models/silver/liquidity_pool/raydium/cpmm/silver__initialization_pools_raydium_cpmm.sql
+++ b/models/silver/liquidity_pool/raydium/cpmm/silver__initialization_pools_raydium_cpmm.sql
@@ -1,0 +1,81 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::DATE','initialization_pools_raydium_cpmm_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+        tags = ['scheduled_non_core'],
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.initialization_pools_raydium_cpmm__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = 'CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C'
+        AND event_type = 'initialize'
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        {% else %}
+        AND _inserted_timestamp BETWEEN '2024-10-11' AND '2025-01-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.initialization_pools_raydium_cpmm__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('poolState', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('lpMint', accounts) AS pool_token_mint,
+        silver.udf_get_account_pubkey_by_name('token0Vault', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('token1Vault', accounts) AS token_b_account,
+        silver.udf_get_account_pubkey_by_name('token0Mint', accounts) AS token_a_mint,
+        silver.udf_get_account_pubkey_by_name('token1Mint', accounts) AS token_b_mint
+    FROM
+        silver.initialization_pools_raydium_cpmm__intermediate_tmp
+)
+SELECT 
+    b.block_id,
+    b.block_timestamp,
+    b.tx_id,
+    b.index,
+    b.inner_index,
+    b.succeeded,
+    b.pool_address,
+    b.pool_token_mint,
+    b.token_a_account,
+    b.token_a_mint,
+    b.token_b_account,
+    b.token_b_mint,
+    b.program_id,
+    b._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['b.block_id', 'b.tx_id', 'b.index', 'b.inner_index']) }} AS initialization_pools_raydium_cpmm_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    base AS b

--- a/models/silver/liquidity_pool/raydium/cpmm/silver__initialization_pools_raydium_cpmm.sql
+++ b/models/silver/liquidity_pool/raydium/cpmm/silver__initialization_pools_raydium_cpmm.sql
@@ -36,6 +36,7 @@
     WHERE
         program_id = 'CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C'
         AND event_type = 'initialize'
+        AND succeeded
         {% if is_incremental() %}
         AND _inserted_timestamp > '{{ max_timestamp }}'
         {% else %}

--- a/models/silver/liquidity_pool/raydium/cpmm/silver__intialization_pools_raydium_cpmm.yml
+++ b/models/silver/liquidity_pool/raydium/cpmm/silver__intialization_pools_raydium_cpmm.yml
@@ -1,0 +1,87 @@
+version: 2
+models:
+  - name: silver__initialization_pools_raydium_cpmm
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp > current_date - 7
+    data_data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+          <<: *recent_date_filter
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_TOKEN_MINT
+        description: "{{ doc('liquidity_pool_token_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_ACCOUNT
+        description:  "{{ doc('token_a_account') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_ACCOUNT
+        description:  "{{ doc('token_b_account') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: INITIALIZATION_POOLS_RAYDIUM_CPMM_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null: 
+              name: test_silver__not_null_initialization_pools_raydium_cpmm_invocation_id
+              <<: *recent_date_filter


### PR DESCRIPTION
- Create `silver__initialization_pools_raydium_cpmm` to capture lp pools being created


`dbt build -s silver__initialization_pools_raydium_cpmm -t dev --full-refresh`
```
16:54:48  Finished running 1 incremental model, 17 data tests, 7 project hooks in 0 hours 0 minutes and 40.14 seconds (40.14s).
16:54:48  
16:54:48  Completed successfully
16:54:48  
16:54:48  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```

`dbt build -s silver__initialization_pools_raydium_cpmm -t dev`
```
16:55:31  Finished running 1 incremental model, 17 data tests, 7 project hooks in 0 hours 0 minutes and 34.61 seconds (34.61s).
16:55:31  
16:55:31  Completed successfully
16:55:31  
16:55:31  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```

Data in dev
```
select *
from solana_dev.silver.initialization_pools_raydium_cpmm
limit 100;
```