### PR TITLE
update tests

### DIFF
--- a/models/silver/balances/silver__sol_balances.yml
+++ b/models/silver/balances/silver__sol_balances.yml
@@ -6,7 +6,7 @@ models:
           combination_of_columns:
             - TX_ID
             - ACCOUNT
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     recent_date_filter: &recent_date_filter
       config:
         where: _inserted_timestamp >= current_date - 7

--- a/models/silver/balances/silver__token_balances.yml
+++ b/models/silver/balances/silver__token_balances.yml
@@ -6,7 +6,7 @@ models:
           combination_of_columns:
             - TX_ID
             - ACCOUNT
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     recent_date_filter: &recent_date_filter
       config:
         where: _inserted_timestamp >= current_date - 7

--- a/models/silver/core/silver___instructions.yml
+++ b/models/silver/core/silver___instructions.yml
@@ -1,6 +1,9 @@
 version: 2
 models:
   - name: silver___instructions
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -13,24 +16,23 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: Location of the instruction within the instructions of a transaction
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: VALUE
         description: json object that contains the instruction
         tests: 
-          - not_null:
-              where: block_timestamp::date > current_date - 30
+          - not_null: *recent_date_filter
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/core/silver__events.yml
+++ b/models/silver/core/silver__events.yml
@@ -1,13 +1,16 @@
 version: 2
 models:
   - name: silver__events
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_ID
             - TX_ID
             - INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -20,23 +23,23 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SIGNERS
         description: List of accounts that signed the transaction
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: "{{ doc('event_index') }}"
         tests:  
-          - not_null
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
       - name: EVENT_TYPE
@@ -44,8 +47,7 @@ models:
       - name: INSTRUCTION
         description: An instruction specifies which program it is calling, which accounts it wants to read or modify, and additional data that serves as auxiliary input to the program
         tests: 
-          - not_null:
-              where: block_timestamp::date > current_date - 30
+          - not_null: *recent_date_filter
       - name: INNER_INSTRUCTION
         description: A call from one smart contract program to another. 
       - name: _INSERTED_TIMESTAMP

--- a/models/silver/core/silver__transfers.yml
+++ b/models/silver/core/silver__transfers.yml
@@ -1,13 +1,16 @@
 version: 2
 models:
   - name: silver__transfers
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_ID
             - TX_ID
             - INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -20,40 +23,41 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INDEX
         description: "{{ doc('index') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_FROM
         description: "{{ doc('tx_from') }}"
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: TX_TO 
         description: "{{ doc('tx_to') }}"
         tests: 
-          - not_null 
+          - not_null: *recent_date_filter
       - name: AMOUNT 
         description: "{{ doc('amount') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT
         description: "{{ doc('mint') }}"
         tests: 
           - null_threshold:
               threshold_percent: 0.70
+              where: block_timestamp::date > current_date - 7
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         tests: 

--- a/models/silver/core/silver__votes.yml
+++ b/models/silver/core/silver__votes.yml
@@ -1,11 +1,14 @@
 version: 2
 models:
   - name: silver__votes
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - TX_ID
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -15,15 +18,15 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: RECENT_BLOCK_HASH
         description: Previous block's hash value
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SIGNERS
         description: List of accounts that signed the transaction
       - name: FEE
@@ -35,12 +38,11 @@ models:
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: ACCOUNT_KEYS
         description: List of accounts that are referenced by pre/post sol/token balances objects
         tests: 
-          - not_null:
-              where: block_timestamp::date > current_date - 30
+          - not_null: *recent_date_filter
       - name: VOTE_ACCOUNT
         description: Account belonging to the voting delegator
         tests: 

--- a/models/silver/nfts/silver__nft_mint_actions.yml
+++ b/models/silver/nfts/silver__nft_mint_actions.yml
@@ -1,6 +1,9 @@
 version: 2
 models:
   - name: silver__nft_mint_actions
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -8,6 +11,7 @@ models:
             - INDEX
             - INNER_INDEX
             - MINT
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -20,11 +24,11 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
@@ -32,32 +36,32 @@ models:
       - name: INDEX 
         description: "Location of the event within the instructions of a transaction"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: INNER_INDEX 
         description: "Location of the event within the inner instructions of a transaction"
       - name: EVENT_TYPE 
         description: "{{ doc('event_type') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT 
         description: "{{ doc('mint') }}"
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT_AMOUNT
         description: Number of tokens burned
         tests: 
           - not_null:
-              where: event_type in ('mintToChecked', 'mintTo')
+              where: event_type in ('mintToChecked', 'mintTo') and _inserted_timestamp >= current_date - 7
       - name: MINT_AUTHORITY
         description: Account address authorizing burn
         tests: 
-          - not_null
+          - not_null: *recent_date_filter
       - name: SIGNERS
         description: Account address authorizing burn
       - name: DECIMAL
         description: "{{ doc('decimal') }}"
         tests:
-          - not_null
+          - not_null: *recent_date_filter
       - name: MINT_STANDARD_TYPE
         description: "{{ doc('mint_standard_type') }}"
       - name: _INSERTED_TIMESTAMP


### PR DESCRIPTION
Optimize long-running tests
- reduce uniqueness test to last 7 days
- add recent_date_filter

test run (failures for recency since most dev tables havent been updated)
`20:51:07  Done. PASS=83 WARN=0 ERROR=6 SKIP=0 TOTAL=89`