### PR TITLE
update partition filter

### DIFF
--- a/models/streamline/core/realtime/streamline__block_txs_index.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_index.sql
@@ -34,7 +34,7 @@ WITH block_ids AS (
     FROM
         {{ ref('silver__backfill_transactions_index') }}
     WHERE
-        _partition_by_created_timestamp > '2025-02-13'
+        _partition_by_created_timestamp >= '2025-05-20'
 )
 SELECT
     block_id,


### PR DESCRIPTION
Update model for backfilling tx_index
- Restart this workflow for transactions that ended up with null tx_index
- a temp dev table is created to store all the blocks that need to be rerun: `solana_dev.silver.backfill_tx_index_errors`

- dbt run --vars '{"UPDATE_UDFS_AND_SPS": True}' -s bronze__streamline_block_tx_index_backfill bronze__streamline_FR_block_tx_index_backfill -t dev
03:25:17  1 of 2 OK created sql view model bronze.streamline_FR_block_tx_index_backfill .. [SUCCESS 1 in 2.21s]
03:25:17  2 of 2 OK created sql view model bronze.streamline_block_tx_index_backfill ..... [SUCCESS 1 in 2.22s]

- dbt run -s silver__backfill_transactions_index -t dev --full-refresh

00:13:07  1 of 1 OK created sql incremental model silver.backfill_transactions_index ..... [SUCCESS 1 in 106.77s]

- dbt run --vars '{"STREAMLINE_INVOKE_STREAMS": True}' -s streamline__block_txs_index -t dev
{
  "exploded_key": "[\"result.signatures\"]",
  "external_table": "block_txs_index_backfill",
  "include_top_level_json": "[\"result.blockTime\"]",
  "order_by_column": "block_id DESC",
  "producer_batch_size": "37500",
  "sql_limit": "37500",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "750"
}
 on {{this.schema}}.{{this.identifier}}
00:16:09  1 of 1 OK created sql view model streamline.block_txs_index .................... [SUCCESS 1 in 10.40s]

DML to update silver.transactions in batches when data is ready

UPDATE {{ target.database }}.silver.transactions AS t
SET
    t.tx_index = s.tx_index,
    t.modified_timestamp = sysdate()
FROM
    {{ target.database }}.silver.backfill_transactions_index AS s
WHERE
    t.block_timestamp::date = s.block_timestamp::date
    AND t.block_id = s.block_id
    AND t.tx_id = s.tx_id
    AND s.block_timestamp::date BETWEEN <start_date> AND <end_date>;