### PR TITLE
delete past 6months of vote data

### DIFF
--- a/.github/workflows/dbt_test_weekly.yml
+++ b/.github/workflows/dbt_test_weekly.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Run DBT Jobs
         run: |
           dbt test -s "solana_models,tag:test_weekly"
+          dbt run -s models/silver/core/silver__votes.sql --vars '{"run_votes_cleanup": true}'
 
   notify-failure:
     needs: [run_dbt_jobs]

--- a/models/silver/core/silver__votes.sql
+++ b/models/silver/core/silver__votes.sql
@@ -5,6 +5,7 @@
     unique_key = "tx_id",
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     cluster_by = ['block_timestamp::DATE','block_id','_inserted_timestamp::DATE'],
+    pre_hook = "{% if var('run_votes_cleanup', false) %}DELETE FROM {{ this }} WHERE _inserted_timestamp < CURRENT_DATE - INTERVAL '6 months'{% endif %}",
     post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id)'),
     full_refresh = false,
     tags = ['scheduled_core']


### PR DESCRIPTION
Delete records older then 6 months in `silver.votes`
- use pre_hook with var, which runs weekly (added to test_weekly job to avoid adding more workflows)
- Votes data goes largely unused, as only recent data is necessary for the gold votes_agg table and for observability purposes. The decision to only keep 6 months of data was due to the costs of storage ($7k+ yearly savings from removing the old data), and there has been little to no interest from users to have the 'raw' vote data available. 