### PR TITLE
add takeBidLegacy sales

### DIFF
--- a/models/silver/nfts/silver__nft_sales_tensor_bid.sql
+++ b/models/silver/nfts/silver__nft_sales_tensor_bid.sql
@@ -26,9 +26,14 @@
     FROM
         {{ ref('silver__decoded_instructions_combined') }}
     WHERE
-        ((program_id = 'TB1Dqt8JeKQh7RLDzfYDJsq8KS4fS2yt87avRjyRxMv'
-        and event_type = 'takeBid')
-        or (program_id = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' and event_type = 'takeBidLegacy' ))
+        (
+            (
+                program_id = 'TB1Dqt8JeKQh7RLDzfYDJsq8KS4fS2yt87avRjyRxMv' AND event_type = 'takeBid'
+            )
+            OR (
+                program_id = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' AND event_type = 'takeBidLegacy'
+            )
+        )
         AND succeeded
 
 {% if is_incremental() %}
@@ -58,15 +63,15 @@ WITH decoded AS (
         index,
         inner_index,
         program_id,
-        case when event_type = 'takeBidLegacy' then silver.udf_get_account_pubkey_by_name('owner',decoded_instruction :accounts)
-        else silver.udf_get_account_pubkey_by_name('bidder',decoded_instruction :accounts) 
-        end AS purchaser,
-        
-        silver.udf_get_account_pubkey_by_name('seller',decoded_instruction :accounts) AS seller,
-                silver.udf_get_account_pubkey_by_name('nftMint', decoded_instruction:accounts) AS mint,
-        
-        case when event_type = 'takeBidLegacy' then (decoded_instruction:args:minAmount::int)/pow(10,9)
-        else (decoded_instruction:args:lamports::int) / pow(10, 9) 
+        CASE 
+            WHEN event_type = 'takeBidLegacy' THEN silver.udf_get_account_pubkey_by_name('owner', decoded_instruction:accounts)
+            ELSE silver.udf_get_account_pubkey_by_name('bidder', decoded_instruction:accounts)
+        END AS purchaser,
+        silver.udf_get_account_pubkey_by_name('seller', decoded_instruction:accounts) AS seller,
+        silver.udf_get_account_pubkey_by_name('nftMint', decoded_instruction:accounts) AS mint,
+        CASE
+            WHEN event_type = 'takeBidLegacy' THEN (decoded_instruction:args:minAmount::int)/pow(10,9)
+            ELSE (decoded_instruction:args:lamports::int)/pow(10,9)
         end as sales_amount,
         _inserted_timestamp
     FROM 

--- a/models/silver/nfts/silver__nft_sales_tensor_bid.sql
+++ b/models/silver/nfts/silver__nft_sales_tensor_bid.sql
@@ -26,8 +26,9 @@
     FROM
         {{ ref('silver__decoded_instructions_combined') }}
     WHERE
-        program_id = 'TB1Dqt8JeKQh7RLDzfYDJsq8KS4fS2yt87avRjyRxMv'
-        and event_type = 'takeBid'
+        ((program_id = 'TB1Dqt8JeKQh7RLDzfYDJsq8KS4fS2yt87avRjyRxMv'
+        and event_type = 'takeBid')
+        or (program_id = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' and event_type = 'takeBidLegacy' ))
         AND succeeded
 
 {% if is_incremental() %}
@@ -57,10 +58,16 @@ WITH decoded AS (
         index,
         inner_index,
         program_id,
-        silver.udf_get_account_pubkey_by_name('bidder', decoded_instruction:accounts) AS purchaser,
-        silver.udf_get_account_pubkey_by_name('seller', decoded_instruction:accounts) AS seller,
-        silver.udf_get_account_pubkey_by_name('nftMint', decoded_instruction:accounts) AS mint,
-        (decoded_instruction:args:lamports::int) / pow(10, 9) as sales_amount,
+        case when event_type = 'takeBidLegacy' then silver.udf_get_account_pubkey_by_name('owner',decoded_instruction :accounts)
+        else silver.udf_get_account_pubkey_by_name('bidder',decoded_instruction :accounts) 
+        end AS purchaser,
+        
+        silver.udf_get_account_pubkey_by_name('seller',decoded_instruction :accounts) AS seller,
+                silver.udf_get_account_pubkey_by_name('nftMint', decoded_instruction:accounts) AS mint,
+        
+        case when event_type = 'takeBidLegacy' then (decoded_instruction:args:minAmount::int)/pow(10,9)
+        else (decoded_instruction:args:lamports::int) / pow(10, 9) 
+        end as sales_amount,
         _inserted_timestamp
     FROM 
         silver.nft_sales_tensor_bid__intermediate_tmp

--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -200,8 +200,10 @@ models:
               to: ref('silver__nft_sales_tensor_bid')
               field: tx_id
               from_condition: >
-                program_id = 'TB1Dqt8JeKQh7RLDzfYDJsq8KS4fS2yt87avRjyRxMv'
-                AND event_type = 'takeBid'
+                (
+                  (program_id = 'TB1Dqt8JeKQh7RLDzfYDJsq8KS4fS2yt87avRjyRxMv' AND event_type = 'takeBid')
+                  OR (program_id = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' AND event_type = 'takeBidLegacy')
+                )
                 AND succeeded
                 and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
               to_condition: "_inserted_timestamp >= current_date - 7"


### PR DESCRIPTION
Add takeBidLegacy NFT sales
- The `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp` program  is called `Tensor cNFT` but these sales are all standard NFTs, so added it to the `bid` model.
- Will have to FR model in between incremental runs

runs:
- fr on 2xl
`17:35:07  Finished running 1 incremental model, 7 project hooks in 0 hours 0 minutes and 53.67 seconds (53.67s).
`
- incremental on med
`17:36:41  1 of 1 OK created sql incremental model silver.nft_sales_tensor_bid ............ [SUCCESS 3 in 37.70s]`

- test
```
17:46:25  Finished running 18 data tests, 7 project hooks in 0 hours 0 minutes and 43.73 seconds (43.73s).
17:46:25  
17:46:25  Completed successfully
17:46:25  
17:46:25  Done. PASS=18 WARN=0 ERROR=0 SKIP=0 TOTAL=18
```
