### PR TITLE
exclude stake snapshot; add alerting

### DIFF
--- a/.github/workflows/dbt_test_tasks.yml
+++ b/.github/workflows/dbt_test_tasks.yml
@@ -25,3 +25,10 @@ jobs:
   called_workflow_template:
     uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_test_tasks.yml@AN-4374/upgrade-dbt-1.7
     secrets: inherit
+
+  notify-failure:
+    needs: [run_dbt_jobs]
+    if: failure()
+    uses: ./.github/workflows/slack_notify.yml
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dbt_test_tasks.yml
+++ b/.github/workflows/dbt_test_tasks.yml
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
 
   notify-failure:
-    needs: [run_dbt_jobs]
+    needs: [called_workflow_template]
     if: failure()
     uses: ./.github/workflows/slack_notify.yml
     secrets:

--- a/models/github_actions/github_actions__current_task_status.yml
+++ b/models/github_actions/github_actions__current_task_status.yml
@@ -7,6 +7,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_set:
               value_set:
                 - TRUE
+              where: "workflow_name != 'dbt_run_streamline_stake_accounts_snapshot'"
       - name: SUCCESSES
         tests:
           - dbt_expectations.expect_column_values_to_be_in_set:
@@ -15,3 +16,4 @@ models:
               config: 
                   severity: warn
                   warn_if: ">0"
+              where: "workflow_name != 'dbt_run_streamline_stake_accounts_snapshot'"


### PR DESCRIPTION
Tests now passing after filtering out snapshot stake accounts job (which runs on a custom trigger):

```
1 of 2 PASS dbt_expectations_expect_column_values_to_be_in_set_github_actions__current_task_status_PIPELINE_ACTIVE__True  [PASS in 15.73s]
2 of 2 PASS dbt_expectations_expect_column_values_to_be_in_set_github_actions__current_task_status_SUCCESSES__2  [PASS in 15.73s]
```