### PR TITLE
An 6397/marinade update

### DIFF
--- a/models/gold/marinade/marinade__ez_liquidity_pool_actions.sql
+++ b/models/gold/marinade/marinade__ez_liquidity_pool_actions.sql
@@ -26,9 +26,9 @@
     'raydium_clmm', 
     'orcav1', 
     'orcav2',
-    'meteora',
-    'meteora_dlmm',
-    'meteora_multi',
+    'meteora_2',
+    'meteora_dlmm_2',
+    'meteora_multi_2',
     'orca_whirlpool',
 ] %}
 
@@ -84,11 +84,7 @@ base AS (
             m.platform,
             lp.liquidity_pool_actions_{{ platform }}_id AS ez_liquidity_pool_actions_id
         from 
-            {% if platform in ['meteora', 'meteora_dlmm', 'meteora_multi'] %}
-            {{ ref('marinade__' ~ platform ~ '_pivot') }} AS lp
-            {% else %}
             {{ ref('silver__liquidity_pool_actions_' ~ platform) }} AS lp
-            {% endif %}
         inner join
             {{ ref('marinade__dim_pools') }} AS m
             using(pool_address)

--- a/models/gold/marinade/marinade__meteora_dlmm_pivot.sql
+++ b/models/gold/marinade/marinade__meteora_dlmm_pivot.sql
@@ -5,7 +5,8 @@ but external user should not have perms to select from this view */
 {{
     config(
         materialized = 'view',
-        tags = ['exclude_change_tracking']
+        tags = ['exclude_change_tracking'],
+        enabled = false
     )
 }}
 

--- a/models/gold/marinade/marinade__meteora_multi_pivot.sql
+++ b/models/gold/marinade/marinade__meteora_multi_pivot.sql
@@ -5,7 +5,8 @@ but external user should not have perms to select from this view */
 {{
     config(
         materialized = 'view',
-        tags = ['exclude_change_tracking']
+        tags = ['exclude_change_tracking'],
+        enabled = false
     )
 }}
 

--- a/models/gold/marinade/marinade__meteora_pivot.sql
+++ b/models/gold/marinade/marinade__meteora_pivot.sql
@@ -5,7 +5,8 @@ but external user should not have perms to select from this view */
 {{
     config(
         materialized = 'view',
-        tags = ['exclude_change_tracking']
+        tags = ['exclude_change_tracking'],
+        enabled = false
     )
 }}
 

--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora.sql
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora.sql
@@ -5,7 +5,8 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
-    tags = ['scheduled_non_core'],
+    full_refresh = false,
+    enabled = false
 ) }}
 
 {% if execute %}

--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_dlmm.sql
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_dlmm.sql
@@ -5,7 +5,8 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
-    tags = ['scheduled_non_core'],
+    full_refresh = false,
+    enabled = false
 ) }}
 
 {% if execute %}

--- a/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_multi.sql
+++ b/models/silver/liquidity_pool/silver__liquidity_pool_actions_meteora_multi.sql
@@ -5,7 +5,8 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','modified_timestamp::DATE'],
-    tags = ['scheduled_non_core'],
+    full_refresh = false,
+    enabled = false
 ) }}
 
 {% if execute %}

--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -89,16 +89,6 @@ models:
                 AND _inserted_timestamp between current_date - 7 AND current_timestamp() - INTERVAL '4 HOUR'
               to_condition: "_inserted_timestamp >= current_date - 7"
           - dbt_utils.relationships_where:
-              name: dbt_utils_relationships_where_silver__decoded_instructions_combined_meteora_liquidity_pool_actions_tx_id
-              to: ref('silver__liquidity_pool_actions_meteora')
-              field: tx_id
-              from_condition: >
-                program_id = 'Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB'
-                AND event_type IN ('addBalanceLiquidity','addImbalanceLiquidity','bootstrapLiquidity','removeBalanceLiquidity','removeLiquiditySingleSide')
-                AND succeeded
-                AND coalesce(decoded_instruction:args:poolTokenAmount::int,decoded_instruction:args:minimumPoolTokenAmount::int,-1) <> 0
-                and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
-          - dbt_utils.relationships_where:
               name: dbt_utils_relationships_where_silver__decoded_instructions_combined_meteora_2_liquidity_pool_actions_tx_id
               to: ref('silver__liquidity_pool_actions_meteora_2')
               field: tx_id
@@ -108,16 +98,6 @@ models:
                 AND succeeded
                 AND coalesce(decoded_instruction:args:poolTokenAmount::int,-1) <> 0
                 AND _inserted_timestamp BETWEEN current_date - 7 AND current_timestamp() - INTERVAL '4 HOUR'
