### PR TITLE
suface index/inner_index

### DIFF
--- a/models/silver/swaps/bonkswap/silver__swaps_intermediate_bonkswap.sql
+++ b/models/silver/swaps/bonkswap/silver__swaps_intermediate_bonkswap.sql
@@ -175,6 +175,8 @@ SELECT
     block_timestamp,
     program_id,
     tx_id,
+    index,
+    inner_index,
     ROW_NUMBER() over (
         PARTITION BY tx_id
         ORDER BY

--- a/models/silver/swaps/bonkswap/silver__swaps_intermediate_bonkswap.yml
+++ b/models/silver/swaps/bonkswap/silver__swaps_intermediate_bonkswap.yml
@@ -28,55 +28,64 @@ models:
           '5ghJVhQyZuQoXLTjznjhmJ3EiGSDtdy1PT6xk7iw5GhukX7F4CmsYtPmh6C5Si8cY31Wuwo1dkX7iCzWgXuvNVgc',
           '6HuXhDg9cc5nkbWmTQYjj7hpAxrJwMW3ZQT21jNgTouabAm3CxBtAdAf9Q21Ffov9kQnADjEmxYLaSZrDFjcbDx',
           'fgmeRM6JRo9jZk53h4ECQpe5pt2joQK9PpBetFt9pSHpGNBrNjqDhW7Hihivb4n4d6VX2Gkpy3Dzk6wkCTvRjt1')"  
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('index') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SWAPPER
         description: "{{ doc('swaps_swapper') }}"
         tests: 
           - not_null:
-              where: succeeded = TRUE
+              where: succeeded = TRUE AND _inserted_timestamp >= current_date - 7
       - name: FROM_AMT
         description:  "{{ doc('swaps_from_amt') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: FROM_MINT
         description:  "{{ doc('swaps_from_mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TO_AMT
         description:  "{{ doc('swaps_to_amt') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TO_MINT
         description:  "{{ doc('swaps_to_mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SWAP_INDEX
         description: "{{ doc('swaps_swap_index') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/swaps/meteora/silver__swaps_intermediate_meteora.sql
+++ b/models/silver/swaps/meteora/silver__swaps_intermediate_meteora.sql
@@ -270,6 +270,8 @@ SELECT
     block_timestamp,
     program_id,
     tx_id,
+    index,
+    inner_index,
     ROW_NUMBER() over (
         PARTITION BY tx_id
         ORDER BY

--- a/models/silver/swaps/meteora/silver__swaps_intermediate_meteora.yml
+++ b/models/silver/swaps/meteora/silver__swaps_intermediate_meteora.yml
@@ -29,43 +29,52 @@ models:
           '64PW2o1TjxU3kJXAWsAZrL6wJAhKeAY2esJNbjp9UfBb4q4mZMF9KdXXqv3DjkAiNZUacitwzU5v8rCCb3zkdvmp',
           '42a7GeWqCVi8p3e5EGqKh6pcYnuqK4c6Kjg9ZmiN7SKe1aFhtvUDQJrPiMinTwvKPeAcTVVYjXE4TH33mMH52yD5',
           '5KboaM89D79KwHwmRaoaSA7wD3xduMpdqVnWWxkEYvi4b16dTKBQBtGQYoQ1PgStD66mF95vi7FGNrcfmW3EGTpB')"  
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('index') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SWAPPER
         description: "{{ doc('swaps_swapper') }}"
         tests: 
           - not_null:
-              where: succeeded = TRUE
+              where: succeeded = TRUE AND _inserted_timestamp >= current_date - 7
       - name: FROM_AMT
         description:  "{{ doc('swaps_from_amt') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: FROM_MINT
         description:  "{{ doc('swaps_from_mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TO_AMT
         description:  "{{ doc('swaps_to_amt') }}"
       - name: TO_MINT
@@ -73,7 +82,7 @@ models:
       - name: SWAP_INDEX
         description: "{{ doc('swaps_swap_index') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.sql
+++ b/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.sql
@@ -166,6 +166,8 @@ SELECT
     block_timestamp,
     program_id,
     tx_id,
+    index,
+    inner_index,
     ROW_NUMBER() over (
         PARTITION BY tx_id
         ORDER BY

--- a/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.yml
+++ b/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.yml
@@ -32,55 +32,64 @@ models:
             - 44b7tkzuKHqQsn7Eoh3RnTy12sLijudPFz3ZX2ewJ7vxKqs5LveeNKxBVLUstggr5Jk3LFzoNs9SSZxcMSSgVE7j
             - 1M48Smd6EQ4phktTsGfdk3HjXf2sEW6J8TpUpPjEaGjLy5viWPC9D4rS9SoutVWTJkLkjbVLQpEG9eboscoybQ6
             - fLwJbyNV8kF3qZcmUrPrQB7B1keipAB5XNiEsJ8oFtvMroZ4SttabxgP2nhUsTT1jKvN4NfrSf8DMYVoadY57Da
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('index') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SWAPPER
         description: "{{ doc('swaps_swapper') }}"
         tests: 
           - not_null:
-              where: succeeded = TRUE
+              where: succeeded = TRUE AND _inserted_timestamp >= current_date - 7
       - name: FROM_AMT
         description:  "{{ doc('swaps_from_amt') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: FROM_MINT
         description:  "{{ doc('swaps_from_mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TO_AMT
         description:  "{{ doc('swaps_to_amt') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TO_MINT
         description:  "{{ doc('swaps_to_mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SWAP_INDEX
         description: "{{ doc('swaps_swap_index') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 


### PR DESCRIPTION
surface `index`/`inner_index` in silver swaps models needed for marinade curation
- will update `index`/`inner_index` in prod after merge by FR'ing `dev` and using ad-hoc `update` statement

dbt runs successful:
```
18:07:53  1 of 3 OK created sql incremental model silver.swaps_intermediate_bonkswap ..... [SUCCESS 229 in 28.91s]
18:07:53  3 of 3 OK created sql incremental model silver.swaps_intermediate_phoenix ...... [SUCCESS 8702 in 29.36s]
18:08:02  2 of 3 OK created sql incremental model silver.swaps_intermediate_meteora ...... [SUCCESS 75423 in 37.93s]
```