### PR TITLE
add snake case for jupv6

### DIFF
--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
@@ -24,7 +24,7 @@
                 {{ ref('silver__decoded_instructions_combined') }} d
             WHERE
                 program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
-                AND event_type IN ('exactOutRoute','sharedAccountsExactOutRoute','sharedAccountsRoute','routeWithTokenLedger','route','sharedAccountsRouteWithTokenLedger')
+                AND event_type IN ('exactOutRoute','sharedAccountsExactOutRoute','sharedAccountsRoute','routeWithTokenLedger','route','sharedAccountsRouteWithTokenLedger', 'exact_out_route', 'shared_accounts_exact_out_route', 'shared_accounts_route', 'route_with_token_ledger', 'shared_accounts_route_with_token_ledger')
                 AND succeeded
                 {% if is_incremental() %}
                 AND _inserted_timestamp >= (
@@ -62,7 +62,7 @@
             table(flatten(decoded_instruction:args:routePlan)) p
         WHERE
             program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
-            AND event_type IN ('exactOutRoute','sharedAccountsExactOutRoute','sharedAccountsRoute','routeWithTokenLedger','route','sharedAccountsRouteWithTokenLedger')
+            AND event_type IN ('exactOutRoute','sharedAccountsExactOutRoute','sharedAccountsRoute','routeWithTokenLedger','route','sharedAccountsRouteWithTokenLedger', 'exact_out_route', 'shared_accounts_exact_out_route', 'shared_accounts_route', 'route_with_token_ledger', 'shared_accounts_route_with_token_ledger')
             AND succeeded
     {% endset %}
     {% do run_query(base_query) %}


### PR DESCRIPTION
New JUPv6 IDL returns event_types and account name as snake case so update logic to filter for those
- table is stall since idl was updated yesterday so 1st run will take a while and will use 2xl for it

inc runs on 2xl
- 20:51:02  1 of 1 OK created sql incremental model silver.swaps_intermediate_jupiterv6_2 .. [SUCCESS 26590691 in 95.52s]
- 20:44:07  1 of 1 OK created sql incremental model silver.swaps_inner_intermediate_jupiterv6  [SUCCESS 13277181 in 113.31s]