### PR TITLE
add buffer to cnft sales

### DIFF
--- a/models/silver/nfts/silver__nft_sales_magic_eden_cnft.sql
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_cnft.sql
@@ -63,7 +63,7 @@ FROM
 {% if is_incremental() %}
 WHERE A._inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        MAX(_inserted_timestamp) - INTERVAL '2 hour'
     FROM
         {{ this }}
 )

--- a/models/silver/nfts/silver__nft_sales_solsniper_cnft.sql
+++ b/models/silver/nfts/silver__nft_sales_solsniper_cnft.sql
@@ -63,7 +63,7 @@ FROM
 {% if is_incremental() %}
 WHERE A._inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        MAX(_inserted_timestamp) - INTERVAL '2 hour'
     FROM
         {{ this }}
 )


### PR DESCRIPTION
Add a buffer into the incremental combining our onchain cNFT data and decoded mints -- cNFT decoding for mints sometimes lands later into bronze, and the incremental doesn't pick it up in silver.