### PR TITLE
gov gold table conversions

### DIFF
--- a/models/gold/gov/gov__dim_epoch.sql
+++ b/models/gold/gov/gov__dim_epoch.sql
@@ -1,6 +1,6 @@
 {{ config(
-    materialized = 'view',
-    tags = ['scheduled_non_core']
+    materialized = 'table',
+    unique_key = ['dim_epoch_id']
 ) }}
 
 SELECT
@@ -8,7 +8,7 @@ SELECT
     start_block,
     end_block,
     epoch_id as dim_epoch_id,
-    modified_timestamp,
-    inserted_timestamp
+    SYSDATE() AS modified_timestamp,
+    SYSDATE() AS inserted_timestamp
 from
   {{ ref('silver__epoch') }}

--- a/models/gold/gov/gov__ez_staking_lp_actions.yml
+++ b/models/gold/gov/gov__ez_staking_lp_actions.yml
@@ -2,11 +2,17 @@ version: 2
 models:
   - name: gov__ez_staking_lp_actions
     description: EZ table for staking & LP actions that contains additional information about the validator. 
+    recent_date_filter: &recent_date_filter
+      config:
+        where: modified_timestamp >= current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/gold/gov/gov__fact_gauges_creates.sql
+++ b/models/gold/gov/gov__fact_gauges_creates.sql
@@ -1,7 +1,6 @@
 {{ config(
-    materialized = 'view',
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'GOVERNANCE' }}},
-    tags = ['scheduled_non_core']
+    materialized = 'table',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'GOVERNANCE' }}}
 ) }}
 
 SELECT
@@ -17,7 +16,7 @@ SELECT
     {{ dbt_utils.generate_surrogate_key(
         ['tx_id']
     ) }} AS fact_gauges_creates_id,
-    '2000-01-01' as inserted_timestamp,
-    '2000-01-01' AS modified_timestamp
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp
 FROM
     {{ ref('silver__gauges_creates_marinade_view') }}

--- a/models/gold/gov/gov__fact_proposal_votes.sql
+++ b/models/gold/gov/gov__fact_proposal_votes.sql
@@ -29,7 +29,7 @@ SELECT
     tx_id,
     succeeded,
     voter,
-    vote_account,
+    voter_account,
     NULL AS voter_nft,
     proposal,
     realms_id,

--- a/models/gold/gov/gov__fact_proposal_votes.sql
+++ b/models/gold/gov/gov__fact_proposal_votes.sql
@@ -1,32 +1,26 @@
 {{ config(
-    materialized = 'view',
+    materialized = 'incremental',
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'GOVERNANCE' }}},
+    unique_key = ['fact_proposal_votes_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id)'),
     tags = ['scheduled_non_core']
 ) }}
 
-SELECT
-    'tribeca' AS governance_platform,
-    'marinade' AS program_name,
-    block_timestamp,
-    block_id,
-    tx_id,
-    succeeded,
-    voter,
-    voter_account,
-    voter_nft,
-    proposal,
-    NULL AS realms_id,
-    NULL AS vote_choice,
-    NULL AS vote_rank,
-    NULL AS vote_weight,
-    {{ dbt_utils.generate_surrogate_key(
-        ['tx_id', 'voter_nft', 'proposal']
-    ) }} AS fact_proposal_votes_id,
-    '2000-01-01' as inserted_timestamp,
-    '2000-01-01' AS modified_timestamp
-FROM
-    {{ ref('silver__proposal_votes_marinade_view') }}
-UNION ALL
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT 
+              max(modified_timestamp) AS max_modified_timestamp
+            FROM 
+              {{ this }}
+        {% endset %}
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
+
 SELECT
     'realms' AS governance_platform,
     program_id AS program_name,
@@ -48,13 +42,36 @@ SELECT
             ['tx_id','index']
         ) }}
     ) AS fact_proposal_votes_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp
 FROM
     {{ ref('silver__proposal_votes_realms') }}
