### PR TITLE
only resend if not exist or error in silver for single day retries

### DIFF
--- a/macros/helpers/decoded_instructions_backfill_helpers.sql
+++ b/macros/helpers/decoded_instructions_backfill_helpers.sql
@@ -252,7 +252,7 @@
                 WHERE   
                     program_id <> 'FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH'
             ),
-            retry_events AS (
+            retry_events_tmp AS (
                 SELECT
                     e.program_id,
                     e.tx_id,
@@ -295,6 +295,23 @@
                         )
                         OR e.program_id NOT IN ('FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn','SNPRohhBurQwrpwAptw1QYtpFdfEKitr4WSJ125cN1g','GovaE4iu227srtG2s3tZzB4RmWBzw8sTwrCLZz7kN7rY','JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
                     )
+            ),
+            retry_events AS (
+                SELECT
+                    e.*
+                FROM
+                    retry_events_tmp AS e
+                LEFT JOIN
+                    {{ ref('silver__decoded_instructions_combined') }} AS d
+                    ON e.block_timestamp = d.block_timestamp
+                    AND e.program_id = d.program_id
+                    AND e.tx_id = d.tx_id
+                    AND e.index = d.index
+                    AND e.inner_index IS NOT DISTINCT FROM d.inner_index
+                WHERE
+                    d.tx_id IS NULL
+                    OR d.decoded_instruction:error::string IS NOT NULL
+                    OR d.event_type IS NULL
             ),
             completed_subset AS (
                 SELECT 


### PR DESCRIPTION
Filter down events for single day retries to only get data that isnt already in silver or has an error/incomplete decoding in silver

```
(dbt-env) ➜  solana-models git:(only-retry-null-or-error-for-single-date-retries) ✗ dbt run-operation decoded_instructions_backfill_retry_single_date_all_programs --args '{"backfill_date": "2023-09-09"}' -t dev
dbt run-operation decoded_logs_backfill_retry_single_date_all_programs --args '{"backfill_date": "2023-09-09"}' -t dev
16:37:57  Running with dbt=1.8.5
16:37:58  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
16:37:58  Registered adapter: snowflake=1.8.3
16:37:59  Found 464 models, 2934 data tests, 58 seeds, 7 operations, 5 analyses, 99 sources, 1107 macros
16:38:02  Running with dbt=1.8.5
16:38:02  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
16:38:02  Registered adapter: snowflake=1.8.3
16:38:04  Found 464 models, 2934 data tests, 58 seeds, 7 operations, 5 analyses, 99 sources, 1107 macros
```