### PR TITLE
convert core views to tables

### DIFF
--- a/models/gold/core/core__ez_events_decoded.sql
+++ b/models/gold/core/core__ez_events_decoded.sql
@@ -1,24 +1,48 @@
 {{ config(
-    materialized = 'view',
-    tags = ['scheduled_non_core'],
+    materialized = 'incremental',
+    unique_key = ['ez_events_decoded_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','ROUND(block_id, -3)','program_id'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id, event_type)'),
+    full_refresh = false,
+    tags = ['scheduled_non_core']
 ) }}
 
+{% if execute %}
+    {% if is_incremental() %}
+    {% set max_modified_query %}
+    SELECT
+        MAX(modified_timestamp) AS modified_timestamp
+    FROM
+        {{ this }}
+    {% endset %}
+    {% set max_modified_timestamp = run_query(max_modified_query)[0][0] %}
+    {% endif %}
+{% endif %}
+
 SELECT
-    A.block_timestamp,
-    A.block_id,
-    A.tx_id,
-    A.signers,
-    A.succeeded,
-    A.index,
-    A.inner_index,
-    A.event_type,
-    A.program_id,
-    A.decoded_instruction,
-    A.decoded_instruction :accounts :: ARRAY AS decoded_accounts,
-    A.decoded_instruction :args :: variant AS decoded_args,
-    A.decoded_instruction :error :: STRING AS decoding_error,
-    A.decoded_instructions_combined_id AS ez_events_decoded_id,
-    A.inserted_timestamp,
-    A.modified_timestamp
+    block_timestamp,
+    block_id,
+    tx_id,
+    signers,
+    succeeded,
+    index,
+    inner_index,
+    event_type,
+    program_id,
+    decoded_instruction,
+    decoded_instruction :accounts :: ARRAY AS decoded_accounts,
+    decoded_instruction :args :: variant AS decoded_args,
+    decoded_instruction :error :: STRING AS decoding_error,
+    decoded_instructions_combined_id AS ez_events_decoded_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp
 FROM
-    {{ ref('silver__decoded_instructions_combined') }} A
+    {{ ref('silver__decoded_instructions_combined') }}
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}
+
+

--- a/models/gold/core/core__ez_events_decoded.yml
+++ b/models/gold/core/core__ez_events_decoded.yml
@@ -2,59 +2,46 @@ version: 2
 models:
   - name: core__ez_events_decoded
     description: Contains each event that occurs on Solana where the instruction has been decoded. A transaction can consist of more than one event and not all events within a transaction will be decoded.
+    recent_modified_date_filter: &recent_modified_date_filter
+      config:
+        where: modified_timestamp >= current_date - 2
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: SIGNERS
         description: List of accounts that signed the transaction
-        tests: 
-          - dbt_expectations.expect_column_to_exist
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
-        tests: 
-          - dbt_expectations.expect_column_to_exist
       - name: INDEX
         description: Location of the event within the instructions of a transaction
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: INNER_INDEX
         description: "{{ doc('inner_index') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: EVENT_TYPE
         description: "{{ doc('event_type') }}"
       - name: DECODED_INSTRUCTION
         description: An instruction specifies which program it is calling, which accounts it wants to read or modify, and additional data that serves as auxiliary input to the program
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: DECODED_ACCOUNTS
         description: The accounts object within the decoded instruction
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: DECODED_ARGS
         description: The args object within the decoded instruction
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: DECODING_ERROR
         description: The error if the decoding failed
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: EZ_EVENTS_DECODED_ID
         description: '{{ doc("pk") }}'   
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - unique: *recent_modified_date_filter    
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -2,13 +2,20 @@ version: 2
 models:
   - name: core__fact_blocks
     description: Contains general information about each block produced on Solana. 
+    recent_modified_date_filter: &recent_modified_date_filter
+      config:
+        where: modified_timestamp >= current_date - 2
     columns:
-      - name: BLOCK_ID
-        description: "{{ doc('block_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
+        data_tests:
+          - not_null:
+              where: block_id > 39824213 and modified_timestamp >= current_date - 2
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: NETWORK
@@ -21,22 +28,17 @@ models:
           - dbt_expectations.expect_column_to_exist
       - name: BLOCK_HEIGHT
         description: heigh of the block
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: BLOCK_HASH
         description: hash of the block
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: PREVIOUS_BLOCK_ID
         description: previous slot value
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: PREVIOUS_BLOCK_HASH
         description: previous block's hash value
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: FACT_BLOCKS_ID
         description: '{{ doc("pk") }}'   
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - unique: *recent_modified_date_filter   
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP

