### PR TITLE
deprecate unused models

### DIFF
--- a/.github/workflows/dbt_run_daily.yml
+++ b/.github/workflows/dbt_run_daily.yml
@@ -43,8 +43,6 @@ jobs:
         run: |
           dbt run -s silver__daily_signers.sql+
           dbt run -s models/silver/nfts/silver__nft_mints.sql --full-refresh
-          dbt run-operation run_sp_snapshot_get_stake_accounts
-          dbt run -s models/bronze/bronze__stake_program_accounts.sql
           dbt run -s models/silver/validator/silver__snapshot_validators_app_data.sql models/silver/validator/silver__snapshot_vote_accounts.sql models/silver/validator/silver__snapshot_vote_accounts_extended_stats.sql
           dbt run -s "solana_models,tag:nft_api"
           dbt run -s "solana_models,tag:daily"

--- a/models/gold/gov/gov__fact_gov_actions.sql
+++ b/models/gold/gov/gov__fact_gov_actions.sql
@@ -21,6 +21,8 @@
     {% endif %}
 {% endif %}
 
+-- Only select from the deprecated model during the initial FR
+{% if not is_incremental() %}
 SELECT 
     'saber' as program_name,
     block_timestamp,
@@ -48,12 +50,10 @@ SELECT
         '2000-01-01'
     ) AS modified_timestamp
 FROM
-    {{ ref('silver__gov_actions_saber') }}
-{% if is_incremental() %}
-WHERE
-    modified_timestamp >= '{{ max_modified_timestamp }}'
-{% endif %}
+    {{ ref('silver__gov_actions_saber_view') }}
 UNION ALL
+{% endif %}
+-- Only select from active models during incremental
 SELECT 
     'marinade' as program_name,
     block_timestamp,

--- a/models/silver/governance/silver__gov_actions_saber.sql
+++ b/models/silver/governance/silver__gov_actions_saber.sql
@@ -2,7 +2,8 @@
     materialized = 'incremental',
     unique_key = "tx_id",
     incremental_strategy = 'delete+insert',
-    tags = ['daily']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH post_token_balances AS (

--- a/models/silver/governance/silver__gov_actions_saber_view.sql
+++ b/models/silver/governance/silver__gov_actions_saber_view.sql
@@ -1,0 +1,25 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    signer,
+    locker_account,
+    escrow_account,
+    mint,
+    action,
+    amount,
+    _inserted_timestamp,
+    gov_actions_saber_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
+FROM
+  {{ source(
+    'solana_silver',
+    'gov_actions_saber'
+  ) }}

--- a/models/silver/protocols/marinade/silver__marinade_swaps.sql
+++ b/models/silver/protocols/marinade/silver__marinade_swaps.sql
@@ -40,34 +40,6 @@ SELECT
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS invocation_id
 FROM
-    {{ ref('silver__swaps_intermediate_generic') }}
-WHERE 
-    (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
-    AND succeeded
-    {% if is_incremental() %}
-    AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
-    {% endif %}
-UNION ALL
-SELECT
-    block_timestamp,
-    block_id,
-    tx_id,
-    succeeded,
-    index,
-    inner_index,
-    swap_index,
-    swapper,
-    from_amt AS swap_from_amount,
-    from_mint AS swap_from_mint,
-    to_amt AS swap_to_amount,
-    to_mint AS swap_to_mint,
-    program_id,
-    _inserted_timestamp,
-    {{ dbt_utils.generate_surrogate_key(['tx_id','index','swap_index']) }} AS marinade_swaps_id,
-    SYSDATE() AS inserted_timestamp,
-    SYSDATE() AS modified_timestamp,
-    '{{ invocation_id }}' AS invocation_id
-FROM
     {{ ref('silver__swaps_intermediate_orca_view') }}
 WHERE 
     (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
@@ -238,6 +210,34 @@ SELECT
     '{{ invocation_id }}' AS invocation_id
 FROM
     {{ ref('silver__swaps_intermediate_raydium_clmm') }}
+WHERE
+    (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
+    AND succeeded
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+    {% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    swap_index,
+    swapper,
+    swap_from_amount,
+    swap_from_mint,
+    swap_to_amount,
+    swap_to_mint,
+    program_id,
+    _inserted_timestamp,
+     swaps_intermediate_saber_id as marinade_swaps_id,
+    inserted_timestamp,
+    modified_timestamp,
+    '{{ invocation_id }}' AS invocation_id
+FROM
+    {{ ref('silver__swaps_intermediate_saber') }}
 WHERE
     (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
     AND succeeded

--- a/models/silver/swaps/generic/silver__swaps_intermediate_generic.sql
+++ b/models/silver/swaps/generic/silver__swaps_intermediate_generic.sql
@@ -8,7 +8,8 @@
         '{{this.identifier}}',
         'ON EQUALITY(tx_id, program_id, swapper, from_mint, to_mint)'
     ),
-    tags = ['scheduled_non_core','scheduled_non_core_hourly']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 WITH base_events AS(

--- a/models/silver/swaps/generic/silver__swaps_intermediate_generic_view.sql
+++ b/models/silver/swaps/generic/silver__swaps_intermediate_generic_view.sql
@@ -1,0 +1,25 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    block_id,
+    block_timestamp,
+    tx_id,
+    succeeded,
+    program_id,
+    index,
+    inner_index,
+    swapper,
+    from_mint,
+    from_amt,
+    to_mint,
+    to_amt,
+    _inserted_timestamp,
+    swap_index,
+    _log_id
+FROM
+  {{ source(
+    'solana_silver',
+    'swaps_intermediate_generic'
+  ) }}

--- a/models/silver/swaps/silver__swaps.sql
+++ b/models/silver/swaps/silver__swaps.sql
@@ -30,7 +30,7 @@ WITH base AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__swaps_intermediate_generic') }}
+        {{ ref('silver__swaps_intermediate_generic_view') }}
 
 {% if is_incremental() %}
 WHERE

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -120,6 +120,8 @@ sources:
       - name: nft_sales_solanart
       - name: swaps_intermediate_orca
       - name: swaps
+      - name: swaps_intermediate_generic
+      - name: gov_actions_saber
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
Cleanup unused models
- remove old stake accts pipeline from daily job
- generic swaps table is deprecated as it was replaced by other models, specifically the new saber table
- deprecate gov_actions_saber as no new records in last month