### PR TITLE
incremental filter to last 3 days

### DIFF
--- a/models/silver/governance/silver__gov_actions_marinade.sql
+++ b/models/silver/governance/silver__gov_actions_marinade.sql
@@ -34,7 +34,7 @@ more_locks AS (
     AND
         _inserted_timestamp >= (
             SELECT
-                MAX(_inserted_timestamp)
+                GREATEST(MAX(_inserted_timestamp),current_date-3)
             FROM
                 {{ this }}
         )
@@ -51,7 +51,7 @@ more_locks AS (
     WHERE
         _inserted_timestamp >= (
             SELECT
-                MAX(_inserted_timestamp)
+                GREATEST(MAX(_inserted_timestamp),current_date-3)
             FROM
                 {{ this }}
         )
@@ -84,7 +84,7 @@ WHERE
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        GREATEST(MAX(_inserted_timestamp),current_date-3)
     FROM
         {{ this }}
 )
@@ -129,13 +129,13 @@ FROM
 WHERE
     e._inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp)
+            GREATEST(MAX(_inserted_timestamp),current_date-3)
         FROM
             {{ this }}
     )
     AND t._inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp)
+            GREATEST(MAX(_inserted_timestamp),current_date-3)
         FROM
             {{ this }}
     )

--- a/models/silver/governance/silver__gov_actions_marinade_tmp.sql
+++ b/models/silver/governance/silver__gov_actions_marinade_tmp.sql
@@ -21,7 +21,7 @@ WITH token_balances AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        GREATEST(MAX(_inserted_timestamp),current_date-3)
     FROM
         {{ this }}
 )
@@ -42,7 +42,7 @@ WHERE
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        GREATEST(MAX(_inserted_timestamp),current_date-3)
     FROM
         {{ this }}
 )
@@ -69,7 +69,7 @@ marinade_lock_txs AS (
 {% if is_incremental() %}
 AND e._inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        GREATEST(MAX(_inserted_timestamp),current_date-3)
     FROM
         {{ this }}
 )
@@ -101,7 +101,7 @@ WHERE
 {% if is_incremental() %}
 AND e._inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        GREATEST(MAX(_inserted_timestamp),current_date-3)
     FROM
         {{ this }}
 )
@@ -136,7 +136,7 @@ b AS (
 WHERE
     t._inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp)
+            GREATEST(MAX(_inserted_timestamp),current_date-3)
         FROM
             {{ this }}
     )
@@ -262,7 +262,7 @@ actions_tmp AS (
 {% if is_incremental() %}
 AND e._inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp)
+        GREATEST(MAX(_inserted_timestamp),current_date-3)
     FROM
         {{ this }}
 )


### PR DESCRIPTION
Limit incremental to scan for last 3days of data (model is currently scanning large amounts of data due to large gap from most recent _inserted_timestamp)

ran successfully:
```
17:59:42  1 of 2 OK created sql incremental model silver.gov_actions_marinade_tmp ........ [SUCCESS 0 in 4.45s]
17:59:47  2 of 2 OK created sql incremental model silver.gov_actions_marinade ............ [SUCCESS 0 in 4.65s] 
```