### PR TITLE
update mayan bridge

### DIFF
--- a/models/gold/defi/defi__fact_bridge_activity.sql
+++ b/models/gold/defi/defi__fact_bridge_activity.sql
@@ -74,19 +74,26 @@ SELECT
     user_address,
     amount,
     mint,
-    COALESCE (
-        bridge_mayan_transfers_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['block_id','tx_id', 'index']
-        ) }}
-    ) AS fact_bridge_activity_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    bridge_mayan_transfers_id AS fact_bridge_activity_id,
+    inserted_timestamp,
+    modified_timestamp
 FROM
-    {{ ref('silver__bridge_mayan_transfers') }}
+    {{ ref('silver__bridge_mayan_transfers_view') }}
+union all
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    INDEX,
+    program_id,
+    platform,
+    direction,
+    user_address,
+    amount,
+    mint,
+    bridge_mayan_transfers_decoded_id AS fact_bridge_activity_id,
+    inserted_timestamp,
+    modified_timestamp
+FROM
+    {{ ref('silver__bridge_mayan_transfers_decoded') }}

--- a/models/silver/bridges/silver__bridge_mayan_transfers.sql
+++ b/models/silver/bridges/silver__bridge_mayan_transfers.sql
@@ -4,7 +4,9 @@
     incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp::date >= LEAST(current_date-7,(select min(block_timestamp)::date from ' ~ generate_tmp_view_name(this) ~ '))'],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id,user_address,mint)'),
-    tags = ['scheduled_non_core']
+    tags = ['scheduled_non_core'],
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH base_events AS (

--- a/models/silver/bridges/silver__bridge_mayan_transfers_decoded.sql
+++ b/models/silver/bridges/silver__bridge_mayan_transfers_decoded.sql
@@ -1,0 +1,185 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+
+{{ config(
+    materialized = 'incremental',
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    merge_exclude_columns = ["inserted_timestamp"],
+    unique_key = "bridge_mayan_transfers_decoded_id",
+    cluster_by = ['block_timestamp::DATE', 'modified_timestamp::DATE'],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id,user_address,mint)'),
+    tags = ['scheduled_non_core']
+) }}
+
+{% if execute %}
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.bridge_mayan_transfers_decoded__intermediate_tmp AS
+    SELECT
+        block_timestamp,
+        block_id,
+        tx_id,
+        succeeded,
+        signers,
+        index,
+        inner_index,
+        program_id,
+        event_type,
+        decoded_instruction,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined') }}
+    WHERE
+        program_id = 'BLZRi6frs4X4DNLw56V4EXai1b6QVESN1BhHBTYM9VcY'
+        AND event_type IN ('settle', 'initOrder')
+        AND succeeded
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '1 hour'
+    FROM
+        {{ this }}
+)
+{% else %}
+    AND block_timestamp :: DATE >= '2024-06-16'
+{% endif %}
+{% endset %}
+
+{% do run_query(base_query) %}
+{% set between_stmts = fsc_utils.dynamic_range_predicate(
+    "silver.bridge_mayan_transfers_decoded__intermediate_tmp",
+    "block_timestamp::date"
+) %}
+{% endif %}
+
+WITH base AS (
+    SELECT
+        *
+    FROM
+        silver.bridge_mayan_transfers_decoded__intermediate_tmp
+),
+
+bridge_out AS (
+    SELECT
+        block_timestamp,
+        block_id,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        program_id,
+        silver.udf_get_account_pubkey_by_name('trader', decoded_instruction:accounts) AS user_address,
+        silver.udf_get_account_pubkey_by_name('mintFrom', decoded_instruction:accounts) AS mint,
+        decoded_instruction:args:params:amountInMin::int AS mint_amount_raw,
+        _inserted_timestamp
+    FROM
+        base
+    WHERE
+        event_type = 'initOrder'
+),
+
+bridge_out_final AS (
+    SELECT
+        a.block_timestamp,
+        a.block_id,
+        a.tx_id,
+        a.succeeded,
+        a.index,
+        a.program_id,
+        'mayan finance' AS platform,
+        'outbound' AS direction,
+        a.user_address,
+        (a.mint_amount_raw / POW(10, b.decimal)) AS amount,
+        a.mint,
+        a._inserted_timestamp
+    FROM
+        bridge_out a
+    LEFT JOIN
+        {{ ref('silver__decoded_metadata') }} b
+    ON
+        a.mint = b.mint
+),
+
+bridge_to AS (
+    SELECT
+        block_timestamp,
+        block_id,
+        tx_id,
+        succeeded,
+        index,
+        program_id,
+        silver.udf_get_account_pubkey_by_name('dest', decoded_instruction:accounts) AS trader_dest,
+        silver.udf_get_account_pubkey_by_name('mintTo', decoded_instruction:accounts) AS mint_to,
+        _inserted_timestamp
+    FROM
+        base
+    WHERE
+        event_type = 'settle'
+),
+
+transfers AS (
+    SELECT
+        a.block_timestamp,
+        a.tx_id,
+        a.tx_from,
+        a.tx_to,
+        a.amount,
+        a.mint,
+        a.succeeded,
+        a.index,
+        COALESCE(SPLIT_PART(a.index, '.', 1)::INT, a.index::INT) AS index_1,
+        a._inserted_timestamp
+    FROM
+        {{ ref('silver__transfers') }} a
+    INNER JOIN (
+        SELECT DISTINCT tx_id
+        FROM bridge_to
+    ) d ON d.tx_id = a.tx_id
+    WHERE
+        a.succeeded
+        AND {{ between_stmts }}
+),
+
+bridge_to_final AS (
+    SELECT
+        a.block_timestamp,
+        a.block_id,
+        a.tx_id,
+        a.succeeded,
+        a.index,
+        a.program_id,
+        'mayan finance' AS platform,
+        'inbound' AS direction,
+        a.trader_dest AS user_address,
+        b.amount,
+        b.mint,
+        a._inserted_timestamp
+    FROM
+        bridge_to a
+    LEFT JOIN
+        transfers b
+    ON
+        a.tx_id = b.tx_id
+        AND a.trader_dest = b.tx_to
+        AND (a.mint_to = b.mint OR a.mint_to = 'So11111111111111111111111111111111111111112')
+        AND a.index = b.index_1
+    qualify row_number() over(PARTITION BY a.block_id, a.tx_id, a.index ORDER BY a._inserted_timestamp desc) = 1
+)
+
+SELECT
+    *,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index']) }} AS bridge_mayan_transfers_decoded_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    bridge_out_final
+UNION ALL
+SELECT
+    *,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index']) }} AS bridge_mayan_transfers_decoded_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    bridge_to_final
+