+{% if is_incremental() %}
+WHERE modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
+{% if not is_incremental() %}
+UNION ALL
+SELECT
+    'tribeca' AS governance_platform,
+    'marinade' AS program_name,
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    voter,
+    voter_account,
+    voter_nft,
+    proposal,
+    NULL AS realms_id,
+    NULL AS vote_choice,
+    NULL AS vote_rank,
+    NULL AS vote_weight,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id', 'voter_nft', 'proposal']
+    ) }} AS fact_proposal_votes_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp
+FROM
+    {{ ref('silver__proposal_votes_marinade_view') }}
+{% endif %}
+

--- a/models/gold/gov/gov__fact_proposal_votes.yml
+++ b/models/gold/gov/gov__fact_proposal_votes.yml
@@ -15,6 +15,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/gold/gov/gov__fact_rewards_fee.sql
+++ b/models/gold/gov/gov__fact_rewards_fee.sql
@@ -1,27 +1,28 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
-  tags = ['scheduled_non_core']
+    materialized = 'incremental',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
+    unique_key = ['fact_rewards_fee_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(pubkey, epoch_earned)'),
+    tags = ['scheduled_non_core']
 ) }}
 
 {% set switchover_block_id = 292334107 %}
 
-SELECT
-  block_timestamp,
-  block_id,
-  vote_pubkey as pubkey,
-  epoch_earned,
-  reward_amount_sol,
-  post_balance_sol,
-  rewards_fee_id as fact_rewards_fee_id,
-  modified_timestamp,
-  inserted_timestamp,
-  epoch_id as dim_epoch_id
-FROM
-  {{ ref('silver__rewards_fee_view') }}
-WHERE
-  block_id <= {{ switchover_block_id }}
-UNION ALL
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT 
+              max(modified_timestamp) AS max_modified_timestamp
+            FROM 
+              {{ this }}
+        {% endset %}
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
+
 SELECT
   block_timestamp,
   block_id,
@@ -30,10 +31,31 @@ SELECT
   reward_amount_sol,
   post_balance_sol,
   rewards_fee_2_id as fact_rewards_fee_id,
-  modified_timestamp,
-  inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  SYSDATE() AS inserted_timestamp,
   epoch_id as dim_epoch_id
 FROM
   {{ ref('silver__rewards_fee_2') }}
 WHERE
   block_id > {{ switchover_block_id }}
+    {% if is_incremental() %}
+    AND modified_timestamp >= '{{ max_modified_timestamp }}'
+    {% endif %}
+{% if not is_incremental() %}
+UNION ALL
+SELECT
+  block_timestamp,
+  block_id,
+  vote_pubkey as pubkey,
+  epoch_earned,
+  reward_amount_sol,
+  post_balance_sol,
+  rewards_fee_id as fact_rewards_fee_id,
+  SYSDATE() AS modified_timestamp,
+  SYSDATE() AS inserted_timestamp,
+  epoch_id as dim_epoch_id
+FROM
+  {{ ref('silver__rewards_fee_view') }}
+WHERE
+  block_id <= {{ switchover_block_id }}
+{% endif %}

--- a/models/gold/gov/gov__fact_rewards_fee.yml
+++ b/models/gold/gov/gov__fact_rewards_fee.yml
@@ -11,6 +11,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2 
       - name: REWARD_AMOUNT_SOL
         description: "{{ doc('amount') }}"
         tests:

--- a/models/gold/gov/gov__fact_rewards_rent.sql
+++ b/models/gold/gov/gov__fact_rewards_rent.sql
@@ -1,7 +1,6 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
-  tags = ['scheduled_non_core']
+    materialized = 'table',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}}
 ) }}
 
 SELECT
@@ -12,8 +11,8 @@ SELECT
     reward_amount_sol,
     post_balance_sol,
     rewards_rent_id as fact_rewards_rent_id,
-    modified_timestamp,
-    inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
     epoch_id as dim_epoch_id
 from
   {{ ref('silver__rewards_rent_view') }}

--- a/models/gold/gov/gov__fact_rewards_staking.sql
+++ b/models/gold/gov/gov__fact_rewards_staking.sql
@@ -1,8 +1,25 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
-  tags = ['scheduled_non_core']
+    materialized = 'incremental',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
+    unique_key = ['fact_rewards_staking_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(stake_pubkey, epoch_earned)'),
+    tags = ['scheduled_non_core']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT 
+              max(modified_timestamp) AS max_modified_timestamp
+            FROM 
+              {{ this }}
+        {% endset %}
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
 
 {% set switchover_block_id = 292334107 %}
 