-          - dbt_utils.relationships_where:
-              name: dbt_utils_relationships_where_silver__decoded_instructions_combined_meteora_dlmm_liquidity_pool_actions_tx_id
-              to: ref('silver__liquidity_pool_actions_meteora_dlmm')
-              field: tx_id
-              from_condition: >
-                program_id = 'LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo'
-                AND event_type IN ('removeLiquidityByRange','removeLiquidity','removeAllLiquidity','addLiquidityByStrategyOneSide','addLiquidityOneSide','addLiquidity','addLiquidityByWeight','addLiquidityByStrategy')
-                AND succeeded
-                and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
-              to_condition: "_inserted_timestamp >= current_date - 7"
           - dbt_utils.relationships_where:
               name: dbt_utils_relationships_where_silver__decoded_instructions_combined_meteora_dlmm_2_liquidity_pool_actions_tx_id
               to: ref('silver__liquidity_pool_actions_meteora_dlmm_2')

--- a/models/silver/protocols/marinade/silver__marinade_swaps.sql
+++ b/models/silver/protocols/marinade/silver__marinade_swaps.sql
@@ -244,3 +244,143 @@ WHERE
     {% if is_incremental() %}
     AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
     {% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    swap_index,
+    swapper,
+    swap_from_amount,
+    swap_from_mint,
+    swap_to_amount,
+    swap_to_mint,
+    program_id,
+    _inserted_timestamp,
+    swaps_pumpswap_id as marinade_swaps_id,
+    inserted_timestamp,
+    modified_timestamp,
+    '{{ invocation_id }}' AS invocation_id
+FROM
+    {{ ref('silver__swaps_pumpswap') }}
+WHERE
+    (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
+    AND succeeded
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+    {% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    swap_index,
+    swapper,
+    from_amt AS swap_from_amount,
+    from_mint AS swap_from_mint,
+    to_amt AS swap_to_amount,
+    to_mint AS swap_to_mint,
+    program_id,
+    _inserted_timestamp,
+    swaps_intermediate_lifinity_id as marinade_swaps_id,
+    inserted_timestamp,
+    modified_timestamp,
+    '{{ invocation_id }}' AS invocation_id
+FROM
+    {{ ref('silver__swaps_intermediate_lifinity') }}
+WHERE
+    (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
+    AND succeeded
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+    {% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    swap_index,
+    swapper,
+    from_amt AS swap_from_amount,
+    from_mint AS swap_from_mint,
+    to_amt AS swap_to_amount,
+    to_mint AS swap_to_mint,
+    program_id,
+    _inserted_timestamp,
+    swaps_intermediate_orca_whirlpool_id as marinade_swaps_id,
+    inserted_timestamp,
+    modified_timestamp,
+    '{{ invocation_id }}' AS invocation_id
+FROM
+    {{ ref('silver__swaps_intermediate_orca_whirlpool') }}
+WHERE
+    (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
+    AND succeeded
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+    {% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    swap_index,
+    swapper,
+    from_amt AS swap_from_amount,
+    from_mint AS swap_from_mint,
+    to_amt AS swap_to_amount,
+    to_mint AS swap_to_mint,
+    program_id,
+    _inserted_timestamp,
+    swaps_intermediate_orca_token_swap_id as marinade_swaps_id,
+    inserted_timestamp,
+    modified_timestamp,
+    '{{ invocation_id }}' AS invocation_id
+FROM
+    {{ ref('silver__swaps_intermediate_orca_token_swap') }}
+WHERE
+    (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
+    AND succeeded
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+    {% endif %}
+UNION ALL
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    swap_index,
+    swapper,
+    swap_from_amount,
+    swap_from_mint,
+    swap_to_amount,
+    swap_to_mint,
+    program_id,
+    _inserted_timestamp,
+    swaps_intermediate_meteora_bonding_id as marinade_swaps_id,
+    inserted_timestamp,
+    modified_timestamp,
+    '{{ invocation_id }}' AS invocation_id
+FROM
+    {{ ref('silver__swaps_intermediate_meteora_bonding') }}
+WHERE
+    (swap_from_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}') OR swap_to_mint IN ('{{ MNDE_MINT }}', '{{ MSOL_MINT }}'))
+    AND succeeded
+    {% if is_incremental() %}
+    AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+    {% endif %}


### PR DESCRIPTION
Update `marinade` tables
- For ez_liquidity_pool actions, use newer `_2` meteora tables. The `_pivot` tables were created because the existing meteora tables werent in the standard format as other lp tables. The `_pivot` tables have been disabled, as well as the old `silver` tables.
- For `marinade_swaps`, add in swap protocols that were missing.