### PR TITLE
Refactor lp actions meteora multi

### DIFF
--- a/models/silver/liquidity_pool/meteora/multi/silver__liquidity_pool_actions_meteora_multi_2.sql
+++ b/models/silver/liquidity_pool/meteora/multi/silver__liquidity_pool_actions_meteora_multi_2.sql
@@ -1,0 +1,429 @@
+-- depends_on: {{ ref('silver__decoded_instructions_combined') }}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['block_timestamp::date','liquidity_pool_actions_meteora_multi_2_id'],
+        incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+        merge_exclude_columns = ["inserted_timestamp"],
+        cluster_by = ['block_timestamp::date','modified_timestamp::date'],
+        post_hook = enable_search_optimization(
+            '{{this.schema}}',
+            '{{this.identifier}}',
+            'ON EQUALITY(tx_id, provider_address, token_a_mint, token_b_mint, liquidity_pool_actions_meteora_multi_2_id)'
+        ),
+        tags = ['scheduled_non_core']
+    )
+}}
+
+{% set batch_backfill_size = var('batch_backfill_size', 0) %}
+{% set batch_backfill = False if batch_backfill_size == 0 else True %}
+
+
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set max_timestamp_query %}
+            SELECT max(_inserted_timestamp) FROM {{ this }}
+        {% endset %}
+        {% set max_timestamp = run_query(max_timestamp_query)[0][0] %}
+    {% endif %}
+
+    {% set base_query %}
+    CREATE OR REPLACE TEMPORARY TABLE silver.liquidity_pool_actions_meteora_multi_2__intermediate_tmp AS 
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        decoded_instruction:accounts AS accounts,
+        decoded_instruction:args AS args,
+        program_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_instructions_combined')}}
+    WHERE
+        program_id = 'MERLuDFBMmsHnsBPZw2sDQZHvXFMwp8EdjudcU2HKky'
+        AND event_type IN (
+            'addLiquidity',
+            'removeLiquidity',
+            'removeLiquidityOneToken'
+        )
+        AND succeeded
+        {% if is_incremental() and not batch_backfill %}
+        AND _inserted_timestamp > '{{ max_timestamp }}'
+        /* batches for reload */
+        {% elif batch_backfill %}
+            {% set max_block_ts_query %}
+                SELECT max(_inserted_timestamp)::date FROM {{ this }}
+            {% endset %}
+            {% set max_block_ts = run_query(max_block_ts_query)[0][0] %}
+            {% set end_date = max_block_ts + modules.datetime.timedelta(days=batch_backfill_size) %}
+            AND _inserted_timestamp::date BETWEEN '{{ max_block_ts }}' AND '{{ end_date }}'
+        {% else %}
+        AND _inserted_timestamp::date BETWEEN '2025-01-01' AND '2025-02-01'
+        {% endif %}
+    {% endset %}
+    {% do run_query(base_query) %}
+    {% set between_stmts = fsc_utils.dynamic_range_predicate("silver.liquidity_pool_actions_meteora_multi_2__intermediate_tmp","block_timestamp::date") %}
+{% endif %}
+
+WITH base AS (
+    SELECT 
+        * exclude(accounts),
+        silver.udf_get_account_pubkey_by_name('stableSwap', accounts) AS pool_address,
+        silver.udf_get_account_pubkey_by_name('userTransferAuthority', accounts) AS provider_address,
+        silver.udf_get_account_pubkey_by_name('Remaining 0', accounts) AS pool_token_a_account,
+        silver.udf_get_account_pubkey_by_name('Remaining 1', accounts) AS pool_token_b_account,
+        iff(array_size(accounts) >= 12,silver.udf_get_account_pubkey_by_name('Remaining 2', accounts),NULL) AS pool_token_c_account,
+        iff(array_size(accounts) >= 14,silver.udf_get_account_pubkey_by_name('Remaining 3', accounts),NULL) AS pool_token_d_account,
+        CASE
+            WHEN array_size(accounts) = 10 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 3', accounts)
+            WHEN array_size(accounts) = 12 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 4', accounts)
+            WHEN array_size(accounts) = 14 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 5', accounts)
+            ELSE
+                NULL
+        END AS token_a_account,
+        CASE
+            WHEN array_size(accounts) = 10 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 4', accounts)
+            WHEN array_size(accounts) = 12 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 5', accounts)
+            WHEN array_size(accounts) = 14 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 6', accounts)
+            ELSE
+                NULL
+        END AS token_b_account,
+        CASE
+            WHEN array_size(accounts) = 12 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 6', accounts)
+            WHEN array_size(accounts) = 14 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 7', accounts)
+            ELSE
+                NULL
+        END AS token_c_account,
+        CASE
+            WHEN array_size(accounts) = 14 THEN
+                silver.udf_get_account_pubkey_by_name('Remaining 8', accounts)
+            ELSE
+                NULL
+        END AS token_d_account,
+        coalesce(lead(inner_index) OVER (
+            PARTITION BY tx_id, index 
+            ORDER BY inner_index
+        ), 9999) AS next_lp_action_inner_index
+    FROM 
+        silver.liquidity_pool_actions_meteora_multi_2__intermediate_tmp
+),
+
+transfers AS (
+    SELECT 
+        t.* exclude(index),
+        split_part(t.index,'.',1)::int AS index,
+        nullif(split_part(t.index,'.',2),'')::int AS inner_index
+    FROM
+        {{ ref('silver__transfers') }} AS t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp AS bt, tx_id FROM base) AS b
+        ON b.bt::date = t.block_timestamp::date
+        AND b.tx_id = t.tx_id
+    WHERE
+        t.succeeded
+        AND {{ between_stmts }}
+),
+
+distinct_pool_accounts AS (
+    SELECT DISTINCT
+        pool_token_a_account AS pool_account
+    FROM
+        base
+    WHERE
+        pool_token_a_account IS NOT NULL
+    UNION
+    SELECT DISTINCT
+        pool_token_b_account
+    FROM
+        base
+    WHERE
+        pool_token_b_account IS NOT NULL
+    UNION
+    SELECT DISTINCT
+        pool_token_c_account
+    FROM
+        base
+    WHERE
+        pool_token_c_account IS NOT NULL
+    UNION
+    SELECT DISTINCT
+        pool_token_d_account
+    FROM
+        base
+    WHERE
+        pool_token_d_account IS NOT NULL
+),
+
+get_pool_account_mints AS (
+    SELECT
+        pool_account,
+        live.udf_api(
+            'POST',
+            '{service}/{Authentication}',
+            OBJECT_CONSTRUCT(
+                'Content-Type',
+                'application/json',
+                'fsc-quantum-state',
+                'livequery'
+            ),
+            OBJECT_CONSTRUCT(
+                'id',
+                0,
+                'jsonrpc',
+                '2.0',
+                'method',
+                'getAccountInfo',
+                'params',
+                ARRAY_CONSTRUCT(
+                    pool_account,
+                    OBJECT_CONSTRUCT(
+                        'encoding',
+                        'jsonParsed'
+                    )
+                )
+            ),
+            'Vault/prod/solana/quicknode/mainnet'
+        ):data:result:value:data:parsed:info AS parsed_info,
+        parsed_info:mint::string AS mint,
+        parsed_info:tokenAmount:decimals::int AS decimals
+    FROM
+        distinct_pool_accounts
+),
+
+deposit_transfers AS (
+    -- SELECT 
+    --     b.* exclude(args),
+    --     token_a.mint AS token_a_mint,
+    --     b.args:depositAmounts:"0"::int / pow(10, token_a.decimals) AS token_a_amount,
+    --     token_b.mint AS token_b_mint,
+    --     b.args:depositAmounts:"1"::int / pow(10, token_b.decimals) AS token_b_amount,
+    --     token_c.mint AS token_c_mint,
+    --     b.args:depositAmounts:"2"::int / pow(10, token_c.decimals) AS token_c_amount,
+    --     token_d.mint AS token_d_mint,
+    --     b.args:depositAmounts:"3"::int / pow(10, token_d.decimals) AS token_d_amount
+    -- FROM 
+    --     base AS b
+    -- LEFT JOIN
+    --     get_pool_account_mints AS token_a
+    --     ON token_a.pool_account = b.pool_token_a_account
+    -- LEFT JOIN
+    --     get_pool_account_mints AS token_b
+    --     ON token_b.pool_account = b.pool_token_b_account
+    -- LEFT JOIN
+    --     get_pool_account_mints AS token_c
+    --     ON token_c.pool_account = b.pool_token_c_account
+    --     AND b.pool_token_c_account IS NOT NULL
+    -- LEFT JOIN
+    --     get_pool_account_mints AS token_d
+    --     ON token_d.pool_account = b.pool_token_d_account
+    --     AND b.pool_token_d_account IS NOT NULL
+
+
+
+    SELECT 
+        b.* exclude(args),
+        t.mint AS token_a_mint,
+        t.amount AS token_a_amount,
+        t2.mint AS token_b_mint,
+        t2.amount AS token_b_amount,
+        t3.mint AS token_c_mint,
+        t3.amount AS token_c_amount,
+        t4.mint AS token_d_mint,
+        t4.amount AS token_d_amount
+    FROM 
+        base AS b
+    LEFT JOIN
+        transfers AS t
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t.source_token_account = b.token_a_account
+        AND t.dest_token_account = b.pool_token_a_account
+    LEFT JOIN
+        transfers AS t2
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND t2.source_token_account = b.token_b_account
+        AND t2.dest_token_account = b.pool_token_b_account
+    LEFT JOIN
+        transfers AS t3
+        ON t.block_timestamp::date = b.block_timestamp::date
+        AND t.tx_id = b.tx_id
+        AND t.index = b.index
+        AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND b.token_c_account IS NOT NULL
+        AND t.source_token_account = b.token_c_account
+        AND t.dest_token_account = b.pool_token_c_account
+    LEFT JOIN
+        transfers AS t4
+        ON t2.block_timestamp::date = b.block_timestamp::date
+        AND t2.tx_id = b.tx_id
+        AND t2.index = b.index
+        AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+        AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+        AND b.token_d_account IS NOT NULL
+        AND t2.source_token_account = b.token_d_account
+        AND t2.dest_token_account = b.pool_token_d_account
+    WHERE
+        b.event_type = 'addLiquidity'
+    QUALIFY
+        row_number() OVER (PARTITION BY b.tx_id, b.index, b.inner_index ORDER BY t.inner_index, t2.inner_index, t3.inner_index, t4.inner_index) = 1
+),
+
+-- withdraw_transfers AS (
+--     SELECT 
+--         b.*,
+--         t.mint AS token_a_mint,
+--         t.amount AS token_a_amount,
+--         t2.mint AS token_b_mint,
+--         t2.amount AS token_b_amount
+--     FROM 
+--         base AS b
+--     LEFT JOIN
+--         transfers AS t
+--         ON t.block_timestamp::date = b.block_timestamp::date
+--         AND t.tx_id = b.tx_id
+--         AND t.index = b.index
+--         AND coalesce(t.inner_index,0) > coalesce(b.inner_index,-1)
+--         AND coalesce(t.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+--         AND t.dest_token_account = b.token_a_account
+--         AND t.source_token_account = b.pool_token_a_account
+--     LEFT JOIN
+--         transfers AS t2
+--         ON t2.block_timestamp::date = b.block_timestamp::date
+--         AND t2.tx_id = b.tx_id
+--         AND t2.index = b.index
+--         AND coalesce(t2.inner_index,0) > coalesce(b.inner_index,-1)
+--         AND coalesce(t2.inner_index,0) < coalesce(b.next_lp_action_inner_index,9999)
+--         AND t2.dest_token_account = b.token_b_account
+--         AND t2.source_token_account = b.pool_token_b_account
+--     WHERE
+--         b.event_type IN (
+--             'removeAllLiquidity',
+--             'removeLiquidity',
+--             'removeLiquidityByRange'
+--         )
+--     QUALIFY
+--         row_number() OVER (PARTITION BY b.tx_id, b.index, b.inner_index ORDER BY t.inner_index, t2.inner_index) = 1
+-- ),
+
+pre_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        index,
+        inner_index,
+        succeeded,
+        event_type,
+        pool_address,
+        provider_address,
+        token_a_mint,
+        token_a_amount,
+        token_b_mint,
+        token_b_amount,
+        token_c_mint,
+        token_c_amount,
+        token_d_mint,
+        token_d_amount,
+        program_id,
+        _inserted_timestamp
+    FROM 
+        deposit_transfers
+
+    -- UNION ALL
+
+    -- SELECT 
+    --     block_id,
+    --     block_timestamp,
+    --     tx_id,
+    --     index,
+    --     inner_index,
+    --     succeeded,
+    --     event_type,
+    --     pool_address,
+    --     provider_address,
+    --     token_a_mint,
+    --     token_a_amount,
+    --     token_b_mint,
+    --     token_b_amount,
+    --     program_id,
+    --     _inserted_timestamp
+    -- FROM 
+    --     withdraw_transfers
+
+    -- UNION ALL
+
+    -- SELECT 
+    --     block_id,
+    --     block_timestamp,
+    --     tx_id,
+    --     index,
+    --     inner_index,
+    --     succeeded,
+    --     event_type,
+    --     pool_address,
+    --     provider_address,
+    --     token_a_mint,
+    --     token_a_amount,
+    --     token_b_mint,
+    --     token_b_amount,
+    --     program_id,
+    --     _inserted_timestamp
+    -- FROM 
+    --     single_deposit_transfers
+)
+SELECT
+    block_id,
+    block_timestamp,
+    tx_id,
+    index,
+    inner_index,
+    succeeded,
+    event_type,
+    pool_address,
+    provider_address,
+    token_a_mint,
+    token_a_amount,
+    token_b_mint,
+    token_b_amount,
+    token_c_mint,
+    token_c_amount,
+    token_d_mint,
+    token_d_amount,
+    /* 
+    mimic behavior of our other liquidity pool action models that support single token withdraws/deposits.
+    Represent the single token action as token A
+    */
+    -- iff(token_a_mint IS NULL AND token_a_amount IS NULL, token_b_mint, token_a_mint) AS token_a_mint,
+    -- iff(token_a_mint IS NULL AND token_a_amount IS NULL, token_b_amount, token_a_amount) AS token_a_amount,
+    -- iff(token_a_mint IS NOT NULL OR token_a_amount IS NOT NULL, token_b_mint, NULL) AS token_b_mint,
+    -- iff(token_a_mint IS NOT NULL OR token_a_amount IS NOT NULL, token_b_amount, NULL) AS token_b_amount,
+    program_id,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['block_id', 'tx_id', 'index', 'inner_index']) }} AS liquidity_pool_actions_meteora_multi_2_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    pre_final

