### PR TITLE
replace v1 staking lp actions with v2, add inner_index to gold

### DIFF
--- a/models/gold/gov/gov__ez_staking_lp_actions.sql
+++ b/models/gold/gov/gov__ez_staking_lp_actions.sql
@@ -1,7 +1,13 @@
 {{ config(
     materialized = 'view',
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'STAKING' }}},
-    tags = ["scheduled_non_core"],
+    meta = {
+        'database_tags': {
+            'table': {
+                'PURPOSE': 'STAKING'
+            }
+        }
+    },
+    tags = ['scheduled_non_core']
 ) }}
 
 SELECT
@@ -9,7 +15,8 @@ SELECT
     block_timestamp,
     tx_id,
     succeeded,
-    INDEX,
+    index,
+    inner_index,
     event_type,
     signers,
     stake_authority,
@@ -25,19 +32,13 @@ SELECT
     validator_rank,
     commission,
     validator_name,
-    COALESCE (
-        staking_lp_actions_labeled_id,
+    coalesce(
+        staking_lp_actions_labeled_2_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['block_id','tx_id','index']
+            ['block_id', 'tx_id', 'index']
         ) }}
     ) AS ez_staking_lp_actions_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    coalesce(inserted_timestamp, '2000-01-01') AS inserted_timestamp,
+    coalesce(modified_timestamp, '2000-01-01') AS modified_timestamp
 FROM
-    {{ ref('silver__staking_lp_actions_labeled') }}
+    {{ ref('silver__staking_lp_actions_labeled_2') }}

--- a/models/gold/gov/gov__ez_staking_lp_actions.yml
+++ b/models/gold/gov/gov__ez_staking_lp_actions.yml
@@ -16,7 +16,11 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: INDEX
-        description: Location of the event within the instructions of a transaction
+        description: "{{ doc('index') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: SUCCEEDED

--- a/models/gold/gov/gov__fact_staking_lp_actions.sql
+++ b/models/gold/gov/gov__fact_staking_lp_actions.sql
@@ -1,6 +1,12 @@
 {{ config(
   materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'STAKING' }}},
+  meta = {
+        'database_tags': {
+            'table': {
+                'PURPOSE': 'STAKING'
+            }
+        }
+    },
   tags = ['scheduled_non_core']
 ) }}
 
@@ -10,6 +16,7 @@ SELECT
     tx_id,
     succeeded,
     index,
+    inner_index,
     event_type,
     program_id,
     signers,
@@ -20,19 +27,13 @@ SELECT
     post_balances,
     pre_token_balances,
     post_token_balances,
-    COALESCE (
-    staking_lp_actions_id,
+    coalesce(
+    staking_lp_actions_2_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['block_id', 'tx_id', 'index']
+            ['block_id', 'tx_id', 'index', 'inner_index']
         ) }}
     ) AS fact_staking_lp_actions_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    coalesce(inserted_timestamp,'2000-01-01') AS inserted_timestamp,
+    coalesce(modified_timestamp, '2000-01-01') AS modified_timestamp
 FROM
-    {{ ref('silver__staking_lp_actions') }}
+    {{ ref('silver__staking_lp_actions_2') }}

--- a/models/gold/gov/gov__fact_staking_lp_actions.yml
+++ b/models/gold/gov/gov__fact_staking_lp_actions.yml
@@ -16,7 +16,11 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: INDEX
-        description: Location of the event within the instructions of a transaction
+        description: "{{ doc('index') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: INNER_INDEX
+        description: "{{ doc('inner_index') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: SUCCEEDED

--- a/models/silver/non_core/silver__staking_lp_actions.sql
+++ b/models/silver/non_core/silver__staking_lp_actions.sql
@@ -5,7 +5,8 @@
     cluster_by = ['block_timestamp::DATE','event_type'],
     full_refresh = false,
     post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id)'),
-    tags = ['scheduled_non_core']
+    tags = ['deprecated'],
+    enabled = false,
 ) }}
 
 WITH base_e AS (

--- a/models/silver/non_core/silver__staking_lp_actions_labeled.sql
+++ b/models/silver/non_core/silver__staking_lp_actions_labeled.sql
@@ -4,7 +4,9 @@
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE','event_type'],
     post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id,stake_authority,withdraw_authority,stake_account)'),
-    tags = ['scheduled_non_core']
+    tags = ['deprecated'],
+    enabled = false,
+    full_refresh = false,
 ) }}
 
 WITH base_staking_lp_actions AS (


### PR DESCRIPTION
- Use `silver__staking_lp_actions_2` and `silver__staking_lp_actions_labeled_2` in gold
- Add `inner_index` to gold models
- `index` in gold is now an INT instead of STRING
- Deprecate v1 of the above models

`dbt build -s gov__fact_staking_lp_actions gov__ez_staking_lp_actions -t dev`
```
15:58:09  Finished running 2 view models, 32 data tests, 7 project hooks in 0 hours 0 minutes and 32.52 seconds (32.52s).
15:58:09  
15:58:09  Completed successfully
15:58:09  
15:58:09  Done. PASS=34 WARN=0 ERROR=0 SKIP=0 TOTAL=34
```