### PR TITLE
remove saber gauges from model updates

### DIFF
--- a/models/silver/gauges/silver__gauges_votes_saber.sql
+++ b/models/silver/gauges/silver__gauges_votes_saber.sql
@@ -4,8 +4,10 @@
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
-    tags = ['scheduled_non_core']
+    tags = ['deprecated'],
 ) }}
+
+-- no longer running this model because gauges is not a thing anymore and neither is saber
 
 WITH all_saber_gauges_events AS (
 


### PR DESCRIPTION
Pretty certain no one is looking at this...both `gauges` and `saber` are more or less defunct products. There are still events but few and far between. We can easily spin this back up and have it up to date if there is a true downstream use-case

<img width="1548" alt="Screenshot 2025-02-14 at 9 19 52 AM" src="https://github.com/user-attachments/assets/bac68ce2-b37d-495e-ab0a-d9e9df4c0aa2" />
