### PR TITLE
use timestamp filter

### DIFF
--- a/models/silver/swaps/jupiter/v4/silver__swaps_inner_intermediate_jupiterv4.sql
+++ b/models/silver/swaps/jupiter/v4/silver__swaps_inner_intermediate_jupiterv4.sql
@@ -18,7 +18,8 @@
         CREATE OR REPLACE TEMPORARY TABLE silver.swaps_inner_intermediate_jupiterv4__intermediate_tmp AS 
         WITH base AS (
             SELECT 
-                tx_id
+                tx_id,
+                block_timestamp
             FROM 
                 {{ ref('silver__decoded_logs') }}
             WHERE
@@ -36,7 +37,8 @@
             {% if is_incremental() %}
             UNION ALL
             SELECT 
-                l.tx_id
+                l.tx_id,
+                l.block_timestamp
             FROM
                 {{ this }} s 
             INNER JOIN 
@@ -53,8 +55,9 @@
         ),
         /* we need to grab all inner_swaps for any tx that is in the incremental subset because it is required to do the window function later on */
         distinct_entities AS (
-            SELECT
-                DISTINCT tx_id
+            SELECT DISTINCT 
+                tx_id,
+                block_timestamp
             FROM
                 base
         )
@@ -83,6 +86,12 @@
             program_id = 'JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB'
             AND event_type = 'Swap'
             AND succeeded
+            AND block_timestamp >= (
+                SELECT
+                    MIN(block_timestamp)
+                FROM
+                    distinct_entities
+            )
             /* need to always keep the upper bound (if there is one) to prevent time gaps in incremental loading */
             {% if is_incremental() %} 
             AND _inserted_timestamp < (

--- a/models/silver/swaps/jupiter/v4/silver__swaps_intermediate_jupiterv4_2.sql
+++ b/models/silver/swaps/jupiter/v4/silver__swaps_intermediate_jupiterv4_2.sql
@@ -19,7 +19,8 @@
         CREATE OR REPLACE TEMPORARY TABLE silver.swaps_intermediate_jupiterv4__intermediate_tmp AS
         WITH distinct_entities AS (
             SELECT DISTINCT
-                tx_id
+                tx_id,
+                block_timestamp
             FROM 
                 {{ ref('silver__decoded_instructions_combined') }}
             WHERE 
@@ -55,6 +56,12 @@
             program_id = 'JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB'
             AND event_type IN ('route', 'raydiumSwapExactOutput', 'raydiumClmmSwapExactOutput', 'whirlpoolSwapExactOutput')
             AND succeeded
+            AND block_timestamp >= (
+                SELECT
+                    MIN(block_timestamp)
+                FROM
+                    distinct_entities
+            )
     {% endset %}
     {% do run_query(base_query) %}
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.swaps_intermediate_jupiterv4__intermediate_tmp", "block_timestamp::date") %}

--- a/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
+++ b/models/silver/swaps/jupiter/v6/silver__swaps_intermediate_jupiterv6_2.sql
@@ -19,7 +19,8 @@
         CREATE OR REPLACE TEMPORARY TABLE silver.swaps_intermediate_jupiterv6__intermediate_tmp AS 
         WITH distinct_entities AS (
             SELECT DISTINCT
-                tx_id
+                tx_id,
+                block_timestamp
             FROM 
                 {{ ref('silver__decoded_instructions_combined') }} d
             WHERE
@@ -64,6 +65,12 @@
             program_id = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
             AND event_type IN ('exactOutRoute','sharedAccountsExactOutRoute','sharedAccountsRoute','routeWithTokenLedger','route','sharedAccountsRouteWithTokenLedger', 'exact_out_route', 'shared_accounts_exact_out_route', 'shared_accounts_route', 'route_with_token_ledger', 'shared_accounts_route_with_token_ledger')
             AND succeeded
+            AND block_timestamp >= (
+                SELECT
+                    MIN(block_timestamp)
+                FROM
+                    distinct_entities
+            )
     {% endset %}
     {% do run_query(base_query) %}
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.swaps_intermediate_jupiterv6__intermediate_tmp","block_timestamp::date") %}

--- a/models/silver/swaps/meteora/silver__swaps_intermediate_meteora.sql
+++ b/models/silver/swaps/meteora/silver__swaps_intermediate_meteora.sql
@@ -14,7 +14,8 @@
         CREATE OR REPLACE TEMPORARY TABLE silver.swaps_intermediate_meteora__intermediate_tmp AS 
         WITH distinct_entities AS (
             SELECT DISTINCT
-                tx_id
+                tx_id,
+                block_timestamp
             FROM 
                 {{ ref('silver__decoded_instructions_combined') }} d
             WHERE
@@ -59,6 +60,12 @@
         )
         AND event_type = 'swap'                
         AND succeeded
+        AND block_timestamp >= (
+            SELECT
+                MIN(block_timestamp)
+            FROM
+                distinct_entities
+        )
     {% endset %}
     {% do run_query(base_query) %}
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.swaps_intermediate_meteora__intermediate_tmp","block_timestamp::date") %}

--- a/models/silver/swaps/raydium/silver__swaps_intermediate_raydium_v4_amm.sql
+++ b/models/silver/swaps/raydium/silver__swaps_intermediate_raydium_v4_amm.sql
@@ -13,7 +13,8 @@
         CREATE OR REPLACE TEMPORARY TABLE silver.swaps_intermediate_raydium_v4_amm__intermediate_tmp AS
         WITH distinct_entities AS (
             SELECT DISTINCT
-                tx_id
+                tx_id,
+                block_timestamp
             FROM 
                 {{ ref('silver__decoded_instructions_combined') }}
             WHERE
@@ -33,6 +34,7 @@
                 {% else %}
                     AND _inserted_timestamp :: DATE >= '2024-05-14'
                 {% endif %}
+            GROUP BY 1,2
         )
         /* need to re-select all decoded instructions from all tx_ids in incremental subset 
         in order for the window function to output accurate values */
@@ -59,6 +61,7 @@
                 'swapBaseIn',
                 'swapBaseOut'
             )
+            and d.block_timestamp >= (select min(block_timestamp) from distinct_entities)
     {% endset %}
     {% do run_query(base_query) %}
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.swaps_intermediate_raydium_v4_amm__intermediate_tmp","block_timestamp::date") %}

--- a/models/silver/swaps/raydium/silver__swaps_intermediate_raydium_v4_amm.sql
+++ b/models/silver/swaps/raydium/silver__swaps_intermediate_raydium_v4_amm.sql
@@ -34,7 +34,6 @@
                 {% else %}
                     AND _inserted_timestamp :: DATE >= '2024-05-14'
                 {% endif %}
-            GROUP BY 1,2
         )
         /* need to re-select all decoded instructions from all tx_ids in incremental subset 
         in order for the window function to output accurate values */
@@ -61,7 +60,12 @@
                 'swapBaseIn',
                 'swapBaseOut'
             )
