### PR TITLE
An 5632/update gold orca swaps

### DIFF
--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -42,7 +42,7 @@ SELECT
 FROM
     {{ ref('silver__swaps') }}
 WHERE
-    program_id != 'JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB'
+    program_id not in ('JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB','9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP', 'DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1', 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc')
 {% if is_incremental() %}
 AND
     modified_timestamp >= '{{ max_modified_timestamp }}'

--- a/models/gold/defi/defi__fact_swaps.sql
+++ b/models/gold/defi/defi__fact_swaps.sql
@@ -307,6 +307,48 @@ FROM
 {% if is_incremental() %}
 WHERE modified_timestamp >= '{{ max_modified_timestamp }}'
 {% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    swapper,
+    from_amt AS swap_from_amount,
+    from_mint AS swap_from_mint,
+    to_amt AS swap_to_amount,
+    to_mint AS swap_to_mint,
+    program_id,
+    swap_index,
+    swaps_intermediate_orca_whirlpool_id as fact_swaps_id,
+    inserted_timestamp,
+    modified_timestamp
+FROM
+    {{ ref('silver__swaps_intermediate_orca_whirlpool') }}
+{% if is_incremental() %}
+WHERE modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    swapper,
+    from_amt AS swap_from_amount,
+    from_mint AS swap_from_mint,
+    to_amt AS swap_to_amount,
+    to_mint AS swap_to_mint,
+    program_id,
+    swap_index,
+    swaps_intermediate_orca_token_swap_id as fact_swaps_id,
+    inserted_timestamp,
+    modified_timestamp
+FROM
+    {{ ref('silver__swaps_intermediate_orca_token_swap') }}
+{% if is_incremental() %}
+WHERE modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
 )
 
 select 

--- a/models/silver/protocols/marinade/silver__marinade_swaps.sql
+++ b/models/silver/protocols/marinade/silver__marinade_swaps.sql
@@ -68,7 +68,7 @@ SELECT
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS invocation_id
 FROM
-    {{ ref('silver__swaps_intermediate_orca') }}
+    {{ ref('silver__swaps_intermediate_orca_view') }}
 WHERE 
     (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
     AND succeeded

--- a/models/silver/swaps/orca/legacy/silver__swaps_intermediate_orca.sql
+++ b/models/silver/swaps/orca/legacy/silver__swaps_intermediate_orca.sql
@@ -8,7 +8,8 @@
         '{{this.identifier}}',
         'ON EQUALITY(tx_id, swapper, from_mint, to_mint)'
     ),
-    tags = ['scheduled_non_core','scheduled_non_core_hourly']
+    full_refresh = false,
+    enabled = false,
 ) }}
 
 WITH base_events AS(

--- a/models/silver/swaps/orca/legacy/silver__swaps_intermediate_orca_view.sql
+++ b/models/silver/swaps/orca/legacy/silver__swaps_intermediate_orca_view.sql
@@ -1,0 +1,25 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    block_id,
+    block_timestamp,
+    tx_id,
+    succeeded,
+    program_id,
+    index,
+    inner_index,
+    swapper,
+    from_mint,
+    from_amt,
+    to_mint,
+    to_amt,
+    _inserted_timestamp,
+    swap_index,
+    _log_id
+FROM
+  {{ source(
+    'solana_silver',
+    'swaps_intermediate_orca'
+  ) }}

--- a/models/silver/swaps/silver__swaps.sql
+++ b/models/silver/swaps/silver__swaps.sql
@@ -57,7 +57,7 @@ SELECT
     _log_id,
     _inserted_timestamp
 FROM
-    {{ ref('silver__swaps_intermediate_orca') }}
+    {{ ref('silver__swaps_intermediate_orca_view') }}
 
 {% if is_incremental() %}
 WHERE

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -118,6 +118,7 @@ sources:
       - name: nft_sales_solsniper_cnft
       - name: nft_sales_solsniper
       - name: nft_sales_solanart
+      - name: swaps_intermediate_orca
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
Add updated Orca swaps to gold and deprecate legacy

The new silver orca tables are large (~700m records), so letting the gold model run incrementally will take far too long. To update fact_swaps I will:
1. Delete the existing swaps using Orca programs
2. Run dev table to get it up-to-date and use insert statement into prod
