### PR TITLE
Orca whirlpool lp actions

### DIFF
--- a/models/silver/liquidity_pool/orca/whirlpool/silver__initialization_pools_orca_whirlpool.sql
+++ b/models/silver/liquidity_pool/orca/whirlpool/silver__initialization_pools_orca_whirlpool.sql
@@ -1,0 +1,82 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::DATE','initialization_pools_orca_whirlpool_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+        tags = ['scheduled_non_core'],
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.initialization_pools_orca_whirlpool__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc'
+        AND event_type IN ('initializePool','initializePoolV2')
+        AND succeeded
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        {% else %}
+        AND _inserted_timestamp BETWEEN '2023-11-14' AND '2025-01-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.initialization_pools_orca_whirlpool__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('whirlpool', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('tokenVaultA', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('tokenVaultB', accounts) AS token_b_account,
+        silver.udf_get_account_pubkey_by_name('tokenMintA', accounts) AS token_a_mint,
+        silver.udf_get_account_pubkey_by_name('tokenMintB', accounts) AS token_b_mint
+    FROM
+        silver.initialization_pools_orca_whirlpool__intermediate_tmp
+)
+SELECT 
+    b.block_id,
+    b.block_timestamp,
+    b.tx_id,
+    b.index,
+    b.inner_index,
+    b.succeeded,
+    b.pool_address,
+    NULL AS pool_token_mint, -- Whirlpool does not have LP mints
+    b.token_a_account,
+    b.token_a_mint,
+    b.token_b_account,
+    b.token_b_mint,
+    b.program_id,
+    b._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['b.block_id', 'b.tx_id', 'b.index', 'b.inner_index']) }} AS initialization_pools_orca_whirlpool_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    base AS b

--- a/models/silver/liquidity_pool/orca/whirlpool/silver__initialization_pools_orca_whirlpool.yml
+++ b/models/silver/liquidity_pool/orca/whirlpool/silver__initialization_pools_orca_whirlpool.yml
@@ -1,0 +1,85 @@
+version: 2
+models:
+  - name: silver__initialization_pools_orca_whirlpool
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp > current_date - 7
+    data_data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+          <<: *recent_date_filter
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_TOKEN_MINT
+        description: "{{ doc('liquidity_pool_token_mint') }}. Always NULL for Whirlpool as there are no LP mints"
+      - name: TOKEN_A_ACCOUNT
+        description:  "{{ doc('token_a_account') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_ACCOUNT
+        description:  "{{ doc('token_b_account') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: INITIALIZATION_POOLS_ORCA_WHIRLPOOL_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null: 
+              name: test_silver__not_null_initialization_pools_orca_whirlpool_invocation_id
+              <<: *recent_date_filter

--- a/models/silver/liquidity_pool/orca/whirlpool/silver__liquidity_pool_actions_orca_whirlpool.sql
+++ b/models/silver/liquidity_pool/orca/whirlpool/silver__liquidity_pool_actions_orca_whirlpool.sql
@@ -1,0 +1,237 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::date','liquidity_pool_actions_orca_whirlpool_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::date','modified_timestamp::date'],
+        post_hook = enable_search_optimization(
+            '{{this.schema}}',
+            '{{this.identifier}}',
+            'ON EQUALITY(tx_id, provider_address, token_a_mint, token_b_mint, liquidity_pool_actions_orca_whirlpool_id)'
+        ),
+        tags = ['scheduled_non_core']
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.liquidity_pool_actions_orca_whirlpool__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        decoded_instruction:accounts AS accounts,
+        decoded_instruction:args AS args,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc'
+        AND event_type IN (
+            'decreaseLiquidity',
+            'decreaseLiquidityV2',
+            'increaseLiquidity',
+            'increaseLiquidityV2'
+        )
+        AND succeeded
+        {% if is_incremental() %}
+        -- AND _inserted_timestamp > '{{ max_timestamp }}'
+        /* batches for reload */
+        -- AND block_timestamp::date BETWEEN '2023-01-01' AND '2023-06-01'
+        -- AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
+        -- AND block_timestamp::date BETWEEN '2024-01-01' AND '2024-06-01'
+        AND block_timestamp::date BETWEEN '2024-06-01' AND '2025-01-05'
+        -- AND _inserted_timestamp > '{{ max_timestamp }}'::timestamp_ntz - INTERVAL '1 DAY'
+        {% else %}
+        AND block_timestamp::date BETWEEN '2023-06-01' AND '2024-01-01'
+        -- AND block_timestamp::date BETWEEN '2022-03-10' AND '2023-01-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.liquidity_pool_actions_orca_whirlpool__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT 
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('whirlpool', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('positionAuthority', accounts) AS provider_address,
+        silver.udf_get_account_pubkey_by_name('tokenVaultA', accounts) AS pool_token_a_account,
+        silver.udf_get_account_pubkey_by_name('tokenVaultB', accounts) AS pool_token_b_account,
+        silver.udf_get_account_pubkey_by_name('tokenOwnerAccountA', accounts) AS token_a_account,
+        silver.udf_get_account_pubkey_by_name('tokenOwnerAccountB', accounts) AS token_b_account,
+        coalesce(lead(inner_index) OVER (
+            PARTITION BY tx_id, index 
+            ORDER BY inner_index
+        ), 9999) AS next_lp_action_inner_index
+    FROM 
+        silver.liquidity_pool_actions_orca_whirlpool__intermediate_tmp
+),
+
+transfers AS (
+    SELECT 
+        * exclude(index),
+        split_part(index,'.',1)::int AS index,
+        nullif(split_part(index,'.',2),'')::int AS inner_index
+    FROM
+        {{ ref('silver__transfers') }}
+    WHERE
+        succeeded
+        AND {{ between_stmts }}
+),
+
+deposit_transfers AS (
+    SELECT 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t.source_token_account = b.token_a_account
+        AND t.dest_token_account = b.pool_token_a_account
+    LEFT JOIN
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.source_token_account = b.token_b_account
+        AND t2.dest_token_account = b.pool_token_b_account
+    WHERE
+        b.event_type IN (
+            'increaseLiquidity',
+            'increaseLiquidityV2'
+        )
+    QUALIFY
+        row_number() OVER (PARTITION BY b.tx_id, b.index, b.inner_index ORDER BY t.inner_index, t2.inner_index) = 1
+),
+
+withdraw_transfers AS (
+    SELECT 
+        b.*,
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount
+    FROM 
+        base AS b
+    LEFT JOIN
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t.dest_token_account = b.token_a_account
+        AND t.source_token_account = b.pool_token_a_account
+    LEFT JOIN
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.dest_token_account = b.token_b_account
+        AND t2.source_token_account = b.pool_token_b_account
+    WHERE
+        b.event_type IN (
+            'decreaseLiquidity',
+            'decreaseLiquidityV2'
+        )
+    QUALIFY
+        row_number() OVER (PARTITION BY b.tx_id, b.index, b.inner_index ORDER BY t.inner_index, t2.inner_index) = 1
+),
+
+pre_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        pool_address,
+        provider_address,
+        token_a_mint,
+        token_a_amount,
+        token_b_mint,
+        token_b_amount,
+        program_id,
+        _inserted_timestamp
+    FROM 
+        deposit_transfers
+
+    UNION ALL
+
+    SELECT 
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        pool_address,
+        provider_address,
+        token_a_mint,
+        token_a_amount,
+        token_b_mint,
+        token_b_amount,
+        program_id,
+        _inserted_timestamp
+    FROM 
+        withdraw_transfers
+)
+SELECT
+    *,
+    -- block_id,
+    -- block_timestamp,
+    -- tx_id,
+    -- index,
+    -- inner_index,
+    -- succeeded,
+    -- event_type,
+    -- pool_address,
+    -- provider_address,
+    -- /* 
+    -- mimic behavior of our other liquidity pool action models that support single token withdraws/deposits.
+    -- Represent the single token action as token A
+    -- */
+    -- iff(token_a_mint IS NULL AND token_a_amount IS NULL, token_b_mint, token_a_mint) AS token_a_mint,
+    -- iff(token_a_mint IS NULL AND token_a_amount IS NULL, token_b_amount, token_a_amount) AS token_a_amount,
+    -- iff(token_a_mint IS NOT NULL OR token_a_amount IS NOT NULL, token_b_mint, NULL) AS token_b_mint,
+    -- iff(token_a_mint IS NOT NULL OR token_a_amount IS NOT NULL, token_b_amount, NULL) AS token_b_amount,
+    -- program_id,
+    -- _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_orca_whirlpool_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    pre_final

