### PR TITLE
Switch block tx counts back to solscan

### DIFF
--- a/.github/workflows/dbt_run_streamline_solscan_blocks.yml
+++ b/.github/workflows/dbt_run_streamline_solscan_blocks.yml
@@ -40,8 +40,6 @@ jobs:
           pip install -r requirements.txt
           dbt deps
       - name: Run DBT Jobs
-        # TODO: Replace w/ solscan blocks once we have credits again
-        # dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__solscan_blocks
         run: |
           dbt run -s silver___blocks_tx_count
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__helius_blocks
+          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__solscan_blocks

--- a/models/silver/non_core/silver___blocks_tx_count.sql
+++ b/models/silver/non_core/silver___blocks_tx_count.sql
@@ -20,6 +20,7 @@ WITH solscan_blocks AS (
         )
     {% endif %}
 ),
+/* This is used as a backup for when there are issues with solscan raw data pipeline */
 helius_blocks AS (
     SELECT
         block_id,


### PR DESCRIPTION
Revert back to using `solscan` raw data for block tx counts (reverts this [change](https://github.com/FlipsideCrypto/solana-models/pull/729/files#diff-33db680672616b55cc809252838d9bbd10a7eeb382a5b177d36d3a1b169200f7)).