### PR TITLE
Refactor decoded instructions realtime 3

### DIFF
--- a/models/streamline/decode_instructions/streamline__decode_instructions_3_realtime.sql
+++ b/models/streamline/decode_instructions/streamline__decode_instructions_3_realtime.sql
@@ -9,16 +9,17 @@
 
 {% if execute %}
     {% set min_event_block_id_query %}
-        select min(block_id)
-        from {{ ref('silver__events') }}
-        where 
+        SELECT
+            min(block_id)
+        FROM
+            {{ ref('silver__events') }}
+        WHERE 
             block_timestamp >= CURRENT_DATE - 2
     {% endset %}
     {% set min_event_block_id = run_query(min_event_block_id_query).columns[0].values()[0] %}
 {% endif %}
 
 WITH idl_in_play AS (
-
     SELECT
         program_id
     FROM
@@ -37,42 +38,37 @@ event_subset AS (
         e.block_timestamp,
         {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','e.program_id']) }} as id
     FROM
-        {{ ref('silver__events') }}
-        e
-        JOIN idl_in_play b
+        {{ ref('silver__events') }} AS e
+    JOIN 
+        idl_in_play AS b
         ON e.program_id = b.program_id
     WHERE
         e.block_timestamp >= CURRENT_DATE - 2
-    AND 
-        e.succeeded
+        AND e.succeeded
     UNION ALL
     SELECT
-        i.value :programId :: STRING AS inner_program_id,
+        e.program_id AS inner_program_id,
         e.tx_id,
-        e.index,
-        i.index AS inner_index,
-        i.value AS instruction,
+        e.instruction_index AS index,
+        e.inner_index,
+        e.instruction,
         e.block_id,
         e.block_timestamp,
-        {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.index','inner_index','inner_program_id']) }} as id
+        {{ dbt_utils.generate_surrogate_key(['e.block_id','e.tx_id','e.instruction_index','inner_index','inner_program_id']) }} as id
     FROM
-        {{ ref('silver__events') }}
-        e
-        JOIN idl_in_play b
-        ON ARRAY_CONTAINS(b.program_id::variant, e.inner_instruction_program_ids) 
-        JOIN table(flatten(e.inner_instruction:instructions)) i 
+        {{ ref('silver__events_inner') }} AS e
+    JOIN 
+        idl_in_play AS b
+        ON e.program_id = b.program_id
     WHERE
         e.block_timestamp >= CURRENT_DATE - 2
-    AND 
-        e.succeeded
-    AND 
-        i.value :programId :: STRING = b.program_id
-    AND (
+        AND e.succeeded
+        AND (
             (
-                inner_program_id in ('FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn','SNPRohhBurQwrpwAptw1QYtpFdfEKitr4WSJ125cN1g','GovaE4iu227srtG2s3tZzB4RmWBzw8sTwrCLZz7kN7rY','JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
-                AND array_size(i.value:accounts) > 1
+                inner_program_id IN ('FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn','SNPRohhBurQwrpwAptw1QYtpFdfEKitr4WSJ125cN1g','GovaE4iu227srtG2s3tZzB4RmWBzw8sTwrCLZz7kN7rY','JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
+                AND array_size(e.instruction:accounts) > 1
             )
-            OR inner_program_id not in ('FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn','SNPRohhBurQwrpwAptw1QYtpFdfEKitr4WSJ125cN1g','GovaE4iu227srtG2s3tZzB4RmWBzw8sTwrCLZz7kN7rY','JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
+            OR inner_program_id NOT IN ('FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn','SNPRohhBurQwrpwAptw1QYtpFdfEKitr4WSJ125cN1g','GovaE4iu227srtG2s3tZzB4RmWBzw8sTwrCLZz7kN7rY','JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M','PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu','LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo','PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY','6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
         )
 ),
 completed_subset AS (
@@ -83,9 +79,9 @@ completed_subset AS (
         {{ ref('streamline__complete_decoded_instructions_3') }}
     WHERE
         block_id >= {{ min_event_block_id }} --ensure we at least prune to last 2 days worth of blocks since the dynamic below will scan everything
-    AND block_id >= (
+        AND block_id >= (
             SELECT
-                MIN(block_id)
+                min(block_id)
             FROM
                 event_subset
         )
@@ -99,9 +95,10 @@ SELECT
     e.block_id,
     e.block_timestamp
 FROM
-    event_subset e
-    LEFT OUTER JOIN completed_subset C
-    ON C.block_id = e.block_id
-    AND e.id = C.id
+    event_subset AS e
+LEFT OUTER JOIN 
+    completed_subset AS c
+    ON c.block_id = e.block_id
+    AND e.id = c.id
 WHERE
-    C.block_id IS NULL
+    c.block_id IS NULL


### PR DESCRIPTION
- Refactor `decode_instructions_realtime_3`
  - Use `silver.events_inner`
  - Reference IDLs to decode as a static list

Existing
<img width="1617" alt="Screenshot 2025-02-10 at 9 28 35 AM" src="https://github.com/user-attachments/assets/ce5d55ef-3a66-4150-a77c-29293085db10" />

New (executed using prod upstreams)
<img width="1606" alt="Screenshot 2025-02-10 at 9 26 34 AM" src="https://github.com/user-attachments/assets/3e00f0e3-b34d-45ed-bb79-b1dd99ff5c11" />


Data in DEV
```
select count(*) from solana_dev.streamline.decode_instructions_3_realtime_test;
```