### PR TITLE
Meteora AMM initialize pools

### DIFF
--- a/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.sql
+++ b/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.sql
@@ -1,0 +1,104 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::DATE','initialization_pools_meteora_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
+        tags = ['scheduled_non_core'],
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.initialization_pools_meteora__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        decoded_instruction:accounts AS accounts,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = 'Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB'
+        AND event_type IN (
+            'initializeCustomizablePermissionlessConstantProductPool',
+            'initializePermissionedPool',
+            'initializePermissionlessConstantProductPoolWithConfig',
+            'initializePermissionlessConstantProductPoolWithConfig2',
+            'initializePermissionlessPool',
+            'initializePermissionlessPoolWithFeeTier'
+        )
+        AND succeeded
+        {% if is_incremental() %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        {% else %}
+        AND _inserted_timestamp BETWEEN '2024-02-15' AND '2025-01-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.initialization_pools_meteora__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('pool', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('lpMint', accounts) AS pool_token_mint,
+        CASE
+            /* 
+            initializePermissionedPool does not provide token A/B accounts in the initialization instructions
+            */
+            WHEN event_type NOT IN ('initializePermissionedPool') THEN
+                silver.udf_get_account_pubkey_by_name('aTokenVault', accounts)
+            ELSE NULL
+        END AS token_a_account,
+        CASE
+            /* 
+            initializePermissionedPool does not provide token A/B accounts in the initialization instructions
+            */
+            WHEN event_type NOT IN ('initializePermissionedPool') THEN
+                silver.udf_get_account_pubkey_by_name('bTokenVault', accounts)
+            ELSE NULL
+        END AS token_b_account,
+        silver.udf_get_account_pubkey_by_name('tokenAMint', accounts) AS token_a_mint,
+        silver.udf_get_account_pubkey_by_name('tokenBMint', accounts) AS token_b_mint
+    FROM
+        silver.initialization_pools_meteora__intermediate_tmp
+)
+SELECT 
+    b.block_id,
+    b.block_timestamp,
+    b.tx_id,
+    b.index,
+    b.inner_index,
+    b.succeeded,
+    b.pool_address,
+    b.pool_token_mint,
+    b.token_a_account,
+    b.token_a_mint,
+    b.token_b_account,
+    b.token_b_mint,
+    b.program_id,
+    b._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['b.block_id', 'b.tx_id', 'b.index', 'b.inner_index']) }} AS initialization_pools_meteora_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    base AS b

--- a/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml
+++ b/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml
@@ -1,0 +1,95 @@
+version: 2
+models:
+  - name: silver__initialization_pools_meteora
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp > current_date - 7
+    data_data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+          <<: *recent_date_filter
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_TOKEN_MINT
+        description: "{{ doc('liquidity_pool_token_mint') }}. Always NULL for DLMM as there are no LP mints"
+      - name: TOKEN_A_ACCOUNT
+        description:  "{{ doc('token_a_account') }}"
+        data_tests: 
+          - not_null:
+              # event_type = initializePermissionedPool does not provide token A/B accounts in the initialization instructions
+              # As of 2025-01-11, there are only 27 such events
+              config:
+                severity: error
+                error_if: "> 27" 
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_ACCOUNT
+        description:  "{{ doc('token_b_account') }}"
+        data_tests: 
+          - not_null:
+              # event_type = initializePermissionedPool does not provide token A/B accounts in the initialization instructions
+              # As of 2025-01-11, there are only 27 such events
+              config:
+                severity: error
+                error_if: "> 27"
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: INITIALIZATION_POOLS_METEORA_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null: 
+              name: test_silver__not_null_initialization_pools_meteora_invocation_id
+              <<: *recent_date_filter

--- a/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml
+++ b/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml
@@ -40,7 +40,9 @@ models:
         data_tests: 
           - not_null: *recent_date_filter
       - name: POOL_TOKEN_MINT
-        description: "{{ doc('liquidity_pool_token_mint') }}. Always NULL for DLMM as there are no LP mints"
+        description: "{{ doc('liquidity_pool_token_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
       - name: TOKEN_A_ACCOUNT
         description:  "{{ doc('token_a_account') }}"
         data_tests: 


### PR DESCRIPTION
- Create `silver__initialization_pools_meteora` to capture lp pools being created
  - event type `initializePermissionedPool` does not provide pool token A/B account values in the instruction. It says it does, but they are actually the token A/B authorities, not the vaults. There are 27 of these and they should produce warnings in the tests or errors if we receive more than 27 records with a NULL token A/B account

`dbt build -s silver__initialization_pools_meteora -t dev-2xl --full-refresh`
```
16:35:44  Finished running 1 incremental model, 16 data tests, 7 project hooks in 0 hours 0 minutes and 29.29 seconds (29.29s).
16:35:44  
16:35:44  Completed with 2 warnings:
16:35:44  
16:35:44  Warning in test not_null_silver__initialization_pools_meteora_TOKEN_A_ACCOUNT (models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml)
16:35:44  Got 27 results, configured to warn if != 0
16:35:44  
16:35:44    compiled code at target/compiled/solana_models/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml/not_null_silver__initialization_pools_meteora_TOKEN_A_ACCOUNT.sql
16:35:44  
16:35:44    See test failures:
  -------------------------------------------------------------------------------------
  select * from SOLANA_DEV.not_null_silver.initialization_pools_meteora_TOKEN_A_ACCOUNT
  -------------------------------------------------------------------------------------
16:35:44  
16:35:44  Warning in test not_null_silver__initialization_pools_meteora_TOKEN_B_ACCOUNT (models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml)
16:35:44  Got 27 results, configured to warn if != 0
16:35:44  
16:35:44    compiled code at target/compiled/solana_models/models/silver/liquidity_pool/meteora/amm/silver__initialization_pools_meteora.yml/not_null_silver__initialization_pools_meteora_TOKEN_B_ACCOUNT.sql
16:35:44  
16:35:44    See test failures:
  -------------------------------------------------------------------------------------
  select * from SOLANA_DEV.not_null_silver.initialization_pools_meteora_TOKEN_B_ACCOUNT
  -------------------------------------------------------------------------------------
```

`dbt build -s silver__initialization_pools_meteora -t dev`
```
16:37:15  1 of 17 OK created sql incremental model silver.initialization_pools_meteora ... [SUCCESS 11785 in 13.42s]
```

Data in dev
```
select *
from solana_dev.silver.initialization_pools_meteora;
```