### PR TITLE
Add decoder backfill helper for single dates

### DIFF
--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -306,6 +306,7 @@
                     ON c.program_id = b.program_id
                 WHERE 
                     _inserted_timestamp >= '{{ retry_start_timestamp }}'
+                    AND block_id BETWEEN {{ start_block }} AND {{ end_block }}
             )
             SELECT
                 e.program_id,

--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -298,12 +298,14 @@
             ),
             completed_subset AS (
                 SELECT 
-                    *
+                    complete_decoded_instructions_3_id
                 FROM 
-                    {{ ref('streamline__complete_decoded_instructions_3') }}
+                    {{ ref('streamline__complete_decoded_instructions_3') }} AS c
+                JOIN 
+                    idl_in_play b
+                    ON c.program_id = b.program_id
                 WHERE 
-                    program_id = '{{ program_id }}'
-                    AND _inserted_timestamp >= '{{ retry_start_timestamp }}'
+                    _inserted_timestamp >= '{{ retry_start_timestamp }}'
             )
             SELECT
                 e.program_id,

--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -200,7 +200,7 @@
     {% endfor %}
 {% endmacro %}
 
-{% macro decoded_instructions_backfill_single_date_all_programs(backfill_date, priority=None) %}
+{% macro decoded_instructions_backfill_retry_single_date_all_programs(backfill_date, priority=None) %}
     {% set get_block_id_range_query %}
         SELECT 
             min(block_id),


### PR DESCRIPTION
Add macro helpers for backfilling decoder instructions and logs for a specific `block_timestamp::date`. This can be useful for situations where there are significant raw data ingestion delays as the current real-time streamline requests only have a 2 day lookback.

`dbt run-operation decoded_logs_backfill_retry_single_date_all_programs --args '{"backfill_date": "2024-12-15"}' -t dev`
<img width="1258" alt="Screenshot 2025-01-14 at 4 09 46 PM" src="https://github.com/user-attachments/assets/98018566-d39d-47d1-8d57-57a97f4c0ad0" />


`dbt run-operation decoded_instructions_backfill_single_date_all_programs --args '{"backfill_date": "2024-12-15"}' -t dev`
<img width="1263" alt="Screenshot 2025-01-14 at 4 10 40 PM" src="https://github.com/user-attachments/assets/38ce39a2-45eb-4ec8-9d87-214d24bc6d7a" />
