### PR TITLE
Backfill tx index re-request error responses

### DIFF
--- a/models/streamline/core/realtime/streamline__block_txs_index.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_index.sql
@@ -16,13 +16,18 @@
 ) }}
 
 WITH block_ids AS (
-    SELECT 
-        b.block_id
-    FROM 
-        {{ ref('silver__blocks') }} b
-    WHERE 
-        -- all blocks after this should have tx id filled in already so start the backfill here
-        b.block_id <= 307868470 
+    -- SELECT 
+    --     b.block_id
+    -- FROM 
+    --     {{ ref('silver__blocks') }} b
+    -- WHERE 
+    --     -- all blocks after this should have tx id filled in already so start the backfill here
+    --     b.block_id <= 307868470 
+    -- EXCEPT
+    SELECT
+        block_id
+    FROM
+        solana_dev.silver.backfill_tx_index_errors
     EXCEPT
     SELECT DISTINCT
         block_id
@@ -65,7 +70,7 @@ SELECT
                 )
             )
         ),
-        'Vault/prod/solana/ankr/mainnet'
+        'Vault/prod/solana/quicknode/mainnet'
     ) AS request
 FROM
     block_ids


### PR DESCRIPTION
- Temporarily set different upstream to get blocks that errored from Ankr calls
- Switch to QN
- After this is done backfilling (~1 day) we should can switch to @tarikceric [PR](https://github.com/FlipsideCrypto/solana-models/pull/801) and continue from there

`dbt run -s streamline__block_txs_index --vars '{STREAMLINE_INVOKE_STREAMS: true, UPDATE_UDFS_AND_SPS: true}'`
```
16:16:55  1 of 1 OK created sql view model streamline.block_txs_index .................... [SUCCESS 1 in 87.96s]
```