### PR TITLE
optimize cte distinct joins

### DIFF
--- a/models/silver/bridges/silver__bridge_mayan_transfers_decoded.sql
+++ b/models/silver/bridges/silver__bridge_mayan_transfers_decoded.sql
@@ -131,9 +131,9 @@ transfers AS (
     FROM
         {{ ref('silver__transfers') }} a
     INNER JOIN (
-        SELECT DISTINCT tx_id
-        FROM bridge_to
-    ) d ON d.tx_id = a.tx_id
+        SELECT DISTINCT tx_id, block_timestamp::date as bt FROM bridge_to) d 
+        ON d.tx_id = a.tx_id 
+        AND d.bt = a.block_timestamp::date
     WHERE
         a.succeeded
         AND {{ between_stmts }}

--- a/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
+++ b/models/silver/liquidity_pool/orca/v1/silver__liquidity_pool_actions_orcav1.sql
@@ -106,13 +106,18 @@ WITH base AS (
 
 transfers AS (
     SELECT 
-        * exclude(index),
-        split_part(index,'.',1)::int AS index,
-        nullif(split_part(index,'.',2),'')::int AS inner_index
+        t.* exclude(index),
+        split_part(t.index,'.',1)::int AS index,
+        nullif(split_part(t.index,'.',2),'')::int AS inner_index
     FROM
-        {{ ref('silver__transfers') }}
+        {{ ref('silver__transfers') }} AS t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM base) AS b
+        ON b.bt = t.block_timestamp::date
+        AND b.tx_id = t.tx_id
     WHERE
-        {{ between_stmts }}
+        t.succeeded
+        AND {{ between_stmts }}
 ),
 
 deposit_transfers AS (

--- a/models/silver/liquidity_pool/orca/v2/silver__liquidity_pool_actions_orcav2.sql
+++ b/models/silver/liquidity_pool/orca/v2/silver__liquidity_pool_actions_orcav2.sql
@@ -92,13 +92,18 @@ WITH base AS (
 
 transfers AS (
     SELECT 
-        * exclude(index),
-        split_part(index,'.',1)::int AS index,
-        nullif(split_part(index,'.',2),'')::int AS inner_index
+        t.* exclude(index),
+        split_part(t.index,'.',1)::int AS index,
+        nullif(split_part(t.index,'.',2),'')::int AS inner_index
     FROM
-        {{ ref('silver__transfers') }}
+        {{ ref('silver__transfers') }} AS t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM base) AS b
+        ON b.bt = t.block_timestamp::date
+        AND b.tx_id = t.tx_id
     WHERE
-        {{ between_stmts }}
+        t.succeeded
+        AND {{ between_stmts }}
 ),
 
 deposit_transfers AS (

--- a/models/silver/liquidity_pool/orca/whirlpool/silver__liquidity_pool_actions_orca_whirlpool.sql
+++ b/models/silver/liquidity_pool/orca/whirlpool/silver__liquidity_pool_actions_orca_whirlpool.sql
@@ -84,13 +84,17 @@ WITH base AS (
 
 transfers AS (
     SELECT 
-        * exclude(index),
-        split_part(index,'.',1)::int AS index,
-        nullif(split_part(index,'.',2),'')::int AS inner_index
+        t.* exclude(index),
+        split_part(t.index,'.',1)::int AS index,
+        nullif(split_part(t.index,'.',2),'')::int AS inner_index
     FROM
-        {{ ref('silver__transfers') }}
+        {{ ref('silver__transfers') }} AS t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM base) AS b
+        ON b.bt = t.block_timestamp::date
+        AND b.tx_id = t.tx_id
     WHERE
-        succeeded
+        t.succeeded
         AND {{ between_stmts }}
 ),
 

--- a/models/silver/liquidity_pool/raydium/clmm/silver__liquidity_pool_actions_raydium_clmm.sql
+++ b/models/silver/liquidity_pool/raydium/clmm/silver__liquidity_pool_actions_raydium_clmm.sql
@@ -120,13 +120,17 @@ WITH base AS (
 
 transfers AS (
     SELECT 
-        * exclude(index),
-        split_part(index,'.',1)::int AS index,
-        nullif(split_part(index,'.',2),'')::int AS inner_index
+        t.* exclude(index),
+        split_part(t.index,'.',1)::int AS index,
+        nullif(split_part(t.index,'.',2),'')::int AS inner_index
     FROM
-        {{ ref('silver__transfers') }}
+        {{ ref('silver__transfers') }} AS t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM base) AS b
+        ON b.bt = t.block_timestamp::date
+        AND b.tx_id = t.tx_id
     WHERE
-        succeeded
+        t.succeeded
         AND {{ between_stmts }}
 ),
 

--- a/models/silver/liquidity_pool/raydium/cpmm/silver__liquidity_pool_actions_raydium_cpmm.sql
+++ b/models/silver/liquidity_pool/raydium/cpmm/silver__liquidity_pool_actions_raydium_cpmm.sql
@@ -78,13 +78,17 @@ WITH base AS (
 
 transfers AS (
     SELECT 
-        * exclude(index),
-        split_part(index,'.',1)::int AS index,
-        nullif(split_part(index,'.',2),'')::int AS inner_index
+        t.* exclude(index),
+        split_part(t.index,'.',1)::int AS index,
+        nullif(split_part(t.index,'.',2),'')::int AS inner_index
     FROM
-        {{ ref('silver__transfers') }}
+        {{ ref('silver__transfers') }} AS t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM base) AS b
+        ON b.bt = t.block_timestamp::date
+        AND b.tx_id = t.tx_id
     WHERE
-        succeeded
+        t.succeeded
         AND {{ between_stmts }}
 ),
 

--- a/models/silver/liquidity_pool/raydium/v4/silver__liquidity_pool_actions_raydiumv4.sql
+++ b/models/silver/liquidity_pool/raydium/v4/silver__liquidity_pool_actions_raydiumv4.sql
@@ -124,13 +124,17 @@ WITH base AS (
 
 transfers AS (
     SELECT 
-        * exclude(index),
-        split_part(index,'.',1)::int AS index,
-        nullif(split_part(index,'.',2),'')::int AS inner_index
+        t.* exclude(index),
+        split_part(t.index,'.',1)::int AS index,
+        nullif(split_part(t.index,'.',2),'')::int AS inner_index
     FROM
-        {{ ref('silver__transfers') }}
+        {{ ref('silver__transfers') }} AS t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM base) AS b
+        ON b.bt = t.block_timestamp::date
+        AND b.tx_id = t.tx_id
     WHERE
-        succeeded
+        t.succeeded
         AND {{ between_stmts }}
 ),
 

--- a/models/silver/nfts/silver__nft_mint_price_candy_machine.sql
+++ b/models/silver/nfts/silver__nft_mint_price_candy_machine.sql
@@ -40,11 +40,15 @@ AND _inserted_timestamp >= (
 ),
 base_ptb AS (
     SELECT
-        DISTINCT mint AS mint_paid,
-        account,
-        DECIMAL
+        DISTINCT p.mint AS mint_paid,
+        p.account,
+        p.DECIMAL
     FROM
-        {{ ref('silver___post_token_balances') }}
+        {{ ref('silver___post_token_balances') }} AS p
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM base_candy_machine_events) AS b
+        ON b.bt = p.block_timestamp::date
+        AND b.tx_id = p.tx_id
 
 {% if is_incremental() %}
 WHERE

--- a/models/silver/nfts/silver__nft_sales_hadeswap_decoded.sql
+++ b/models/silver/nfts/silver__nft_sales_hadeswap_decoded.sql
@@ -91,9 +91,9 @@ transfers AS (
     FROM
         {{ ref('silver__transfers') }} A
     INNER JOIN (
-        SELECT DISTINCT tx_id
-        FROM decoded
-    ) d ON d.tx_id = A.tx_id
+        SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d
+        ON d.tx_id = A.tx_id
+        AND d.bt = A.block_timestamp::date
     WHERE
         A.succeeded
         AND {{ between_stmts }}

--- a/models/silver/nfts/silver__nft_sales_magic_eden_v2_decoded.sql
+++ b/models/silver/nfts/silver__nft_sales_magic_eden_v2_decoded.sql
@@ -95,10 +95,10 @@ transfers AS (
         a._inserted_timestamp 
     FROM
         {{ ref('silver__transfers') }} a
-    INNER JOIN (
-        SELECT DISTINCT tx_id
-        FROM decoded
-    ) d ON d.tx_id = a.tx_id
+    INNER JOIN 
+        (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d 
+        ON d.tx_id = a.tx_id
+        AND d.bt = a.block_timestamp::date
     WHERE
         a.succeeded
         AND {{ between_stmts }}

--- a/models/silver/nfts/silver__nft_sales_solsniper.sql
+++ b/models/silver/nfts/silver__nft_sales_solsniper.sql
@@ -78,8 +78,8 @@ transfers AS (
         NULLIF(SPLIT_PART(INDEX :: text, '.', 2), '') :: INT AS inner_index_1
     FROM
         {{ ref('silver__transfers') }} A
-        INNER JOIN (
-            SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d
+    INNER JOIN 
+        (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d
         ON d.tx_id = A.tx_id
         AND d.bt = A.block_timestamp::date
     WHERE

--- a/models/silver/nfts/silver__nft_sales_solsniper.sql
+++ b/models/silver/nfts/silver__nft_sales_solsniper.sql
@@ -79,12 +79,9 @@ transfers AS (
     FROM
         {{ ref('silver__transfers') }} A
         INNER JOIN (
-            SELECT
-                DISTINCT tx_id
-            FROM
-                decoded
-        ) d
+            SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d
         ON d.tx_id = A.tx_id
+        AND d.bt = A.block_timestamp::date
     WHERE
         A.succeeded
         AND {{ between_stmts }}

--- a/models/silver/nfts/silver__nft_sales_tensorswap.sql
+++ b/models/silver/nfts/silver__nft_sales_tensorswap.sql
@@ -151,14 +151,18 @@ WITH decoded AS (
 ),
 base_transfers AS (
     SELECT 
-        block_timestamp,
-        tx_id,
-        index,
-        tx_from,
-        mint,
-        amount
+        t.block_timestamp,
+        t.tx_id,
+        t.index,
+        t.tx_from,
+        t.mint,
+        t.amount
     FROM
         {{ ref('silver__transfers') }} t
+    INNER JOIN
+        (SELECT DISTINCT block_timestamp::date AS bt, tx_id FROM decoded) AS d
+        ON d.bt = t.block_timestamp::date
+        AND d.tx_id = t.tx_id
     WHERE
         {{ between_stmts }}
 ),

--- a/models/silver/protocols/marinade/silver__marinade_liquid_staking_actions.sql
+++ b/models/silver/protocols/marinade/silver__marinade_liquid_staking_actions.sql
@@ -71,14 +71,7 @@ transfers AS (
         nullif(split_part(a.index,'.',2),'')::int AS inner_index
     FROM 
         {{ ref('silver__transfers') }} a
-        INNER JOIN (
-            SELECT 
-                DISTINCT tx_id, block_timestamp::date as bt
-            FROM 
-                base
-            WHERE 
-                event_type = 'claim'
-        ) b 
+        INNER JOIN (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type = 'claim') b 
         ON b.tx_id = a.tx_id and b.bt = a.block_timestamp::date
     WHERE
         a.succeeded
@@ -89,14 +82,7 @@ sol_balances as (
         a.*
     FROM 
         {{ ref('silver__sol_balances') }} a
-        INNER JOIN (
-            SELECT 
-                DISTINCT tx_id, block_timestamp::date as bt
-            FROM 
-                base
-            WHERE 
-                event_type = 'depositStakeAccount'
-        ) b 
+        INNER JOIN (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type = 'depositStakeAccount') b 
         ON b.tx_id = a.tx_id and b.bt = a.block_timestamp::date
     WHERE
         a.succeeded

--- a/models/silver/protocols/marinade/silver__marinade_liquid_staking_actions.sql
+++ b/models/silver/protocols/marinade/silver__marinade_liquid_staking_actions.sql
@@ -57,14 +57,9 @@ mints AS (
         a.*
     FROM {{ ref('silver__token_mint_actions') }} a
         INNER JOIN (
-            SELECT 
-                DISTINCT tx_id
-            FROM 
-                base
-            WHERE 
-                event_type IN ('deposit', 'depositStakeAccount')
-        ) b 
-        ON b.tx_id = a.tx_id
+            SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type IN ('deposit', 'depositStakeAccount')) b 
+        ON b.tx_id = a.tx_id 
+        AND b.bt = a.block_timestamp::date
     WHERE
         a.succeeded
         AND {{ between_stmts }}
@@ -78,13 +73,13 @@ transfers AS (
         {{ ref('silver__transfers') }} a
         INNER JOIN (
             SELECT 
-                DISTINCT tx_id
+                DISTINCT tx_id, block_timestamp::date as bt
             FROM 
                 base
             WHERE 
                 event_type = 'claim'
         ) b 
-        ON b.tx_id = a.tx_id
+        ON b.tx_id = a.tx_id and b.bt = a.block_timestamp::date
     WHERE
         a.succeeded
         AND {{ between_stmts }}
@@ -96,13 +91,13 @@ sol_balances as (
         {{ ref('silver__sol_balances') }} a
         INNER JOIN (
             SELECT 
-                DISTINCT tx_id
+                DISTINCT tx_id, block_timestamp::date as bt
             FROM 
                 base
             WHERE 
                 event_type = 'depositStakeAccount'
         ) b 
-        ON b.tx_id = a.tx_id
+        ON b.tx_id = a.tx_id and b.bt = a.block_timestamp::date
     WHERE
         a.succeeded
         AND {{ between_stmts }}

--- a/models/silver/protocols/marinade/silver__marinade_liquid_staking_actions.sql
+++ b/models/silver/protocols/marinade/silver__marinade_liquid_staking_actions.sql
@@ -55,9 +55,10 @@ WITH base AS (
 mints AS (
     SELECT 
         a.*
-    FROM {{ ref('silver__token_mint_actions') }} a
-        INNER JOIN (
-            SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type IN ('deposit', 'depositStakeAccount')) b 
+    FROM 
+        {{ ref('silver__token_mint_actions') }} a
+    INNER JOIN 
+        (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type IN ('deposit', 'depositStakeAccount')) b 
         ON b.tx_id = a.tx_id 
         AND b.bt = a.block_timestamp::date
     WHERE
@@ -71,8 +72,10 @@ transfers AS (
         nullif(split_part(a.index,'.',2),'')::int AS inner_index
     FROM 
         {{ ref('silver__transfers') }} a
-        INNER JOIN (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type = 'claim') b 
-        ON b.tx_id = a.tx_id and b.bt = a.block_timestamp::date
+    INNER JOIN 
+        (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type = 'claim') b 
+        ON b.tx_id = a.tx_id 
+        AND b.bt = a.block_timestamp::date
     WHERE
         a.succeeded
         AND {{ between_stmts }}
@@ -82,8 +85,10 @@ sol_balances as (
         a.*
     FROM 
         {{ ref('silver__sol_balances') }} a
-        INNER JOIN (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type = 'depositStakeAccount') b 
-        ON b.tx_id = a.tx_id and b.bt = a.block_timestamp::date
+    INNER JOIN 
+        (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM base WHERE event_type = 'depositStakeAccount') b 
+        ON b.tx_id = a.tx_id 
+        AND b.bt = a.block_timestamp::date
     WHERE
         a.succeeded
         AND {{ between_stmts }}

--- a/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.sql
+++ b/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.sql
@@ -116,7 +116,8 @@ transfers AS (
         NULLIF(SPLIT_PART(INDEX :: text, '.', 2), '') :: INT AS inner_index_1
     FROM
         {{ ref('silver__transfers') }} A
-        INNER JOIN (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d
+    INNER JOIN 
+    (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d
         ON d.tx_id = A.tx_id
         AND d.bt = A.block_timestamp::date
     WHERE   

--- a/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.sql
+++ b/models/silver/swaps/phoenix/silver__swaps_intermediate_phoenix.sql
@@ -116,14 +116,10 @@ transfers AS (
         NULLIF(SPLIT_PART(INDEX :: text, '.', 2), '') :: INT AS inner_index_1
     FROM
         {{ ref('silver__transfers') }} A
-        INNER JOIN (
-            SELECT
-                DISTINCT tx_id
-            FROM
-                decoded
-        ) d
+        INNER JOIN (SELECT DISTINCT tx_id, block_timestamp::date as bt FROM decoded) d
         ON d.tx_id = A.tx_id
-    WHERE
+        AND d.bt = A.block_timestamp::date
+    WHERE   
         A.succeeded
     and {{ between_stmts }}
 ),


### PR DESCRIPTION
Optimize joins by filtering records in tables such as `transfers` with inner joins to base tables
- this initial PR makes updates to the tables that use `decoded_instructions_combined` and `{{ between_stmts }}` logic. Other models will be updated in future PRs.

Results in significant run time improvements, ie:
old:
-  `20:05:34  1 of 1 OK created sql incremental model silver.liquidity_pool_actions_raydium_clmm  [SUCCESS 1921 in 105.12s]`
- `20:30:55  1 of 1 OK created sql incremental model silver.liquidity_pool_actions_orca_whirlpool  [SUCCESS 38740 in 253.82s]`

new:
- `20:01:40  1 of 1 OK created sql incremental model silver.liquidity_pool_actions_raydium_clmm  [SUCCESS 1921 in 26.61s]`
- `20:33:14  1 of 1 OK created sql incremental model silver.liquidity_pool_actions_orca_whirlpool  [SUCCESS 38740 in 67.20s]`

- Runs on medium:
```
21:34:41  4 of 12 OK created sql incremental model silver.liquidity_pool_actions_orcav2 .. [SUCCESS 1 in 21.97s]
21:34:42  1 of 12 OK created sql incremental model silver.bridge_mayan_transfers_decoded . [SUCCESS 817 in 22.96s]
21:34:43  3 of 12 OK created sql incremental model silver.liquidity_pool_actions_orcav1 .. [SUCCESS 2 in 24.81s]
21:34:44  2 of 12 OK created sql incremental model silver.liquidity_pool_actions_orca_whirlpool  [SUCCESS 29742 in 25.24s]
21:34:56  5 of 12 OK created sql incremental model silver.liquidity_pool_actions_raydium_clmm  [SUCCESS 7 in 15.18s]
21:34:56  6 of 12 OK created sql incremental model silver.liquidity_pool_actions_raydium_cpmm  [SUCCESS 1 in 14.46s]
21:34:59  8 of 12 OK created sql incremental model silver.marinade_liquid_staking_actions  [SUCCESS 23 in 14.99s]
21:34:59  7 of 12 OK created sql incremental model silver.liquidity_pool_actions_raydiumv4  [SUCCESS 36 in 15.87s]
21:35:08  9 of 12 OK created sql incremental model silver.nft_sales_hadeswap_decoded ..... [SUCCESS 2 in 12.70s]
21:35:12  11 of 12 OK created sql incremental model silver.nft_sales_solsniper ........... [SUCCESS 1 in 13.06s]
21:35:13  12 of 12 OK created sql incremental model silver.nft_sales_tensorswap .......... [SUCCESS 75 in 13.20s]
21:35:13  10 of 12 OK created sql incremental model silver.nft_sales_magic_eden_v2_decoded  [SUCCESS 72 in 16.46s]
22:11:59  1 of 1 OK created sql incremental model silver.swaps_intermediate_phoenix ...... [SUCCESS 8185 in 46.90s]
```