-            and d.block_timestamp >= (select min(block_timestamp) from distinct_entities)
+            AND d.block_timestamp >= (
+                SELECT
+                    MIN(block_timestamp)
+                FROM
+                    distinct_entities
+            )
     {% endset %}
     {% do run_query(base_query) %}
     {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.swaps_intermediate_raydium_v4_amm__intermediate_tmp","block_timestamp::date") %}


### PR DESCRIPTION
For models where we need to reselect all tx_id's in the the incremental subset, include the block_timestamp in the initial select and use that as a filter to scan less of the decoded table
- this step seems to take the most time and which is in a number of models

The temp table creation runs considerable faster with the additional logic - example runs below:

- new logic: https://app.snowflake.com/us-east-1/vna27887/#/compute/history/queries/01ba2c71-0412-db47-3d4f-8302e81379cf/detail
- existing: https://app.snowflake.com/zsniary/exa10207/#/compute/history/queries/01ba2c60-0412-ddf6-3d4f-8302e811879b/detail

- incremental runs on medium
00:09:36  1 of 6 OK created sql incremental model silver.swaps_inner_intermediate_jupiterv4  [SUCCESS 89 in 42.49s]
00:09:46  4 of 6 OK created sql incremental model silver.swaps_intermediate_raydium_v4_amm  [SUCCESS 949333 in 52.31s]
00:09:47  3 of 6 OK created sql incremental model silver.swaps_intermediate_meteora ...... [SUCCESS 100556 in 53.52s]
00:09:49  5 of 6 OK created sql incremental model silver.swaps_intermediate_jupiterv4_2 .. [SUCCESS 36 in 12.89s]
00:09:56  2 of 6 OK created sql incremental model silver.swaps_inner_intermediate_jupiterv6  [SUCCESS 356574 in 62.25s]
00:10:19  6 of 6 OK created sql incremental model silver.swaps_intermediate_jupiterv6_2 .. [SUCCESS 336684 in 22.61s]