--- a/models/silver/liquidity_pool/meteora/multi/silver__liquidity_pool_actions_meteora_multi_2.yml
+++ b/models/silver/liquidity_pool/meteora/multi/silver__liquidity_pool_actions_meteora_multi_2.yml
@@ -1,0 +1,110 @@
+version: 2
+models:
+  - name: silver__liquidity_pool_actions_meteora_multi_2
+    recent_date_filter: &recent_date_filter
+      config:
+        where: >
+          _inserted_timestamp > current_date - 1000
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+            - INNER_INDEX
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        data_tests:
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('event_index') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: EVENT_TYPE
+        description: "{{ doc('event_type') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: POOL_ADDRESS
+        description: "{{ doc('liquidity_pool_address') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: PROVIDER_ADDRESS
+        description:  "{{ doc('liquidity_provider') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_MINT
+        description:  "{{ doc('token_a_mint') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_A_AMOUNT
+        description:  "{{ doc('token_a_amount') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TOKEN_B_MINT
+        description:  "{{ doc('token_b_mint') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp > current_date - 1000
+                  AND event_type <> 'removeLiquidityOneToken'
+      - name: TOKEN_B_AMOUNT
+        description:  "{{ doc('token_b_amount') }}"
+        data_tests: 
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp > current_date - 1000
+                  AND event_type <> 'removeLiquidityOneToken'
+      - name: TOKEN_C_MINT
+        description:  >
+          Address of the mint representing the third token in a multi-token liquidity pool
+      - name: TOKEN_C_AMOUNT
+        description:  >
+          Amount of the third token in a multi-token liquidity pool transferred during a liquidity pool action
+      - name: TOKEN_D_MINT
+        description:  >
+          Address of the mint representing the fourth token in a multi-token liquidity pool
+      - name: TOKEN_D_AMOUNT
+        description:  >
+          Amount of the fourth token in a multi-token liquidity pool transferred during a liquidity pool action
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null
+      - name: LIQUIDITY_POOL_ACTIONS_METEORA_MULTI_2_ID
+        description: '{{ doc("pk") }}'   
+        data_tests: 
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_liquidity_pool_actions_meteora_multi_2_invocation_id
+              <<: *recent_date_filter