--- a/models/silver/liquidity_pool/orca/whirlpool/silver__liquidity_pool_actions_orca_whirlpool.yml
+++ b/models/silver/liquidity_pool/orca/whirlpool/silver__liquidity_pool_actions_orca_whirlpool.yml
@@ -1,0 +1,90 @@
+version: 2
+models:
+  - name: silver__liquidity_pool_actions_orca_whirlpool
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp > '2022-01-01'
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: EVENT_TYPE
+        description: "{{ doc('event_type') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROVIDER_ADDRESS
+        description:  "{{ doc('liquidity_provider') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_AMOUNT
+        description:  "{{ doc('token_a_amount') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_AMOUNT
+        description:  "{{ doc('token_b_amount') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: LIQUIDITY_POOL_ACTIONS_ORCA_WHIRLPOOL_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_liquidity_pool_actions_orca_whirlpool_invocation_id
+              <<: *recent_date_filter


### PR DESCRIPTION
- Create `silver__liquidity_pool_actions_orca_whirlpool` to capture deposits and withdraws for whirlpool pools
  - Uses decoded instructions and transfers as upstreams
  
> [!NOTE]
> We will need to backfill this table in batches before merging which will take a ~2 hour total on 2xl


`dbt run -s silver__liquidity_pool_actions_orca_whirlpool -t dev-2xl --full-refresh`
```
02:11:07  Finished running 1 incremental model, 7 project hooks in 0 hours 5 minutes and 9.09 seconds (309.09s).
02:11:07  
02:11:07  Completed successfully
02:11:07  
02:11:07  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

Incremental on 6 months of data (data has been loaded from `2023-06-01` to `2025-01-05`)
`dbt run -s silver__liquidity_pool_actions_orca_whirlpool -t dev-2xl `
```
02:27:08  Finished running 1 incremental model, 7 project hooks in 0 hours 12 minutes and 23.62 seconds (743.62s).
02:27:08  
02:27:08  Completed successfully
02:27:08  
02:27:08  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

`dbt test -s silver__liquidity_pool_actions_orca_whirlpool -t dev`
```
03:24:47  Finished running 19 data tests, 7 project hooks in 0 hours 1 minutes and 21.84 seconds (81.84s).
03:24:47  
03:24:47  Completed successfully
03:24:47  
03:24:47  Done. PASS=19 WARN=0 ERROR=0 SKIP=0 TOTAL=19
```

Data in DEV 
```
select *
from solana_dev.silver.liquidity_pool_actions_orca_whirlpool
where tx_id = '5VNFDQKXvvP9BUiCbVC4JP8rZxmA6GYdgTVsPQEELdDSmmVK6YhceybtZVcYwZay3DXJC4moeSzrEKccRwtzFZnq';
```
