### PR TITLE
stage block txs extract columns from value, don't include it in output

### DIFF
--- a/models/bronze/stage/bronze__stage_block_txs_2.sql
+++ b/models/bronze/stage/bronze__stage_block_txs_2.sql
@@ -8,9 +8,14 @@
 }}
 
 SELECT
-    *
+    to_timestamp_ntz(t.value:"result.blockTime"::int) AS block_timestamp,
+    t.block_id,
+    t.value:array_index::int AS tx_index,
+    t.data,
+    t._partition_id,
+    t._inserted_timestamp
 FROM
-    {{ ref('bronze__streamline_block_txs_2') }}
+    {{ ref('bronze__streamline_block_txs_2') }} AS t
 WHERE
     {% if is_incremental() %}
     _partition_id >= (SELECT max(_partition_id) FROM {{ this }})


### PR DESCRIPTION
- Exclude the `value` column from the output for `bronze.stage_block_txs_2`
  - Extract only the data we need downstream from the value column 
  - Reduces the amount written by about half which also then decreases run time

Existing
<img width="647" alt="Screenshot 2025-01-29 at 9 29 08 AM" src="https://github.com/user-attachments/assets/5f62d609-39eb-4209-8c90-f813a821bc5d" />
New
<img width="576" alt="Screenshot 2025-01-29 at 9 29 16 AM" src="https://github.com/user-attachments/assets/bcb0ab47-11dc-4a38-b62c-e81c7682c066" />

Existing
```
17:28:23  1 of 1 OK created sql incremental model bronze.stage_block_txs_2 ............... [SUCCESS 2100383 in 155.33s]
```
New
```
17:27:53  1 of 1 OK created sql incremental model bronze.stage_block_txs_2 ............... [SUCCESS 2100383 in 131.10s]
```
