### PR TITLE
Backfill solana tx index pipeline

### DIFF
--- a/models/bronze/streamline/bronze__streamline_FR_block_tx_index_backfill.sql
+++ b/models/bronze/streamline/bronze__streamline_FR_block_tx_index_backfill.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "block_txs_index_backfill" %}
+{{ streamline_external_table_FR_query_v2(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "block_id",
+    other_cols=""
+) }}

--- a/models/bronze/streamline/bronze__streamline_block_tx_index_backfill.sql
+++ b/models/bronze/streamline/bronze__streamline_block_tx_index_backfill.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "block_txs_index_backfill" %}
+{{ streamline_external_table_query_v2(
+    model,
+    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
+    partition_name = "_partition_by_created_date",
+    unique_key = "block_id",
+    other_cols=""
+) }}

--- a/models/silver/backfill/silver__backfill_transactions_index.sql
+++ b/models/silver/backfill/silver__backfill_transactions_index.sql
@@ -1,0 +1,41 @@
+-- depends_on: {{ ref('bronze__streamline_block_tx_index_backfill') }}
+
+{{
+    config(
+        materialized="incremental",
+        cluster_by = ["_partition_by_created_date","_inserted_timestamp::date"],
+        tags=['tx_index_backfill']
+    )
+}}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_partition_query %}
+        SELECT max(_partition_by_created_date) FROM {{ this }}
+        {% endset %}
+        {% set max_partition = run_query(max_partition_query)[0][0] %}
+    {% endif %}
+{% endif %}
+
+SELECT 
+    block_id,
+    to_timestamp_ntz(value:"result.blockTime"::int) AS block_timestamp,
+    data::string as tx_id,
+    value:array_index::int as tx_index,
+    _partition_by_created_date,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['tx_id']) }} AS transactions_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    {% if is_incremental() %}
+    {{ ref('bronze__streamline_block_tx_index_backfill') }}
+    {% else %}
+    {{ ref('bronze__streamline_FR_block_tx_index_backfill') }}
+    {% endif %}
+{% if is_incremental() %}
+WHERE 
+    _partition_by_created_date >= {{ max_partition }}
+    AND _inserted_timestamp > (SELECT max(_inserted_timestamp) FROM {{ this }}) 
+{% endif %}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -69,6 +69,7 @@ sources:
       - name: decoded_logs_2
       - name: block_txs_2
       - name: helius_blocks
+      - name: block_txs_index_backfill
   - name: bronze_api
     schema: bronze_api
     tables:

--- a/models/streamline/core/realtime/streamline__block_txs_index.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_index.sql
@@ -6,7 +6,7 @@
         params ={ "external_table" :"block_txs_index_backfill",
             "sql_limit" :"10000",
             "producer_batch_size" :"10000",
-            "worker_batch_size" :"10000", --20k worker and lambda runs out of disk space
+            "worker_batch_size" :"10000",
             "sql_source" :"{{this.identifier}}", 
             "order_by_column": "block_id DESC",
             "exploded_key": tojson(["result.signatures"]),

--- a/models/streamline/core/realtime/streamline__block_txs_index.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_index.sql
@@ -4,9 +4,9 @@
         func = 'streamline.udf_bulk_rest_api_v2',
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"block_txs_index_backfill",
-            "sql_limit" :"10000",
-            "producer_batch_size" :"10000",
-            "worker_batch_size" :"10000",
+            "sql_limit" :"37500",
+            "producer_batch_size" :"37500",
+            "worker_batch_size" :"750",
             "sql_source" :"{{this.identifier}}", 
             "order_by_column": "block_id DESC",
             "exploded_key": tojson(["result.signatures"]),
@@ -23,6 +23,11 @@ WITH block_ids AS (
     WHERE 
         -- all blocks after this should have tx id filled in already so start the backfill here
         b.block_id <= 307868470 
+    EXCEPT
+    SELECT DISTINCT
+        block_id
+    FROM
+        {{ ref('silver__backfill_transactions_index') }}
 )
 SELECT
     block_id,


### PR DESCRIPTION
Create models to perform tx index backfill
- Add streamline call
- Add bronze models
- Add silver model to track what has been completed + will be used to update `silver.transactions`

`dbt run --vars '{"UPDATE_UDFS_AND_SPS": True}' -s bronze__streamline_block_tx_index_backfill bronze__streamline_FR_block_tx_index_backfill -t dev`
```
15:23:57  2 of 2 OK created sql view model bronze.streamline_block_tx_index_backfill ..... [SUCCESS 1 in 2.86s]
15:23:57  1 of 2 OK created sql view model bronze.streamline_FR_block_tx_index_backfill .. [SUCCESS 1 in 2.92s]
```

`dbt run -s silver__backfill_transactions_index -t dev --full-refresh`
```
15:31:04  1 of 1 OK created sql incremental model silver.backfill_transactions_index ..... [SUCCESS 1 in 104.85s]
```

`dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__block_txs_index -t dev`
```
{
  "exploded_key": "[\"result.signatures\"]",
  "external_table": "block_txs_index_backfill",
  "include_top_level_json": "[\"result.blockTime\"]",
  "order_by_column": "block_id DESC",
  "producer_batch_size": "37500",
  "sql_limit": "37500",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "750"
}
 on {{this.schema}}.{{this.identifier}}
15:32:54  1 of 1 OK created sql view model streamline.block_txs_index .................... [SUCCESS 1 in 10.20s]
```

DML to update `silver.transactions` in batches when data is ready
```
UPDATE {{ target.database }}.silver.transactions AS t
SET
    t.tx_index = s.tx_index,
    t.modified_timestamp = sysdate()
FROM
    {{ target.database }}.silver.backfill_transactions_index AS s
WHERE
    t.block_timestamp::date = s.block_timestamp::date
    AND t.block_id = s.block_id
    AND t.tx_id = s.tx_id
    AND s.block_timestamp::date BETWEEN <start_date> AND <end_date>;
```