### PR TITLE
add tx_index to gold

### DIFF
--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -23,6 +23,7 @@ SELECT
     units_consumed,
     units_limit,
     tx_size,
+    tx_index,
     COALESCE (
         transactions_id,
         {{ dbt_utils.generate_surrogate_key(

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -67,6 +67,10 @@ models:
         description: The size of the transaction in bytes.
         tests:
           - dbt_expectations.expect_column_to_exist
+      - name: TX_INDEX
+        description: "{{ doc('tx_index') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
       - name: FACT_TRANSACTIONS_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP


### PR DESCRIPTION
- Add `tx_index` column to `core.fact_transactions`

`dbt build -s core__fact_transactions -t dev`
```
17:03:51  Finished running 1 view model, 17 data tests, 7 project hooks in 0 hours 0 minutes and 32.64 seconds (32.64s).
17:03:52  
17:03:52  Completed successfully
17:03:52  
17:03:52  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```

Data in Dev
```
select *
from solana_dev.core.fact_transactions
where tx_index is not null
limit 10;
```