--- a/models/gold/core/core__fact_decoded_instructions.sql
+++ b/models/gold/core/core__fact_decoded_instructions.sql
@@ -1,7 +1,25 @@
 {{ config(
-    materialized = 'view',
-    tags = ['scheduled_non_core'],
+    materialized = 'incremental',
+    unique_key = ['fact_decoded_instructions_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','ROUND(block_id, -3)','program_id'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id, event_type)'),
+    full_refresh = false,
+    tags = ['scheduled_non_core']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+    {% set max_modified_query %}
+    SELECT
+        MAX(modified_timestamp) AS modified_timestamp
+    FROM
+        {{ this }}
+    {% endset %}
+    {% set max_modified_timestamp = run_query(max_modified_query)[0][0] %}
+    {% endif %}
+{% endif %}
 
 SELECT
     block_timestamp,
@@ -14,7 +32,12 @@ SELECT
     event_type,
     decoded_instruction,
     decoded_instructions_combined_id AS fact_decoded_instructions_id,
-    inserted_timestamp,
-    modified_timestamp
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp
 FROM
     {{ ref('silver__decoded_instructions_combined') }}
+    
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}

--- a/models/gold/core/core__fact_decoded_instructions.yml
+++ b/models/gold/core/core__fact_decoded_instructions.yml
@@ -2,43 +2,38 @@ version: 2
 models:
   - name: core__fact_decoded_instructions
     description: Contains the decoded instructions for events. This table only contains instructions for the programs that we have idls for. More idls will continually be added.
+    recent_modified_date_filter: &recent_modified_date_filter
+      config:
+        where: modified_timestamp >= current_date - 2
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: SIGNERS
         description: "{{ doc('signers') }}"
-        tests: 
-          - dbt_expectations.expect_column_to_exist
       - name: INDEX
         description: Location of the event within the instructions of a transaction
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: INNER_INDEX
         description: "{{ doc('inner_index') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: PROGRAM_ID
         description: "{{ doc('program_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: EVENT_TYPE
         description: "{{ doc('event_type') }}"
       - name: DECODED_INSTRUCTION
         description: An instruction specifies which program it is calling, which accounts it wants to read or modify, and additional data that serves as auxiliary input to the program
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: FACT_DECODED_INSTRUCTIONS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}'  
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - unique: *recent_modified_date_filter   
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP

--- a/models/gold/core/core__fact_events.sql
+++ b/models/gold/core/core__fact_events.sql
@@ -1,7 +1,25 @@
 {{ config(
-    materialized = 'view',
+    materialized = 'incremental',
+    unique_key = ['fact_events_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','ROUND(block_id, -3)','program_id','succeeded'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id, index, event_type)'),
+    full_refresh = false,
     tags = ['scheduled_core']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+    {% set max_modified_query %}
+    SELECT
+        MAX(modified_timestamp) AS modified_timestamp
+    FROM
+        {{ this }}
+    {% endset %}
+    {% set max_modified_timestamp = run_query(max_modified_query)[0][0] %}
+    {% endif %}
+{% endif %}
 
 SELECT 
     block_timestamp,
@@ -14,19 +32,13 @@ SELECT
     program_id,
     instruction,
     inner_instruction,
-    COALESCE (
-        events_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['block_id', 'tx_id', 'index']
-        ) }}
-    ) AS fact_events_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    events_id AS fact_events_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp
 FROM
     {{ ref('silver__events') }}
+
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}

--- a/models/gold/core/core__fact_events.yml
+++ b/models/gold/core/core__fact_events.yml
@@ -2,11 +2,18 @@ version: 2
 models:
   - name: core__fact_events
     description: Contains each event that occurs on Solana. A transaction can consist of more than one event. 
+    recent_modified_date_filter: &recent_modified_date_filter
+      config:
+        where: modified_timestamp >= current_date - 2
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
+        data_tests:
+          - not_null:
+              where: block_id > 39824213 and modified_timestamp >= current_date - 2
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:
@@ -42,7 +49,10 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: FACT_EVENTS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}' 
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - unique: *recent_modified_date_filter      
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -1,78 +1,56 @@
 version: 2
 models:
   - name: core__fact_transactions
