### PR TITLE
Add meteora multi swap for marinade

### DIFF
--- a/models/gold/marinade/marinade__ez_liquidity_pool_actions.sql
+++ b/models/gold/marinade/marinade__ez_liquidity_pool_actions.sql
@@ -28,6 +28,7 @@
     'orcav2',
     'meteora',
     'meteora_dlmm',
+    'meteora_multi',
     'orca_whirlpool',
 ] %}
 
@@ -83,7 +84,7 @@ base AS (
             m.platform,
             lp.liquidity_pool_actions_{{ platform }}_id AS ez_liquidity_pool_actions_id
         from 
-            {% if platform == 'meteora' or platform == 'meteora_dlmm' %}
+            {% if platform in ['meteora', 'meteora_dlmm', 'meteora_multi'] %}
             {{ ref('marinade__' ~ platform ~ '_pivot') }} AS lp
             {% else %}
             {{ ref('silver__liquidity_pool_actions_' ~ platform) }} AS lp

--- a/models/gold/marinade/marinade__meteora_dlmm_pivot.sql
+++ b/models/gold/marinade/marinade__meteora_dlmm_pivot.sql
@@ -15,11 +15,8 @@ select
     row_number() over (partition by lp.tx_id, lp.index, lp.action order by lp.inner_index) as rn
 from 
     {{ ref('silver__liquidity_pool_actions_meteora_dlmm') }} AS lp
-/*
-TODO: Add this when meteora pools have been added to dim pools
 inner join {{ ref('marinade__dim_pools') }} AS m 
     on lp.liquidity_pool_address = m.pool_address
-*/
 where action in (
             'removeLiquidityByRange',
             'removeLiquidity',

--- a/models/gold/marinade/marinade__meteora_multi_pivot.sql
+++ b/models/gold/marinade/marinade__meteora_multi_pivot.sql
@@ -1,0 +1,61 @@
+/* TODO: ephemeral names are working properly with our custom naming macro, has to be view for now 
+but external user should not have perms to select from this view */
+
+/* this only needs to be run once */
+{{
+    config(
+        materialized = 'view',
+        tags = ['exclude_change_tracking']
+    )
+}}
+
+with base as (
+select 
+    lp.*,
+    row_number() over (partition by lp.tx_id, lp.index, lp.action order by lp.inner_index) as rn
+from 
+    {{ ref('silver__liquidity_pool_actions_meteora_multi') }} AS lp
+inner join {{ ref('marinade__dim_pools') }} AS m 
+    on lp.liquidity_pool_address = m.pool_address
+where action in (
+            'deposit',
+            'withdraw'
+        )
+),
+pre_final as (
+select 
+    b1.* exclude(inner_index),
+    iff(b1.inner_index=0,NULL,b1.inner_index-1) AS inner_index,
+    b2.mint as b_mint,
+    b2.amount AS b_amount
+from base b1
+left join
+    base b2
+    on b1.tx_id = b2.tx_id
+    and b1.index = b2.index
+    and b1.action = b2.action
+    and b1.rn = 1
+    and b2.rn <> 1
+where
+    b1.rn = 1
+qualify
+    row_number() over (partition by b1.tx_id, b1.index, b1.action order by b2.rn) = 1
+)
+select
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    action AS event_type,
+    liquidity_pool_address AS pool_address,
+    liquidity_provider AS provider_address,
+    mint AS token_a_mint,
+    amount AS token_a_amount,
+    b_mint AS token_b_mint,
+    b_amount AS token_b_amount,
+    program_id,
+    modified_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_meteora_multi_id
+from pre_final

--- a/models/gold/marinade/marinade__meteora_multi_pivot.yml
+++ b/models/gold/marinade/marinade__meteora_multi_pivot.yml
@@ -1,0 +1,54 @@
+version: 2
+models:
+  - name: marinade__meteora_multi_pivot
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+      - dbt_utils.expression_is_true:
+          expression: "inner_index >= 0"
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+      - name: EVENT_TYPE
+        description: "{{ doc('event_type') }}"
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+      - name: PROVIDER_ADDRESS
+        description:  "{{ doc('liquidity_provider') }}"
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests:
+          - not_null
+      - name: TOKEN_A_AMOUNT
+        description:  "{{ doc('token_a_amount') }}"
+        data_tests:
+          - not_null
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+      - name: TOKEN_B_AMOUNT
+        description:  "{{ doc('token_b_amount') }}"
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+      - name: LIQUIDITY_POOL_ACTIONS_METEORA_MULTI_ID
+        description: '{{ doc("pk") }}'
+        data_tests:
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/marinade/marinade__meteora_pivot.sql
+++ b/models/gold/marinade/marinade__meteora_pivot.sql
@@ -15,11 +15,8 @@ select
     row_number() over (partition by lp.tx_id, lp.index, lp.action order by lp.inner_index) as rn
 from 
     {{ ref('silver__liquidity_pool_actions_meteora') }} AS lp
-/*
-TODO: Add this when meteora pools have been added to dim pools
 inner join {{ ref('marinade__dim_pools') }} AS m 
     on lp.liquidity_pool_address = m.pool_address
-*/
 where 
     lp.succeeded
     AND action in (


### PR DESCRIPTION
Add pool from meteora multi to the marinade lp actions output
- Add pivoted view for meteora multi lp actions
- Add to `marinade.ez_liquidity_pool_actions`
- Cleanup TODOs from other meteora pivot tables

`dbt build -s marinade__meteora_multi_pivot -t dev`
```
15:32:05  Finished running 1 view model, 5 data tests, 7 project hooks in 0 hours 0 minutes and 23.77 seconds (23.77s).
15:32:06  
15:32:06  Completed successfully
15:32:06  
15:32:06  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 TOTAL=6
```

`dbt build -s marinade__ez_liquidity_pool_actions -t dev --full-refresh`
```
15:33:57  Finished running 1 incremental model, 18 data tests, 7 project hooks in 0 hours 1 minutes and 8.61 seconds (68.61s).
15:33:57  
15:33:57  Completed successfully
15:33:57  
15:33:57  Done. PASS=19 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

`dbt build -s marinade__ez_liquidity_pool_actions -t dev`
```
15:34:51  Finished running 1 incremental model, 18 data tests, 7 project hooks in 0 hours 0 minutes and 31.59 seconds (31.59s).
15:34:52  
15:34:52  Completed successfully
15:34:52  
15:34:52  Done. PASS=19 WARN=0 ERROR=0 SKIP=0 TOTAL=19
```

New pool in DEV table
```
select *
from solana_dev.marinade.ez_liquidity_pool_actions
where pool_address = 'MAR1zHjHaQcniE2gXsDptkyKUnNfMEsLBVcfP7vLyv7'
limit 10;
```