### PR TITLE
Minor test fixes

### DIFF
--- a/models/silver/gauges/silver__gauges_votes_saber.yml
+++ b/models/silver/gauges/silver__gauges_votes_saber.yml
@@ -1,49 +1,22 @@
 version: 2
 models:
   - name: silver__gauges_votes_saber
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - TX_ID
-            - VOTER
-            - GAUGE
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 30
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
-        tests:
-          - not_null
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
-        tests:
-          - not_null
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
-        tests: 
-          - not_null
       - name: VOTER
         description: "{{ doc('tribeca_gauge_voter') }}"
-        tests: 
-          - not_null
       - name: GAUGE
         description: "{{ doc('tribeca_gauge') }}"
-        tests: 
-          - not_null
       - name: DELEGATED_SHARES
         description: "{{ doc('tribeca_gauge_delegated_shares') }}"
-        tests: 
-          - not_null
       - name: POWER
         description: "{{ doc('tribeca_gauge_power') }}"
-        tests: 
-          - not_null
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
-        tests: 
-          - not_null

--- a/models/silver/liquidity_pool/raydium/cpmm/silver__liquidity_pool_actions_raydium_cpmm.sql
+++ b/models/silver/liquidity_pool/raydium/cpmm/silver__liquidity_pool_actions_raydium_cpmm.sql
@@ -74,6 +74,14 @@ WITH base AS (
         ), 9999) AS next_lp_action_inner_index
     FROM 
         silver.liquidity_pool_actions_raydium_cpmm__intermediate_tmp
+    WHERE
+        (
+            event_type = 'deposit'
+            OR (
+                event_type = 'withdraw' 
+                AND args:lpTokenAmount::int > 0
+            )
+        )
 ),
 
 transfers AS (


### PR DESCRIPTION
- Remove saber tests as the model is deprecated
- Add min amount condition for raydium LP cpmm as there was a new transaction that had no transfers. This should not be included in the output anymore

<img width="1171" alt="Screenshot 2025-03-03 at 7 53 56 AM" src="https://github.com/user-attachments/assets/b1c26e79-ceb6-4db2-93d8-cfc840268eeb" />