--- a/models/silver/bridges/silver__bridge_mayan_transfers_decoded.yml
+++ b/models/silver/bridges/silver__bridge_mayan_transfers_decoded.yml
@@ -1,0 +1,75 @@
+version: 2
+models:
+  - name: silver__bridge_mayan_transfers_decoded
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('index') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: PLATFORM
+        description: Name of the bridge
+        tests: 
+          - not_null: *recent_date_filter
+      - name: DIRECTION
+        description: Direction of the bridge - either inbound to Solana or outbound from Solana
+        tests: 
+          - not_null: *recent_date_filter
+      - name: USER_ADDRESS
+        description: The address receiving or sending bridged tokens
+        tests: 
+          - not_null: *recent_date_filter
+      - name: AMOUNT
+        description: "{{ doc('amount') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: MINT
+        description:  "{{ doc('mint') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('tx_id') }}"
+        tests: 
+          - not_null
+      - name: BRIDGE_MAYAN_TRANSFERS_DECODED_ID
+        description: '{{ doc("pk") }}'   
+        tests: 
+          - unique: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        tests: 
+          - not_null: 
+              name: test_silver__not_null_bridge_mayan_transfers_decoded__invocation_id
+              <<: *recent_date_filter

--- a/models/silver/bridges/silver__bridge_mayan_transfers_view.sql
+++ b/models/silver/bridges/silver__bridge_mayan_transfers_view.sql
@@ -1,0 +1,26 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    program_id,
+    platform,
+    direction,
+    user_address,
+    amount,
+    mint,
+    _inserted_timestamp,
+    bridge_mayan_transfers_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
+FROM
+    {{ source('solana_silver', 'bridge_mayan_transfers') }}
+
+

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -113,6 +113,7 @@ sources:
       - name: pool_transfers_orca_non_whirlpool
       - name: initialization_pools_orca
       - name: snapshot_block_production
+      - name: bridge_mayan_transfers
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
Create new silver mayan bridge table using decoded data. No events using the old program_id have landed in the table since `2024-12-23`, and the decoded table allows us to get the bridge events using the newer structure.
- convert old table into view
- Legacy and new table do not overlap so directly added it into the gold view


Runs:
- FR on 2xl
`00:12:26  1 of 1 OK created sql incremental model silver.bridge_mayan_transfers_decoded .. [SUCCESS 1 in 195.91s]
`
- incremental on med
`00:31:50  1 of 1 OK created sql incremental model silver.bridge_mayan_transfers_decoded .. [SUCCESS 1426 in 31.48s]
`
- test:
```
00:15:32  Finished running 16 data tests, 7 project hooks in 0 hours 0 minutes and 49.62 seconds (49.62s).
00:15:32  
00:15:32  Completed successfully
00:15:32  
00:15:32  Done. PASS=16 WARN=0 ERROR=0 SKIP=0 TOTAL=16
```