### PR TITLE
fix bad epoch start/end slots

### DIFF
--- a/models/gold/gov/gov__fact_block_production.sql
+++ b/models/gold/gov/gov__fact_block_production.sql
@@ -10,8 +10,10 @@ WITH base_block_production AS (
     node_pubkey,
     sum(num_leader_slots) AS num_leader_slots,
     sum(num_blocks_produced) AS num_blocks_produced,
+    max(inserted_timestamp) AS inserted_timestamp,
+    max(modified_timestamp) AS modified_timestamp
   FROM
-    {{ ref('silver__snapshot_block_production') }}
+    {{ ref('silver__snapshot_block_production_2') }}
   GROUP BY 1,2
 )
 SELECT
@@ -36,7 +38,6 @@ FROM
 LEFT JOIN
   {{ ref('silver__epoch') }} AS e
   ON bp.epoch = e.epoch
-GROUP BY 1,2
 UNION ALL
 SELECT
   epoch,

--- a/models/gold/gov/gov__fact_block_production.sql
+++ b/models/gold/gov/gov__fact_block_production.sql
@@ -5,28 +5,31 @@
 ) }}
 
 SELECT
-  epoch,
+  bp.epoch,
   node_pubkey,
   num_leader_slots,
   num_blocks_produced,
-  start_slot,
-  end_slot,
+  e.start_block AS start_slot,
+  e.end_block AS end_slot,
   COALESCE (
     snapshot_block_production_id,
     {{ dbt_utils.generate_surrogate_key(
-      ['epoch', 'node_pubkey']
+      ['bp.epoch', 'node_pubkey']
     ) }}
   ) AS fact_block_production_id,
   COALESCE(
-    inserted_timestamp,
+    bp.inserted_timestamp,
     '2000-01-01'
   ) AS inserted_timestamp,
   COALESCE(
-    modified_timestamp,
+    bp.modified_timestamp,
     '2000-01-01'
   ) AS modified_timestamp
 FROM
-  {{ ref('silver__snapshot_block_production') }}
+  {{ ref('silver__snapshot_block_production') }} AS bp
+LEFT JOIN
+  {{ ref('silver__epoch') }} AS e
+  ON bp.epoch = e.epoch
 UNION ALL
 SELECT
   epoch,

--- a/models/silver/validator/silver__historical_block_production.sql
+++ b/models/silver/validator/silver__historical_block_production.sql
@@ -1,29 +1,36 @@
-{{ config (
+{{ config(
     materialized = 'view',
     tags = ['validator_historical']
 ) }}
 
 SELECT
-    a.json_data :metadata :epoch AS epoch,
-    f.value :identityPubkey :: STRING AS node_pubkey,
-    f.value :leaderSlots :: INT AS num_leader_slots,
-    f.value :blocksProduced :: INT AS num_blocks_produced,
-    a.json_data :metadata :start_slot :: INT AS start_slot,
-    a.json_data :metadata :end_slot :: INT AS end_slot
+    a.json_data:metadata:epoch AS epoch,
+    f.value:identityPubkey::STRING AS node_pubkey,
+    f.value:leaderSlots::INT AS num_leader_slots,
+    f.value:blocksProduced::INT AS num_blocks_produced,
+    a.json_data:metadata:start_slot::INT AS start_slot,
+    a.json_data:metadata:end_slot::INT AS end_slot
 FROM
-    {{ source(
-        'bronze',
-        'block_production'
-    ) }} a,
-    LATERAL FLATTEN(
-        input => a.json_data :metadata :leaders
-    ) AS f
+    {{ source('bronze', 'block_production') }} a,
+    LATERAL FLATTEN(input => a.json_data:metadata:leaders) AS f
 GROUP BY
-    1,
-    2,
-    3,
-    4,
-    5,
-    6 qualify(ROW_NUMBER() over(PARTITION BY epoch, node_pubkey
-ORDER BY
-    epoch DESC)) = 1
+    1, 2, 3, 4, 5, 6
+QUALIFY
+    row_number() OVER (
+        PARTITION BY epoch, node_pubkey
+        ORDER BY epoch DESC
+    ) = 1
+
+UNION ALL
+
+SELECT
+    epoch,
+    node_pubkey,
+    num_leader_slots,
+    num_blocks_produced,
+    start_slot,
+    end_slot
+FROM
+    {{ ref('silver__snapshot_block_production_view') }}
+WHERE
+    epoch BETWEEN 469 AND 552

--- a/models/silver/validator/silver__snapshot_block_production.sql
+++ b/models/silver/validator/silver__snapshot_block_production.sql
@@ -3,7 +3,9 @@
   unique_key = "CONCAT_WS('-', epoch, node_pubkey)",
   incremental_strategy = 'delete+insert',
   cluster_by = ['_inserted_timestamp::DATE'],
-  tags = ['validator']
+  full_refresh = false,
+  enabled = false,
+  tags = ['deprecated']
 ) }}
 
 select