### PR DESCRIPTION
- Refactor meteora multi-pool LP actions in new table `silver.liquidity_pool_actions_meteora_multi_2` to match new standard schema for LP actions
- Decoded data currently being backfilled and will likely be finished by `2025-02-12`

FR on 2xl
`dbt run -s silver__liquidity_pool_actions_meteora_multi_2 -t dev-2xl --full-refresh`
```

```

Tests on M
`dbt test -s silver__liquidity_pool_actions_meteora_multi_2`
```
15:50:08  Finished running 19 data tests, 7 project hooks in 0 hours 0 minutes and 22.04 seconds (22.04s).
15:50:09  
15:50:09  Completed successfully
15:50:09  
15:50:09  Done. PASS=19 WARN=0 ERROR=0 SKIP=0 TOTAL=19
```

Data in DEV
```
-- 5fKYCuuERA6md8E4bzTQwbF8NKerhBFhrtrWWP74ZVHtViUJnMNrDmNuUZeffy7fGdjp3Q1nFYZgCRY42AmTanWV
-- ZY4XtKa5VmDPgwm9WUxAXH1tNrJsoY7ojduoiXTAdVKXqC6BA6FiDGsD2pjS82JheuaFMzh3xCEGkiabY5StptG
-- 32xUVvKwVJv9jZWmuEhfjQBtxL5eDfZZwKnwz9bGzpEWnCyb12MTkSqkkvh8FekgoGNnXDn3WzNs6255Nm6M2kE8
-- vG6SfgVKqP31dcd956UA4cjpqsaDRrj2Fe7umF6z436F51CGDbxn5n8mcZXsG9ZBXNnx29kVNR6oP9qdWFgFncZ
-- 2pevoNbJqu1TLDWmhiv9KHYupq6J21uqeUco4gfTgdqZ67qpJJPwNDLYfn1Gx3iwYG4vuX65jtwwZ3znKHhun8N8
-- 59u8sNiq9rbjTYQkQKdoBZscMaJvmS1PNitifikreZrViCadXM9LxLTct9VjfxGmDBUupzB2QBqtDhjpehmNcMBt
-- ikxt2pFTMp5XmyV6ko1xh7urWgp3kGm2FQe2qAuc39mtmmYC591RaxUfwuutKJKgiSdHhTxVHGaVA9H84gT7PbK
select *
from solana_dev.silver.liquidity_pool_actions_meteora_multi_2
where tx_id = '5fKYCuuERA6md8E4bzTQwbF8NKerhBFhrtrWWP74ZVHtViUJnMNrDmNuUZeffy7fGdjp3Q1nFYZgCRY42AmTanWV';
```