### PR TITLE
Use stage block txs table for ingesting raw transactions data into silver

### DIFF
--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -92,7 +92,8 @@ WITH pre_final AS (
         t._partition_id,
         t._inserted_timestamp
     FROM
-        {{ ref('bronze__streamline_block_txs_2') }} AS t
+        /*solana.bronze.stage_block_txs_2 AS t*/
+        {{ ref('bronze__stage_block_txs_2') }} AS t
     WHERE
         t.block_id >= {{ cutover_block_id }}
         AND tx_id IS NOT NULL
@@ -105,6 +106,7 @@ WITH pre_final AS (
         )
         {% if is_incremental() %}
         AND t._partition_id >= (SELECT max(_partition_id)-1 FROM {{ this }})
+        /*AND t._partition_id <= (SELECT max(_partition_id) FROM solana.streamline.complete_block_txs_2)*/
         AND t._partition_id <= (SELECT max(_partition_id) FROM {{ ref('streamline__complete_block_txs_2') }})
         AND t._inserted_timestamp > (SELECT max(_inserted_timestamp) FROM {{ this }})
         {% else %}

--- a/models/silver/non_core/silver__votes.sql
+++ b/models/silver/non_core/silver__votes.sql
@@ -73,7 +73,8 @@ WITH pre_final AS (
         t._partition_id,
         t._inserted_timestamp
     FROM
-        {{ ref('bronze__streamline_block_txs_2') }} AS t
+        /*solana.bronze.stage_block_txs_2 AS t*/
+        {{ ref('bronze__stage_block_txs_2') }} AS t
     WHERE
         t.block_id >= {{ cutover_block_id }}
         AND tx_id IS NOT NULL
@@ -83,6 +84,7 @@ WITH pre_final AS (
         ) = 'Vote111111111111111111111111111111111111111'
         {% if is_incremental() %}
         AND t._partition_id >= (SELECT max(_partition_id)-1 FROM {{ this }})
+        /*AND t._partition_id <= (SELECT max(_partition_id) FROM solana.streamline.complete_block_txs_2)*/
         AND t._partition_id <= (SELECT max(_partition_id) FROM {{ ref('streamline__complete_block_txs_2') }})
         AND t._inserted_timestamp > (SELECT max(_inserted_timestamp) FROM {{ this }})
         {% else %}


### PR DESCRIPTION
Use the `bronze.stage_block_txs_2` to ingest data 
- Have the staging table hold up to ~7 days worth of data to make the process more resilient to data outages
- Update `silver.transactions` and `silver.votes` to pull from new upstream
- In some cases it will load a slightly different set of data due to how the raw file registration works but any "missed" blocks would get automatically re-requested. We can monitor this portion w/ the hourly tests and see if there is an increase in notifications there.


Iterating on same data as prod shows a significant performance boost in runtime

Transactions
```
Old
16:22:32  4 of 16 OK created sql incremental model silver.transactions ................... [SUCCESS 1030654 in 308.30s]
New
16:22:59  1 of 1 OK created sql incremental model silver.transactions .................... [SUCCESS 1030654 in 108.01s]

Old
16:38:04  25 of 171 OK created sql incremental model silver.transactions ................. [SUCCESS 1361976 in 330.59s]
New
16:35:25  1 of 1 OK created sql incremental model silver.transactions .................... [SUCCESS 1058891 in 92.16s]
```

Votes
```
Old
16:36:03  26 of 171 OK created sql incremental model silver.votes ........................ [SUCCESS 6164789 in 209.52s]
New
16:33:18  1 of 1 OK created sql incremental model silver.votes ........................... [SUCCESS 5326780 in 53.58s]
```