### PR TITLE
Create Raydium V4 LP Actions

### DIFF
--- a/models/silver/liquidity_pool/raydium/v4/silver__liquidity_pool_actions_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__liquidity_pool_actions_raydiumv4.sql
@@ -1,0 +1,268 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::date','liquidity_pool_actions_raydiumv4_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::date','modified_timestamp::date'],
+        post_hook = enable_search_optimization(
+            '{{this.schema}}',
+            '{{this.identifier}}',
+            'ON EQUALITY(tx_id, provider_address, token_a_mint, token_b_mint, liquidity_pool_actions_raydiumv4_id)'
+        ),
+        tags = ['scheduled_non_core']
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.liquidity_pool_actions_raydiumv4__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = '675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8'
+        AND event_type IN (
+            'deposit',
+            'withdraw',
+            'withdrawPnl'
+        )
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        /* batches for reload */
+        -- AND block_timestamp::date BETWEEN '2022-01-01' AND '2022-06-01'
+        -- AND block_timestamp::date BETWEEN '2022-06-01' AND '2023-01-01'
+        -- AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
+        -- AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
+        -- AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-06-01'
+        -- AND block_timestamp::date BETWEEN '2024-06-01' AND '2025-01-05'
+        -- AND _inserted_timestamp > '{{ max_timestamp }}'::timestamp_ntz - INTERVAL '1 DAY'
+        {% else %}
+        -- AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-02-05'
+        AND block_timestamp::date BETWEEN '2021-03-21' AND '2022-01-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.liquidity_pool_actions_raydiumv4__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+{% set bad_withdraw_pnl_accounts_cutoff_date = '2023-01-04' %}
+
+WITH base AS (
+    SELECT 
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('amm', accounts) AS pool_address,
+        CASE
+            WHEN event_type IN ('deposit', 'withdraw') THEN
+                silver.udf_get_account_pubkey_by_name('userOwner', accounts)
+            WHEN event_type = 'withdrawPnl' AND block_timestamp >= '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('pnlOwnerAccount', accounts)
+            WHEN event_type = 'withdrawPnl' AND block_timestamp < '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('pcPnlTokenAccount', accounts)
+        END AS provider_address,
+        CASE
+            WHEN event_type = 'withdrawPnl' AND block_timestamp < '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('ammOpenOrders', accounts) 
+            ELSE
+                silver.udf_get_account_pubkey_by_name('poolCoinTokenAccount', accounts) 
+        END AS pool_token_a_account,
+        CASE
+            WHEN event_type = 'withdrawPnl' AND block_timestamp < '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('poolCoinTokenAccount', accounts) 
+            ELSE
+                silver.udf_get_account_pubkey_by_name('poolPcTokenAccount', accounts) 
+        END AS pool_token_b_account,
+        CASE 
+            WHEN event_type = 'deposit' THEN
+                silver.udf_get_account_pubkey_by_name('userCoinTokenAccount', accounts)
+            WHEN event_type = 'withdraw' THEN
+                silver.udf_get_account_pubkey_by_name('uerCoinTokenAccount', accounts)
+            WHEN event_type = 'withdrawPnl' AND block_timestamp >= '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('coinPnlTokenAccount', accounts)
+            WHEN event_type = 'withdrawPnl' AND block_timestamp < '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('poolPcTokenAccount', accounts)
+            ELSE NULL
+        END AS token_a_account,
+        CASE 
+            WHEN event_type = 'deposit' THEN
+                silver.udf_get_account_pubkey_by_name('userPcTokenAccount', accounts)
+            WHEN event_type = 'withdraw' THEN
+                silver.udf_get_account_pubkey_by_name('uerPcTokenAccount', accounts)
+            WHEN event_type = 'withdrawPnl' AND block_timestamp >= '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('pcPnlTokenAccount', accounts)
+            WHEN event_type = 'withdrawPnl' AND block_timestamp < '{{ bad_withdraw_pnl_accounts_cutoff_date }}' THEN
+                silver.udf_get_account_pubkey_by_name('coinPnlTokenAccount', accounts)
+            ELSE NULL
+        END AS token_b_account,
+        coalesce(lead(inner_index) OVER (
+            PARTITION BY tx_id, index 
+            ORDER BY inner_index
+        ), 9999) AS next_lp_action_inner_index
+    FROM 
+        silver.liquidity_pool_actions_raydiumv4__intermediate_tmp
+),
+
+transfers AS (
+    SELECT 
+        * exclude(index),
+        split_part(index,'.',1)::int AS index,
+        nullif(split_part(index,'.',2),'')::int AS inner_index
+    FROM
+        {{ ref('silver__transfers') }}
+    WHERE
+        {{ between_stmts }}
+),
+
+deposit_transfers AS (
+    SELECT 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t.source_token_account = b.token_a_account
+        AND t.dest_token_account = b.pool_token_a_account
+    LEFT JOIN
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.source_token_account = b.token_b_account
+        AND t2.dest_token_account = b.pool_token_b_account
+    WHERE
+        b.event_type = 'deposit'
+    QUALIFY
+        row_number() OVER (PARTITION BY b.tx_id, b.index, b.inner_index ORDER BY t.inner_index, t2.inner_index) = 1
+),
+
+withdraw_transfers AS (
+    SELECT 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t.dest_token_account = b.token_a_account
+        AND t.source_token_account = b.pool_token_a_account
+    LEFT JOIN
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.dest_token_account = b.token_b_account
+        AND t2.source_token_account = b.pool_token_b_account
+    WHERE
+        b.event_type IN ('withdraw', 'withdrawPnl')
+    QUALIFY
+        row_number() OVER (PARTITION BY b.tx_id, b.index, b.inner_index ORDER BY t.inner_index, t2.inner_index) = 1
+),
+
+pre_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        pool_address,
+        provider_address,
+        token_a_mint,
+        token_a_amount,
+        token_b_mint,
+        token_b_amount,
+        program_id,
+        _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_raydiumv4_id,
+        sysdate() AS inserted_timestamp,
+        sysdate() AS modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
+    FROM 
+        deposit_transfers
+
+    UNION ALL
+
+    SELECT 
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        pool_address,
+        provider_address,
+        token_a_mint,
+        token_a_amount,
+        token_b_mint,
+        token_b_amount,
+        program_id,
+        _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_raydiumv4_id,
+        sysdate() AS inserted_timestamp,
+        sysdate() AS modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
+    FROM 
+        withdraw_transfers
+)
+SELECT
+    *
+FROM
+    pre_final
+WHERE
+    /*
+    4 withdraw transactions from 2021 with bad instruction accounts data. 
+    Omitting from model
+    */
+    (
+        block_timestamp > '2021-05-24 08:55:09.000'
+        OR (
+            block_timestamp <= '2021-05-24 08:55:09.000'
+            AND token_a_amount IS NOT NULL
+            AND token_b_amount IS NOT NULL
+            AND token_a_mint IS NOT NULL
+            AND token_b_mint IS NOT NULL
+        )
+    )

