### PR TITLE
change partition key to 15min intervals instead of daily

### DIFF
--- a/models/bronze/streamline/bronze__streamline_FR_block_tx_index_backfill.sql
+++ b/models/bronze/streamline/bronze__streamline_FR_block_tx_index_backfill.sql
@@ -5,8 +5,8 @@
 {% set model = "block_txs_index_backfill" %}
 {{ streamline_external_table_FR_query_v2(
     model,
-    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
-    partition_name = "_partition_by_created_date",
+    partition_function = "to_timestamp_ntz(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD_HH24_MI')",
+    partition_name = "_partition_by_created_timestamp",
     unique_key = "block_id",
     other_cols=""
 ) }}

--- a/models/bronze/streamline/bronze__streamline_block_tx_index_backfill.sql
+++ b/models/bronze/streamline/bronze__streamline_block_tx_index_backfill.sql
@@ -5,8 +5,8 @@
 {% set model = "block_txs_index_backfill" %}
 {{ streamline_external_table_query_v2(
     model,
-    partition_function = "to_date(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD')",
-    partition_name = "_partition_by_created_date",
+    partition_function = "to_timestamp_ntz(split_part(split_part(file_name, '/', -2), '_result', 1), 'YYYY_MM_DD_HH24_MI')",
+    partition_name = "_partition_by_created_timestamp",
     unique_key = "block_id",
     other_cols=""
 ) }}

--- a/models/silver/backfill/silver__backfill_transactions_index.sql
+++ b/models/silver/backfill/silver__backfill_transactions_index.sql
@@ -11,7 +11,7 @@
 {% if execute %}
     {% if is_incremental() %}
         {% set max_partition_query %}
-        SELECT max(_partition_by_created_date) FROM {{ this }}
+        SELECT max(_partition_by_created_timestamp) FROM {{ this }}
         {% endset %}
         {% set max_partition = run_query(max_partition_query)[0][0] %}
     {% endif %}
@@ -22,7 +22,7 @@ SELECT
     to_timestamp_ntz(value:"result.blockTime"::int) AS block_timestamp,
     data::string as tx_id,
     value:array_index::int as tx_index,
-    _partition_by_created_date,
+    _partition_by_created_timestamp,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(['tx_id']) }} AS transactions_id,
     sysdate() AS inserted_timestamp,
@@ -37,6 +37,6 @@ FROM
 WHERE 
     data IS NOT NULL
 {% if is_incremental() %}
-    AND _partition_by_created_date >= '{{ max_partition }}'
+    AND _partition_by_created_timestamp >= '{{ max_partition }}'
     AND _inserted_timestamp > (SELECT max(_inserted_timestamp) FROM {{ this }}) 
 {% endif %}

--- a/models/streamline/core/realtime/streamline__block_txs_index.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_index.sql
@@ -31,7 +31,11 @@ WITH block_ids AS (
 )
 SELECT
     block_id,
-    replace(current_date::string,'-','_') AS partition_key, -- Issue with streamline handling `-` in partition key so changing to `_`
+    to_char(dateadd(
+        minute, 
+        floor(date_part(minute, current_timestamp) / 15) * 15, 
+        date_trunc('hour', current_timestamp)
+    ), 'YYYY_MM_DD_HH24_MI') AS partition_key, -- Issue with streamline handling `-` in partition key so changing to `_`
     {{ target.database }}.live.udf_api(
         'POST',
         '{Service}?apikey={Authentication}',


### PR DESCRIPTION
Change partition key to every 15 minutes to lower run time required to update the silver table. Anything under 5 mins should be OK.
- I will have to move the existing data into a new partition and reload the existing silver table before turning the job back on.

I ran 4 iterations in DEV and times were fairly consistent and all under 5 mins
```
15:57:14  1 of 1 OK created sql incremental model silver.backfill_transactions_index ..... [SUCCESS 70321795 in 138.87s]
16:10:15  1 of 1 OK created sql incremental model silver.backfill_transactions_index ..... [SUCCESS 70507472 in 130.02s]
16:23:40  1 of 1 OK created sql incremental model silver.backfill_transactions_index ..... [SUCCESS 68996177 in 184.72s]
16:33:55  1 of 1 OK created sql incremental model silver.backfill_transactions_index ..... [SUCCESS 69629975 in 127.58s]
```

Data in DEV S3 shows 15min partitions
![Screenshot 2025-01-23 at 8 36 10 AM](https://github.com/user-attachments/assets/9672b3ac-d748-4c6e-916d-cbf684a35dba)