--- a/models/silver/validator/silver__snapshot_block_production.sql
+++ b/models/silver/validator/silver__snapshot_block_production.sql
@@ -1,6 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "CONCAT_WS('-', epoch, node_pubkey, start_slot, end_slot)",
+  unique_key = "CONCAT_WS('-', epoch, node_pubkey)",
   incremental_strategy = 'delete+insert',
   cluster_by = ['_inserted_timestamp::DATE'],
   tags = ['validator']
@@ -15,7 +15,7 @@ select
     json_data:data:result:value:range:lastSlot :: INT as end_slot,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
-        ['epoch', 'node_pubkey', 'start_slot', 'end_slot']
+        ['epoch', 'node_pubkey']
     ) }} AS snapshot_block_production_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,
@@ -33,7 +33,6 @@ WHERE _inserted_timestamp > (
     {{ this }}
 )
 {% endif %}
-qualify(ROW_NUMBER() over(PARTITION BY epoch, node_pubkey, start_slot, end_slot
+qualify(ROW_NUMBER() over(PARTITION BY epoch, node_pubkey
 ORDER BY
     _inserted_timestamp DESC)) = 1
-

--- a/models/silver/validator/silver__snapshot_block_production_2.sql
+++ b/models/silver/validator/silver__snapshot_block_production_2.sql
@@ -1,0 +1,43 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', epoch, node_pubkey, start_slot, end_slot)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['_inserted_timestamp::DATE'],
+  tags = ['validator']
+) }}
+
+{% set historical_epoch_cutoff = 552 %}
+
+SELECT
+    epoch::INT AS epoch,
+    key AS node_pubkey,
+    f.value[0]::INT AS num_leader_slots,
+    f.value[1]::INT AS num_blocks_produced,
+    json_data:data:result:value:range:firstSlot::INT AS start_slot,
+    json_data:data:result:value:range:lastSlot::INT AS end_slot,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['epoch', 'node_pubkey', 'start_slot', 'end_slot']
+    ) }} AS snapshot_block_production_2_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    {{ source('bronze_api', 'block_production') }} a,
+    LATERAL FLATTEN(input => json_data:data:result:value:byIdentity) AS f
+WHERE
+    epoch > {{ historical_epoch_cutoff }}
+    {% if is_incremental() %}
+    AND _inserted_timestamp > (
+        SELECT
+            max(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
+    {% endif %}
+QUALIFY 
+    row_number() OVER (
+        PARTITION BY epoch, node_pubkey, start_slot, end_slot
+        ORDER BY _inserted_timestamp DESC
+    ) = 1
+

--- a/models/silver/validator/silver__snapshot_block_production_2.yml
+++ b/models/silver/validator/silver__snapshot_block_production_2.yml
@@ -1,0 +1,50 @@
+version: 2
+models:
+  - name: silver__snapshot_block_production_2
+    columns:
+      - name: EPOCH
+        description: "{{ doc('epoch') }}"
+        data_tests:
+          - not_null
+      - name: NODE_PUBKEY
+        description: >
+          Pubkey for the Solana validator node
+        data_tests:
+          - not_null
+      - name: NUM_LEADER_SLOTS
+        description: > 
+          Number of slots the validator was the leader for between start_slot and end_slot
+      - name: NUM_BLOCKS_PRODUCED
+        description: >
+          Number of blocks the validator produced between start_slot and end_slot
+      - name: START_SLOT
+        description: >
+          First slot of the RPC request
+      - name: END_SLOT
+        description: >
+          Final slot of the RPC request
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: SNAPSHOT_BLOCK_PRODUCTION_2_ID
+        description: '{{ doc("pk") }}'
+        data_tests: 
+          - not_null
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_snapshot_block_production_2_invocation_id

--- a/models/silver/validator/silver__snapshot_block_production_view.sql
+++ b/models/silver/validator/silver__snapshot_block_production_view.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized = 'view',
+    )
+}}
+
+SELECT
+    *
+FROM
+    {{ source('solana_silver', 'snapshot_block_production') }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -112,6 +112,7 @@ sources:
       - name: mints_orca_non_whirlpool
       - name: pool_transfers_orca_non_whirlpool
       - name: initialization_pools_orca
+      - name: snapshot_block_production
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
Fix for [issue](https://team-1612274056224.atlassian.net/browse/AN-5658) surfaced by marqu
- Get epoch start/end slots from `silver.epoch` as the start/end slot from the raw data is the start/end of the blocks requested in each individual RPC call and no longer the start/end of the entire epoch
- Deprecate existing `snapshot_block_production` model and put it as part of historical view
  - I tried just refreshing the data but for unknown reasons some data in epoch `552` and before was missing
- Add new model `snapshot_block_production_2` to capture all block production data after epoch `552`
- Aggregate leader and block produced values by epoch in gold for all data from `snapshot_block_production_2`

`dbt run -s silver__snapshot_block_production_view silver__historical_block_production -t dev`
```
16:16:50  Finished running 2 view models, 7 project hooks in 0 hours 0 minutes and 23.29 seconds (23.29s).
16:16:51  
16:16:51  Completed successfully
16:16:51  
16:16:51  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```

`dbt build -s silver__snapshot_block_production_2 -t dev --full-refresh`
```
16:17:58  Finished running 1 incremental model, 9 data tests, 7 project hooks in 0 hours 0 minutes and 31.45 seconds (31.45s).
16:17:58  
16:17:58  Completed successfully
16:17:58  
16:17:58  Done. PASS=10 WARN=0 ERROR=0 SKIP=0 TOTAL=10
```

`dbt build -s silver__snapshot_block_production_2 -t dev`
```
16:19:33  Finished running 1 incremental model, 9 data tests, 7 project hooks in 0 hours 0 minutes and 28.51 seconds (28.51s).
16:19:33  
16:19:33  Completed successfully
16:19:33  
16:19:33  Done. PASS=10 WARN=0 ERROR=0 SKIP=0 TOTAL=10
```

`dbt run -s gov__fact_block_production -t dev`
```
16:20:29  1 of 1 OK created sql view model gov.fact_block_production ..................... [SUCCESS 1 in 3.07s]
```

Reconcile prod vs dev gold view
Expect data to be same before epoch `692`
```
select epoch, node_pubkey, start_slot, end_slot, num_leader_slots, num_blocks_produced
from solana.gov.fact_block_production
where epoch < 692
except
select epoch, node_pubkey, start_slot, end_slot, num_leader_slots, num_blocks_produced
from solana_dev.gov.fact_block_production
where epoch < 692;
```
Expect data to be different at or after epoch `692`
```
select epoch, node_pubkey, start_slot, end_slot, num_leader_slots, num_blocks_produced
from solana.gov.fact_block_production
where epoch >= 692
except
select epoch, node_pubkey, start_slot, end_slot, num_leader_slots, num_blocks_produced
from solana_dev.gov.fact_block_production
where epoch >= 692;
```

This query now returns all 1s for `count(distinct start_slot)` and `count(distinct end_slot)` for each epoch as expected
```
select 

  epoch
  , min(start_slot)
  , max(start_slot)
  , min(end_slot)
  , max(end_slot)
  , count(distinct start_slot)
  , count(distinct end_slot)
  , count(1)

from solana_dev.gov.fact_block_production
where epoch >= 692
group by epoch
```

Leader and Blocks produced now aggregated
```
select epoch, node_pubkey
from solana_dev.silver.snapshot_block_production
where epoch = 718
and node_pubkey ='CpuDNi3iVoHXbaT8gHpzKe6rqeBasoYjEKi21q7NRVJS';
```