### PR TITLE
add move events

### DIFF
--- a/models/gold/gov/gov__ez_staking_lp_actions.sql
+++ b/models/gold/gov/gov__ez_staking_lp_actions.sql
@@ -27,6 +27,8 @@ SELECT
     post_tx_staked_balance,
     withdraw_amount,
     withdraw_destination,
+    move_amount,
+    move_destination,
     vote_account,
     node_pubkey,
     validator_rank,

--- a/models/gold/gov/gov__ez_staking_lp_actions.yml
+++ b/models/gold/gov/gov__ez_staking_lp_actions.yml
@@ -51,6 +51,14 @@ models:
         description: The amount of Solana belonging to the stake account after the transaction.
         tests:
           - dbt_expectations.expect_column_to_exist
+      - name: MOVE_AMOUNT
+        description: The amount of SOL being moved from the stake account.
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: MOVE_DESTINATION
+        description: The destination wallet address of the moved SOL.
+        tests:
+          - dbt_expectations.expect_column_to_exist
       - name: VOTE_ACCOUNT
         description: A voting account belonging to the validator. 
         tests:

--- a/models/silver/non_core/silver__staking_lp_actions_labeled_2.yml
+++ b/models/silver/non_core/silver__staking_lp_actions_labeled_2.yml
@@ -95,6 +95,10 @@ models:
         description: The amount of SOL being withdrawn from the stake account.
       - name: WITHDRAW_DESTINATION
         description: The destination wallet address of the withdrawn SOL.
+      - name: MOVE_AMOUNT
+        description: The amount of SOL being moved from the stake account.
+      - name: MOVE_DESTINATION
+        description: The destination wallet address of the moved SOL.
       - name: PRE_TX_STAKED_BALANCE
         description: The amount of Solana belonging to the stake account before the transaction.
       - name: POST_TX_STAKED_BALANCE


### PR DESCRIPTION
Add logic for new staking events `moveLamports` and `moveStake`
- add columns for move_destination and move_amount

Dev runs:
- Successful incremental run on the last month of data (since new event appeared):
`22:54:33  1 of 1 OK created sql incremental model silver.staking_lp_actions_labeled_2 .... [SUCCESS 8244606 in 237.43s]`

- Successful Incremental on gold:
`22:56:26  1 of 1 OK created sql view model gov.ez_staking_lp_actions ..................... [SUCCESS 1 in 2.97s]
`
- Testings passing on silver: 
```
22:59:37  Finished running 15 data tests, 6 project hooks in 0 hours 0 minutes and 40.03 seconds (40.03s).
22:59:38  
22:59:38  Completed successfully
22:59:38  
22:59:38  Done. PASS=15 WARN=0 ERROR=0 SKIP=0 TOTAL=15
```



