### PR TITLE
An 5767/deprecate old decoder and optimizations

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -32,7 +32,6 @@ tests:
 on-run-start:
   - '{{ create_sps() }}'
   - '{{ create_udfs() }}'
-  - '{{ sp_create_bulk_get_decoded_instructions_data() }}'
   - '{{ sp_create_snapshot_get_stake_accounts() }}'
 
 on-run-end:

--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -2,7 +2,6 @@
     {% if var("UPDATE_UDFS_AND_SPS") %}
         {% set sql %}
         {% if target.database != "SOLANA_COMMUNITY_DEV" %}
-            {{ udf_bulk_get_decoded_instructions_data() }};
             {{ udf_snapshot_get_stake_accounts() }};
             {{ udf_bulk_program_parser() }};
             {{ udf_decode_instructions() }};

--- a/models/silver/core/silver__decoded_instructions_data.sql
+++ b/models/silver/core/silver__decoded_instructions_data.sql
@@ -3,7 +3,8 @@
     unique_key = "CONCAT_WS('-', tx_id, event_index)",
     incremental_strategy = 'delete+insert',
     cluster_by = ['program_id'],
-    tags = ['scheduled_core']
+    full_refresh = false,
+    enabled = false,
 ) }}
 
 SELECT


### PR DESCRIPTION
1. Deprecate legacy `decoded_instructions_data` models
2. Use `events_inner` in `silver.transfers` and `silver.mint_actions`, in place of flattening `silver.events`

incremental on medium:
```
--01:36:17  1 of 1 OK created sql incremental model silver.mint_actions .................... [SUCCESS 76111 in 11.13s]
-- 00:51:25  1 of 1 OK created sql incremental model silver.transfers ....................... [SUCCESS 3871273 in 74.29s]
```