--- a/models/silver/liquidity_pool/raydium/v4/silver__liquidity_pool_actions_raydiumv4.yml
+++ b/models/silver/liquidity_pool/raydium/v4/silver__liquidity_pool_actions_raydiumv4.yml
@@ -1,0 +1,98 @@
+version: 2
+models:
+  - name: silver__liquidity_pool_actions_raydiumv4
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp < current_date - 7
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: EVENT_TYPE
+        description: "{{ doc('event_type') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROVIDER_ADDRESS
+        description:  "{{ doc('liquidity_provider') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_AMOUNT
+        description:  "{{ doc('token_a_amount') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp < current_date - 7
+                  AND event_type IN ('withdrawAllTokenTypes','depositAllTokenTypes')
+      - name: TOKEN_B_AMOUNT
+        description:  "{{ doc('token_b_amount') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp < current_date - 7
+                  AND event_type IN ('withdrawAllTokenTypes','depositAllTokenTypes')
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: LIQUIDITY_POOL_ACTIONS_RAYDIUMV4_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_liquidity_pool_actions_raydiumv4_invocation_id
+              <<: *recent_date_filter


### PR DESCRIPTION
- Create `silver__liquidity_pool_actions_raydiumv4` to capture deposits and withdraws for v1 pools
  - Uses decoded instructions and transfers as upstreams
  - There are issues with 5 withdraw records from 2021. These records have been omitted from the model
 
> [!NOTE]
> We will need to backfill this table in batches before merging which will take a ~3 hour total on 2xl


`dbt build -s silver__liquidity_pool_actions_raydiumv4 -t dev-2xl --full-refresh`
```

```

Incremental on next 6 months of data
```

```

Data in DEV 
```
-- 3RcmUcvSHpaEyKZcg2ycM6pV87U89QJTUZ8RYkeV7tvhD3Ppm5pxGXLY3XaivaeUUizMG2XhyvARqJg7dfrTfjoA
-- 3q82V9eUB3b85G1YEPoH2v7a3geno9EfcpHAXJTz9XPhdzXyxueqnhf6WYgygeCrmGyz4RVWQDURxRcnmVJSUPVt
-- 3hkwwBM66dpkW6WWCjByDbgX3C3LM1J2j3PUMbkGVCwL9aTixCxQRMc2tfWe1s3CpFSvGsNQ2YwcLo2msNVoBzX1
select *
from solana_dev.silver.liquidity_pool_actions_raydiumv4
where tx_id = '3hkwwBM66dpkW6WWCjByDbgX3C3LM1J2j3PUMbkGVCwL9aTixCxQRMc2tfWe1s3CpFSvGsNQ2YwcLo2msNVoBzX1';
```