@@ -13,14 +30,18 @@ SELECT
     epoch_earned,
     reward_amount_sol,
     post_balance_sol,
-    rewards_staking_id AS fact_rewards_staking_id,
-    modified_timestamp,
-    inserted_timestamp,
+    rewards_staking_2_id AS fact_rewards_staking_id,
+    SYSDATE() AS modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
     epoch_id AS dim_epoch_id
-FROM 
-    {{ ref('silver__rewards_staking_view') }}
+FROM
+    {{ ref('silver__rewards_staking_2') }}
 WHERE
-    block_id <= {{ switchover_block_id }}
+    block_id > {{ switchover_block_id }}
+    {% if is_incremental() %}
+    AND modified_timestamp >= '{{ max_modified_timestamp }}'
+    {% endif %}
+{% if not is_incremental() %}
 UNION ALL
 SELECT
     block_timestamp,
@@ -29,11 +50,12 @@ SELECT
     epoch_earned,
     reward_amount_sol,
     post_balance_sol,
-    rewards_staking_2_id AS fact_rewards_staking_id,
-    modified_timestamp,
-    inserted_timestamp,
+    rewards_staking_id AS fact_rewards_staking_id,
+    SYSDATE() AS modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
     epoch_id AS dim_epoch_id
 FROM
-    {{ ref('silver__rewards_staking_2') }}
+    {{ ref('silver__rewards_staking_view') }}
 WHERE
-    block_id > {{ switchover_block_id }}
+    block_id <= {{ switchover_block_id }}
+{% endif %}

--- a/models/gold/gov/gov__fact_rewards_staking.yml
+++ b/models/gold/gov/gov__fact_rewards_staking.yml
@@ -11,6 +11,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2 
       - name: REWARD_AMOUNT_SOL
         description: "{{ doc('amount') }}"
         tests:

--- a/models/gold/gov/gov__fact_rewards_voting.sql
+++ b/models/gold/gov/gov__fact_rewards_voting.sql
@@ -1,27 +1,28 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
-  tags = ['scheduled_non_core']
+    materialized = 'incremental',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
+    unique_key = ['fact_rewards_fee_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(vote_pubkey, epoch_earned)'),
+    tags = ['scheduled_non_core']
 ) }}
 
 {% set switchover_block_id = 292334107 %}
 
-SELECT
-    block_timestamp,
-    block_id,
-    vote_pubkey,
-    epoch_earned,
-    reward_amount_sol,
-    post_balance_sol,
-    rewards_voting_id AS fact_rewards_voting_id,
-    modified_timestamp,
-    inserted_timestamp,
-    epoch_id AS dim_epoch_id
-FROM 
-    {{ ref('silver__rewards_voting_view') }}
-WHERE
-    block_id <= {{ switchover_block_id }}
-UNION ALL
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT 
+              max(modified_timestamp) AS max_modified_timestamp
+            FROM 
+              {{ this }}
+        {% endset %}
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
+
 SELECT
     block_timestamp,
     block_id,
@@ -30,10 +31,31 @@ SELECT
     reward_amount_sol,
     post_balance_sol,
     rewards_voting_2_id AS fact_rewards_voting_id,
-    modified_timestamp,
-    inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
     epoch_id AS dim_epoch_id
 FROM
     {{ ref('silver__rewards_voting_2') }}
 WHERE
     block_id > {{ switchover_block_id }}