-    description: A table that contains high level information about every transaction on the Solana blockchain. 
+    description: A table that contains high level information about every transaction on the Solana blockchain.
+    recent_modified_date_filter: &recent_modified_date_filter
+      config:
+        where: modified_timestamp >= current_date - 2 
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
+        data_tests:
+          - not_null:
+              where: block_id > 39824213 and modified_timestamp >= current_date - 2
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: RECENT_BLOCK_HASH
         description: Previous block's hash value
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: FEE
         description: Transaction fee (in lamports)
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: SIGNERS
         description: List of accounts that signed the transaction
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: ACCOUNT_KEYS
         description: List of accounts that are referenced by pre/post sol/token balances objects
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: PRE_BALANCES
         description: List of pre-transaction balances for different accounts
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: POST_BALANCES
         description: List of post-transaction balances for different accounts
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: PRE_TOKEN_BALANCES
         description: List of pre-transaction token balances for different token accounts
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: POST_TOKEN_BALANCES
         description: List of post-transaction token balances for different token accounts
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: LOG_MESSAGES
         description: Array of log messages written by the program for this transaction
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: UNITS_CONSUMED
         description: The number of compute units consumed by the program. 
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: UNITS_LIMIT
         description: The max number of compute units that can be consumed by the program.
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_SIZE
         description: The size of the transaction in bytes.
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_INDEX
         description: "{{ doc('tx_index') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: FACT_TRANSACTIONS_ID
         description: '{{ doc("pk") }}'   
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - unique: *recent_modified_date_filter    
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -1,7 +1,25 @@
 {{ config(
-    materialized = 'view',
+    materialized = 'incremental',
+    unique_key = ['fact_transfers_id'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','ROUND(block_id, -3)'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    post_hook = enable_search_optimization('{{this.schema}}', '{{this.identifier}}', 'ON EQUALITY(tx_id, tx_from, tx_to, mint)'),
+    full_refresh = false,
     tags = ['scheduled_core']
 ) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+    {% set max_modified_query %}
+    SELECT
+        MAX(modified_timestamp) AS modified_timestamp
+    FROM
+        {{ this }}
+    {% endset %}
+    {% set max_modified_timestamp = run_query(max_modified_query)[0][0] %}
+    {% endif %}
+{% endif %}
 
 SELECT 
     block_timestamp,
@@ -12,21 +30,15 @@ SELECT
     tx_to,
     amount,
     mint,
-    COALESCE (
-        transfers_id,
-        {{ dbt_utils.generate_surrogate_key(
-            ['block_id', 'tx_id', 'index']
-        ) }}
-    ) AS fact_transfers_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    transfers_id AS fact_transfers_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp
 FROM
     {{ ref('silver__transfers') }}
 WHERE 
     succeeded
+
+{% if is_incremental() %}
+AND
+    modified_timestamp >= '{{ max_modified_timestamp }}'
+{% endif %}

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -2,41 +2,37 @@ version: 2
 models:
   - name: core__fact_transfers
     description: Contains transfer events for Solana and spl-tokens. 
+    recent_modified_date_filter: &recent_modified_date_filter
+      config:
+        where: modified_timestamp >= current_date - 2
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
+        data_tests:
+          - not_null:
+              where: block_id > 39824213 and modified_timestamp >= current_date - 2
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: INDEX
         description: "{{ doc('index') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_FROM
         description: "{{ doc('tx_from') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: TX_TO 
         description: "{{ doc('tx_to') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: AMOUNT 
         description: "{{ doc('amount') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: MINT
         description: "{{ doc('mint') }}"
-        tests:
-          - dbt_expectations.expect_column_to_exist
       - name: FACT_TRANSFERS_ID
-        description: '{{ doc("pk") }}'   
+        description: '{{ doc("pk") }}' 
+        data_tests:
+          - not_null: *recent_modified_date_filter
+          - unique: *recent_modified_date_filter    
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP


### PR DESCRIPTION
Tables have been backfilled in DEV tables called xxx_2 ie `solana_dev.core.fact_transactions_2`

To update without downtime to users after merge:
- drop views and rename _2 tables ie ALTER TABLE solana.core.fact_transactions_2 RENAME TO solana.core.fact_transactions;
- Double-check grants