### PR TITLE
deprecate hadeswap nft sales

### DIFF
--- a/models/gold/nft/nft__ez_nft_sales.sql
+++ b/models/gold/nft/nft__ez_nft_sales.sql
@@ -25,7 +25,6 @@
 {% endif %}
 
 {% set standard_platforms = [
-    {'name': 'hadeswap_decoded', 'marketplace': 'hadeswap','marketplace_version': 'v1'},
     {'name': 'exchange_art', 'marketplace': 'exchange art', 'marketplace_version': 'v1'},
     {'name': 'amm_sell_decoded', 'marketplace': 'magic eden v2', 'marketplace_version': 'v2'},
     {'name': 'tensor_bid', 'marketplace': 'tensorswap', 'marketplace_version': 'v1'},

--- a/models/silver/nfts/silver__nft_sales_hadeswap_decoded.sql
+++ b/models/silver/nfts/silver__nft_sales_hadeswap_decoded.sql
@@ -5,7 +5,8 @@
     merge_exclude_columns = ["inserted_timestamp"],
     unique_key = "nft_sales_hadeswap_decoded_id",
     cluster_by = ['block_timestamp::DATE', 'modified_timestamp::DATE'],
-    tags = ['scheduled_non_core']
+    full_refresh = false,
+    enabled = false
 ) }}
 
 {% if execute %}

--- a/models/silver/nfts/silver__nft_sales_hadeswap_decoded_view.sql
+++ b/models/silver/nfts/silver__nft_sales_hadeswap_decoded_view.sql
@@ -1,0 +1,26 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    program_id,
+    purchaser,
+    seller,
+    mint,
+    sales_amount,
+    _inserted_timestamp,
+    nft_sales_hadeswap_decoded_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
+FROM
+  {{ source(
+    'solana_silver',
+    'nft_sales_hadeswap_decoded'
+  ) }}

--- a/models/silver/nfts/silver__nft_sales_legacy_combined_view.sql
+++ b/models/silver/nfts/silver__nft_sales_legacy_combined_view.sql
@@ -404,5 +404,30 @@ SELECT
     modified_timestamp
 FROM
     {{ ref('silver__nft_sales_tensorswap_view') }}
+UNION ALL
+SELECT
+    'hadeswap',
+    'v1' AS marketplace_version,
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    index,
+    inner_index,
+    program_id,
+    purchaser,
+    seller,
+    mint,
+    sales_amount,
+    '{{ SOL_MINT }}' AS currency_address,
+    NULL as tree_authority,
+    NULL as merkle_tree,
+    NULL as leaf_index,
+    FALSE as is_compressed,
+    nft_sales_hadeswap_decoded_id AS nft_sales_legacy_combined_id,
+    inserted_timestamp,
+    modified_timestamp
+FROM
+    {{ ref('silver__nft_sales_hadeswap_decoded_view') }}
 
 

--- a/models/silver/parser/silver__decoded_instructions_combined.yml
+++ b/models/silver/parser/silver__decoded_instructions_combined.yml
@@ -199,16 +199,6 @@ models:
                 and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
               to_condition: "_inserted_timestamp >= current_date - 7"
           - dbt_utils.relationships_where:
-              name: dbt_utils_relationships_where_silver__decoded_instructions_combined_nft_sales_hadeswap_decoded_tx_id
-              to: ref('silver__nft_sales_hadeswap_decoded')
-              field: tx_id
-              from_condition: >
-                program_id = 'hadeK9DLv9eA7ya5KCTqSvSvRZeJC3JgD5a9Y3CNbvu'
-                AND event_type IN ('sellNftToLiquidityPair', 'buyNftFromPair', 'sellNftToTokenToNftPair')
-                AND succeeded
-                and _inserted_timestamp between current_date - 7 and current_timestamp() - INTERVAL '4 HOUR'
-              to_condition: "_inserted_timestamp >= current_date - 7"
-          - dbt_utils.relationships_where:
               name: dbt_utils_relationships_where_silver__decoded_instructions_combined_marinade_liquid_staking_actions_tx_id
               to: ref('silver__marinade_liquid_staking_actions')
               field: tx_id

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -124,6 +124,7 @@ sources:
       - name: gov_actions_saber
       - name: nft_sales_tensorswap_buysellevent
       - name: nft_sales_tensorswap
+      - name: nft_sales_hadeswap_decoded
   - name: solana_streamline
     database: solana
     schema: streamline


### PR DESCRIPTION
Deprecate `hadeswap_decoded` model, add to `legacy` view, and remove tests