+    {% if is_incremental() %}
+    AND modified_timestamp >= '{{ max_modified_timestamp }}'
+    {% endif %}
+{% if not is_incremental() %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    vote_pubkey,
+    epoch_earned,
+    reward_amount_sol,
+    post_balance_sol,
+    rewards_voting_id AS fact_rewards_voting_id,
+    SYSDATE() AS modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
+    epoch_id AS dim_epoch_id
+FROM 
+    {{ ref('silver__rewards_voting_view') }}
+WHERE
+    block_id <= {{ switchover_block_id }}
+{% endif %}

--- a/models/gold/gov/gov__fact_rewards_voting.sql
+++ b/models/gold/gov/gov__fact_rewards_voting.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'REWARDS' }}},
-    unique_key = ['fact_rewards_fee_id'],
+    unique_key = ['fact_rewards_voting_id'],
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     cluster_by = ['block_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],

--- a/models/gold/gov/gov__fact_rewards_voting.yml
+++ b/models/gold/gov/gov__fact_rewards_voting.yml
@@ -11,6 +11,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2 
       - name: REWARD_AMOUNT_SOL
         description: "{{ doc('amount') }}"
         tests:

--- a/models/gold/gov/gov__fact_votes_agg_block.sql
+++ b/models/gold/gov/gov__fact_votes_agg_block.sql
@@ -1,8 +1,25 @@
 {{ config(
-  materialized = 'view',
-  meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'GOVERNANCE' }}},
-  tags = ['scheduled_non_core']
+    materialized = 'incremental',
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'GOVERNANCE' }}},
+    unique_key = ['fact_votes_agg_block_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(block_id)'),
+    tags = ['scheduled_non_core']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query %}
+            SELECT 
+              max(modified_timestamp) AS max_modified_timestamp
+            FROM 
+              {{ this }}
+        {% endset %}
+        {% set max_modified_timestamp = run_query(query).columns[0].values()[0] %}
+    {% endif %}
+{% endif %}
 
 SELECT 
     block_timestamp,
@@ -14,13 +31,10 @@ SELECT
             ['block_id']
         ) }}
     ) AS fact_votes_agg_block_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp
 FROM
     {{ ref('silver__votes_agg_block') }}
+{% if is_incremental() %}
+WHERE modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}

--- a/models/gold/gov/gov__fact_votes_agg_block.yml
+++ b/models/gold/gov/gov__fact_votes_agg_block.yml
@@ -7,6 +7,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/silver/non_core/silver__staking_lp_actions_2.sql
+++ b/models/silver/non_core/silver__staking_lp_actions_2.sql
@@ -3,7 +3,6 @@
         materialized = 'incremental',
         unique_key = ['block_timestamp::DATE','staking_lp_actions_2_id'],
         cluster_by = ['block_timestamp::DATE','event_type'],
-        post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id, staking_lp_actions_2_id)'),
         tags = ['scheduled_non_core'],
     )
 }}

--- a/models/silver/rewards/silver__rewards_fee_2.sql
+++ b/models/silver/rewards/silver__rewards_fee_2.sql
@@ -5,7 +5,6 @@
     unique_key = ["vote_pubkey", "epoch_earned", "block_id"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE', 'floor(block_id,-6)', '_inserted_timestamp::DATE'],
-    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(vote_pubkey, epoch_earned)'),
     tags = ['rewards', 'scheduled_non_core']
 ) }}
 

--- a/models/silver/rewards/silver__rewards_staking_2.sql
+++ b/models/silver/rewards/silver__rewards_staking_2.sql
@@ -5,7 +5,6 @@
     unique_key = ["stake_pubkey", "epoch_earned", "block_id"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE', 'floor(block_id,-6)', '_inserted_timestamp::DATE'],
-    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(stake_pubkey, epoch_earned)'),
     tags = ['rewards', 'scheduled_non_core']
 ) }}
 

--- a/models/silver/rewards/silver__rewards_voting_2.sql
+++ b/models/silver/rewards/silver__rewards_voting_2.sql
@@ -5,7 +5,6 @@
     unique_key = ["vote_pubkey", "epoch_earned", "block_id"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE', 'floor(block_id,-6)', '_inserted_timestamp::DATE'],
-    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(vote_pubkey, epoch_earned)'),
     tags = ['rewards', 'scheduled_non_core']
 ) }}
 


### PR DESCRIPTION
Convert view in GOV schema to tables. Also remove SO in silver tables

To update without downtime to users:
1. Add `_2` to models and run locally in prod
2. drop views, then rename `_2` tables -- ie. `ALTER TABLE solana.gov.fact_rewards_voting_2 RENAME TO solana.gov.fact_rewards_voting;`
3. Double-check grants